### PR TITLE
Preliminary Ocamlbuild support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ TAGS
 build
 logmsg
 xcuserdata
+src/_build
+src/linkgtk2.native
+src/linktext.native
+

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -279,7 +279,8 @@ In principle, Unison should work on any platform to which OCaml has been
 ported and on which the \verb|Unix| module is fully implemented.  It has
 been tested on many flavors of Windows (98, NT, 2000, XP) and Unix (OS X,
 Solaris, Linux, FreeBSD), and on both 32- and 64-bit architectures.
-
+Unison can be also built using OPAM, a package/build manager for
+Ocaml, which in some cases greatly simplifies the installation setup.
 
 \SUBSUBSECTION{Unix}{build-unix}
 
@@ -394,6 +395,12 @@ versions, for portability.
 \end{itemize}
 %\finish{Any other important ones?}
 
+\SUBSUBSECTION{OPAM}{build-opam}
+
+In order to build Unison with OPAM, you need a working OPAM
+version. Then, do `{\tt opam install ocamlbuild lablgtk2}` and {\tt
+  make ocb} in the `{\tt src}` directory should do generate the proper
+binaries in all platforms.
 
 \SECTION{Tutorial}{tutorial}{tutorial}
 

--- a/src/.merlin
+++ b/src/.merlin
@@ -1,0 +1,15 @@
+S .
+S lwt
+S lwt/generic
+S system
+S system/generic
+S ubase
+
+B ./_build
+B ./_build/lwt
+B ./_build/lwt/generic
+B ./_build/system
+B ./_build/system/generic
+B ./_build/ubase
+
+PKG unix lablgtk2

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ all:: INSTALL
 	run runbatch runt rundebug runp runtext runsort runprefer \
 	prefsdocs runtest repeattest \
 	selftest selftestdebug selftestremote testmerge \
-	checkin installremote
+	checkin installremote ocb ocb-clean
 
 .DELETE_ON_ERROR:
 # to avoid problems when something fails to run
@@ -384,3 +384,24 @@ strings.ml:
 	echo "(* Dummy strings.ml *)" > strings.ml
 	echo "let docs = []" >> strings.ml
 
+
+# Building with ocamlbuild
+ubase/projectInfo.ml: Makefile.ProjectInfo
+	echo 'let myName = "'$(NAME)'";;' > $@
+	echo 'let myVersion = "'$(VERSION)'";;' >> $@
+	echo 'let myMajorVersion = "'$(MAJORVERSION)'";;' >> $@
+
+ULFLAGS=-lflags libunison_stubs.a -lflags '-cclib -lutil'
+
+ocb: ubase/projectInfo.ml
+# Unfortunately make -f doesn't propagate the proper names so we must that hack
+	# $(MAKE) -f Makefile.OCaml ubase/projectInfo.ml
+	ocamlbuild -use-ocamlfind libunison_stubs.a
+	ocamlbuild -j 4 -use-ocamlfind linktext.native $(ULFLAGS)
+	cp linktext.native $(NAME)
+	ocamlbuild -j 4 -use-ocamlfind linkgtk2.native $(ULFLAGS)
+	cp linkgtk2.native $(NAME)-gtk
+
+ocb-clean:
+	ocamlbuild -clean
+	rm -f unison unison-gtk

--- a/src/_tags
+++ b/src/_tags
@@ -1,0 +1,6 @@
+"ubase": include
+"system": include
+"system/generic": include
+"lwt": include
+"lwt/generic": include
+true: package(unix), package(str), package(bigarray), package(lablgtk2)

--- a/src/libunison_stubs.clib
+++ b/src/libunison_stubs.clib
@@ -1,0 +1,3 @@
+bytearray_stubs.o
+osxsupport.o
+pty.o

--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -4008,7 +4008,7 @@ lst_store#set ~row ~column:c_path path;
     right#add_accelerator ~group:accel_group ~modi:[`SHIFT] GdkKeysyms._comma;
 
     let skip =
-      grAdd grAction
+      (* grAdd grAction *)
         (actionMenu#add_image_item ~key:GdkKeysyms._slash ~callback:questionAction
           ~image:((GMisc.image ~stock:`NO ~icon_size:`MENU ())#coerce)
           "Do _Not Propagate Changes") in


### PR DESCRIPTION
Hi, this patch adds (optional) ocamlbuild support to unison. Do
```
$ make ocb
```
in `src/` to build unison using ocambuild. This fixes #9 as now Unison can be build in an OPAM environment.

IMO it is not ready to merge yet, so I'm using this PR for review.