### PR TITLE
Fixed tags Makefile recipe

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -344,7 +344,7 @@ testmerge:
 .PHONY: tags
 
 tags:
-	-if [ -f `which $(ETAGS)` ]; then \
+	-if [ -n "$(command -v $(ETAGS) 2>/dev/null)" ]; then \
 	    $(ETAGS) *.mli */*.mli *.ml */*.ml */*.m *.c */*.c *.txt \
           ; fi 
 


### PR DESCRIPTION
Hello.

I **love** Unison, and have been using it for the past 3 years.  Since I like to be able to control my software build process + version, I build Unison from scratch whenever possible.  To date, I have built Unison on many different platforms (OSx, FreeBSD, Debian, Ubuntu, Arch Linux, Synology Linux).  However, in every build (except OSx, where the 'etags' executable exists), I have encountered the same (non-fatal) error at the very end of the build process:

```
make tags
make[1]: Entering directory '/tmp/src/unison-2.48.3'
if [ -f `which etags` ]; then \
    etags *.mli */*.mli *.ml */*.ml */*.m *.c */*.c *.txt \
          ; fi 
/bin/sh: 2: etags: not found
Makefile:347: recipe for target 'tags' failed
make[1]: [tags] Error 127 (ignored)
make[1]: Leaving directory '/tmp/src/unison-2.48.3'
```

Despite the build completing successfully, and everything running fine, this error has always bothered me, as the code indicates that the 'etags' executable is not necessary to complete the build of the unison executable.  I've tracked down the error to [this line of code](https://github.com/bcpierce00/unison/blob/master/src/Makefile#L341) in the source Makefile.

First, the 'which' command (which is not as portable as 'command' or 'type') will return nothing if the file is not found, which means that '[ -f "" ]' will be the command run, which is both valid and evaluates true.  This combination is what yields the error above.

To fix the problem, we can instead interpret the (which, command, or type) executable generating some output to stdout as an indication that the directive exists or executable file is present on the PATH.  Our saviour here is the syntax '[ -n "/x/y/z" ]', which tests if the string is **not** empty.  In this case, '[ -n "/some/path/etags" ]' evaluates to true, and we know the command exists and we can proceed to run the etags command.  If not, then we instead get '[ -n "" ]', which evaluates false, allowing us to skip.

I've tested this on Ubuntu 16.04 with BASH, and it works fine.  Easy peasy.  Hopefully you will accept this pull request, as it is pretty straightforward.

Thanks,
Rob
