### PR TITLE
Properly clean up build artefacts

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -359,6 +359,7 @@ clean::
 clean::
 	$(MAKE) -C ubase clean
 	$(MAKE) -C lwt clean
+	$(MAKE) -C fsmonitor/windows clean
 
 ifneq ($(strip $(UIMACDIR)),)
 clean::

--- a/src/fsmonitor/windows/Makefile
+++ b/src/fsmonitor/windows/Makefile
@@ -1,5 +1,5 @@
 
-FSMONITOR = $(NAME)-fsmonitor
+FSMONITOR = unison-fsmonitor
 
 DIR=fsmonitor/windows
 FSMOCAMLOBJS = \

--- a/src/lwt/Makefile
+++ b/src/lwt/Makefile
@@ -48,7 +48,8 @@ uninstall:
 	ocamlfind remove $(NAME)
 
 clean::
-	rm -f *.cmi *.cmo *.cmx *.cma *.cmxa *.a *.o *~ *.bak
+	$(RM) -f *.cmi *.cmo *.cmx *.cma *.cmxa *.a *.o *~ *.bak
+	$(RM) -f win/*.cm[ioxa] win/*.cmxa win/*.a win/*.o win/*~ win/*.bak
 
 clean::
 	cd example && $(MAKE) clean


### PR DESCRIPTION
This change properly cleans up all (Windows) build artefacts. It also uses the `$(RM)` variable as opposed to a hardcoded `rm`