### PR TITLE
Add support for Windows resource compiler (windres)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,3 +224,6 @@ installtext:
 src/$(NAME):
 	$(MAKE) -C src
 
+windres:
+	windres src/win32rc/unison.rc -O coff src/win32rc/unison.res.lib
+	windres src/win32rc/unison.rc -O res src/win32rc/unison.res


### PR DESCRIPTION
The included Windows resource files (`unison.res`  and `unison.res.lib`) are 32-bit. If somebody wants to compile Unison for a Windows 64 bit platform (e.g. MSYS2 / mingw64) then 64-bit resource files are necessary.

The new make target `windres` compiles the proper Windows resources.

E.g. for compiling Unison on MSYS2 / mingw64:
`make windres && make OSARCH=win32gnuc`