### PR TITLE
In GTK interface, show full pathnames in file list

### DIFF
--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -291,7 +291,7 @@ let reconItem2stringList oldPath theRI =
       (replicaContent2shortString diff.rc1,
        direction2action partial diff.direction,
        replicaContent2shortString diff.rc2,
-       displayPath oldPath theRI.path1)
+       Path.toString theRI.path1)
 
 let reconItem2string oldPath theRI status =
   let (r1, action, r2, path) = reconItem2stringList oldPath theRI in


### PR DESCRIPTION
A small code change to show full pathnames in the file list, instead of just an indented filename. It's always seemed to me like the indentation is supposed to suggest the shape of the directory hierarchy - ie. with subfolders and files indented more than their parents - but the exact amount of indentation has always looked erratic to me, and if you change the sorting of the list things get extra confusing.

So, I've changed my copy to just show the full paths. When I say 'full path', I mean relative to the Unison root. Here's a screenshot of what it looks like now:

![unison_with_full_paths](https://cloud.githubusercontent.com/assets/4549132/20026565/91985fc4-a2f4-11e6-8b7b-cf40945d135f.png)
