### PR TITLE
Eks/doc fixes

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1802,7 +1802,7 @@ Setting the \verb|dumbtty| preference will force Unison to leave the
 terminal alone and process input a line at a time.
 \end{itemize}
 
-\SUBSECTION{Exit code}{exit}
+\SUBSECTION{Exit Code}{exit}
 
 When running in the textual mode, Unison returns an exit status, which
 describes whether, and at which level, the synchronization was successful.

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -232,7 +232,7 @@ appears by default, while the textual interface can be selected by including
 provides just the textual interface.
 
 If you don't see a pre-built executable for your architecture, you'll
-need to build it yourself.  See \sectionref{building}{Building Unison}.
+need to build it yourself.  See \sectionref{building}{Building Unison from Scratch}.
 There are also a small number of contributed ports to other
 architectures that are not maintained by us.  See the
 \SHOWURL{http://www.cis.upenn.edu/\home{bcpierce}/unison/download.html}{Contributed
@@ -664,7 +664,7 @@ of the path:
   on the server by using the command-line option \showtt{-servercmd
     /full/path/name/of/unison} or adding
   \showtt{servercmd=/full/path/name/of/unison} to your profile (see
-  \sectionref{profile}{Profile}).  Similarly, you can specify a
+  \sectionref{profile}{Profiles}).  Similarly, you can specify a
   explicit path for the \verb|ssh| program using the \showtt{-sshcmd}
   option.
   Extra arguments can be passed to \verb|ssh| by setting the
@@ -731,7 +731,7 @@ used files.  There are several possible ways of going about this:
 
 \begin{enumerate}
 \item Synchronize your whole home directory, using the Ignore facility
-(see \sectionref{ignore}{Ignore})
+(see \sectionref{ignore}{Ignoring Paths})
 to avoid synchronizing temporary files and things that only belong on
 one host.
 \item Create a subdirectory called {\tt shared} (or {\tt current}, or
@@ -768,7 +768,7 @@ synchronizing a laptop with a fileserver, you'll probably always run
 Unison on the laptop.)  This is a bit different from the usual
 situation with asymmetric mirroring programs like \verb|rdist|, where
 the mirroring operation typically needs to be initiated from the
-machine with the most recent changes.  \sectionref{profile}{Profile}
+machine with the most recent changes.  \sectionref{profile}{Profiles}
 covers the syntax of Unison profiles, together with some sample profiles.
 
 Some tips on improving Unison's performance can be found on the
@@ -810,7 +810,7 @@ The on-line information and the printed manual are essentially identical.
 
 If you use Unison regularly, you should subscribe to one of the mailing
 lists, to receive announcements of new versions.  See
-\sectionref{lists}{Mailing Lists}.
+\sectionref{lists}{Mailing Lists and Bug Reporting}.
 
 \SECTION{Basic Concepts}{basics}{basics}
 
@@ -2033,7 +2033,7 @@ If you don't need the files on the Windows system, you can simply
 disregard Unison's warning message, and go ahead with the
 synchronization; Unison won't touch those files.  If you don't want to
 see the warning on each synchronization, you can tell Unison to ignore
-the files (see \sectionref{ignore}{Ignore}).
+the files (see \sectionref{ignore}{Ignoring Paths}).
 
 \textbf{Illegal filenames.}  Unix allows some filenames that are
 illegal in Windows.  For example, colons (`:') are not allowed in
@@ -2183,7 +2183,7 @@ appear and you will type your password in the DOS window you were
 using.
 
 To use Unison in this mode, you must first create a profile (see
-\sectionref{profile}{Profile}).  Use your favorite editor for this.
+\sectionref{profile}{Profiles}).  Use your favorite editor for this.
 
 
 \appendix

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1617,7 +1617,7 @@ involved).  Each instance of the preference looks like this:
     merge = <PATHSPEC> -> <MERGECMD>
 \end{verbatim}
 The \verb|<PATHSPEC>| here has exactly the same format as for the
-\verb|ignore| preference (see \sectionref{pathspec}{Path specification}).  For example,
+\verb|ignore| preference (see \sectionref{pathspec}{Path Specification}).  For example,
 using ``\verb|Name *.txt|'' as the \verb|<PATHSPEC>| tells Unison that this
 command should be used whenever a file with extension \verb|.txt| needs to
 be merged.
@@ -1817,7 +1817,7 @@ Currently, there are four possible values for the exit status:
 The graphical interface does not return any useful information through the
 exit status.
 
-\SUBSECTION{Path specification}{pathspec}
+\SUBSECTION{Path Specification}{pathspec}
 Several Unison preferences (e.g., \verb|ignore|/\verb|ignorenot|,
 \verb|follow|, \verb|sortfirst|/\verb|sortlast|, \verb|backup|,
 \verb|merge|, etc.)
@@ -1888,7 +1888,7 @@ Most users of Unison will find that their replicas contain lots of
 files that they don't ever want to synchronize --- temporary files,
 very large files, old stuff, architecture-specific binaries, etc.
 They can instruct Unison to ignore these paths using patterns
-introduced in \sectionref{pathspec}{Path Patterns}.
+introduced in \sectionref{pathspec}{Path Specification}.
 
 For example, the following pattern will make Unison ignore any
 path containing the name \verb|CVS| or a name ending in \verb|.cmo|:
@@ -1980,7 +1980,7 @@ to treat a link in this manner, add a line of the form
              follow = \ARG{pathspec}
 \end{alltt}
 to the profile, where \ARG{pathspec} is a path pattern as described in
-\sectionref{pathspec}{Path Patterns}.
+\sectionref{pathspec}{Path Specification}.
 
 Windows file systems do not support symbolic links; Unison will refuse
 to propagate an opaque symbolic link from Unix to Windows and flag the

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -203,7 +203,7 @@ Unison can be used with either of two user interfaces:
 \begin{enumerate}
 \item a simple textual interface, suitable for dumb terminals (and
 running from scripts), and
-\item a more sophisticated grapical interface, based on Gtk2 (on
+\item a more sophisticated graphical interface, based on Gtk2 (on
        Linux/Windows) or the native UI framework (on OSX).
 \end{enumerate}
 
@@ -1490,7 +1490,7 @@ The file {\tt common} contains the real preferences:
 
     # If any new preferences are added by Unison (e.g. 'ignore'
     # preferences added via the graphical UI), then store them in the
-    # file 'common' rathen than in the top-level preference file
+    # file 'common' rather than in the top-level preference file
     addprefsto = common
 
     # Names and paths to ignore:
@@ -1899,7 +1899,7 @@ The next pattern makes Unison ignore the path \verb|a/b|:
 \begin{verbatim}
              ignore = Path a/b
 \end{verbatim}
-Path patterns do {\em not} skip filesnames beginning with \verb|.| (as Name
+Path patterns do {\em not} skip filenames beginning with \verb|.| (as Name
 patterns do).  For example,
 \begin{verbatim}
              ignore = Path */tmp
@@ -1917,7 +1917,7 @@ match the whole path, not just a substring of the path.
 
 Here are a few extra points regarding the \texttt{ignore} preference.
 \begin{itemize}
-\item If a directory is ignored, all its descendents will be too.
+\item If a directory is ignored, all its descendants will be too.
 
 \item The user interface provides some convenient commands for adding
   new patterns to be ignored.  To ignore a particular file, select it
@@ -1992,7 +1992,7 @@ Windows system, all symbolic links should match either an
 \SUBSECTION{Permissions}{perms}
 
 Synchronizing the permission bits of files is slightly tricky when two
-different filesytems are involved (e.g., when synchronizing a Windows
+different filesystems are involved (e.g., when synchronizing a Windows
 client and a Unix server).  In detail, here's how it works:
 \begin{itemize}
 \item When the permission bits of an existing file or directory are
@@ -2169,7 +2169,7 @@ abort.
 On Windows NT/2k/XP systems, the graphical version of Unison can be
 invoked directly by clicking on its icon.  On Windows 95/98 systems,
 click-starting also works, {\em as long as you are not using ssh}.
-Due to an incompatibility with ocaml and Windows 95/98 that is not
+Due to an incompatibility with OCaml and Windows 95/98 that is not
 under our control, you must start Unison from a DOS window in Windows
 95/98 if you want to use ssh.
 
@@ -2214,7 +2214,7 @@ follows.
 
 Warning: there are many implementations and ports of ssh for
 Windows, and not all of them will work with Unison.  We have gotten
-Unison to work with Cygwin's port of openssh, and we suggest you try
+Unison to work with Cygwin's port of OpenSSH, and we suggest you try
 that one first.  Here's how to install it:
 \begin{enumerate}
 \item First, create a new folder on your desktop to hold temporary

--- a/src/globals.ml
+++ b/src/globals.ml
@@ -282,7 +282,7 @@ let merge =
      ^ "The syntax of \\ARG{pathspec>cmd} is "
      ^ "described in \\sectionref{pathspec}{Path Specification}, and further "
      ^ "details on Merging functions are present in "
-     ^ "\\sectionref{merge}{Merging files}.")
+     ^ "\\sectionref{merge}{Merging Conflicting Versions}.")
 
 let shouldMerge p = Pred.test merge (Path.toString p)
 

--- a/src/update.ml
+++ b/src/update.ml
@@ -1063,7 +1063,7 @@ let mountpoints =
      ^ "double-check, at the end of update detection, that \\texttt{PATH} exists "
      ^ "and abort if it does not.  This is useful when Unison is used to synchronize "
      ^ "removable media.  This preference can be given more than once.  "
-     ^ "See \\sectionref{mountpoints}{Mount Points}.")
+     ^ "See \\sectionref{mountpoints}{Mount Points and Removable Media}.")
 
 let abortIfAnyMountpointsAreMissing fspath =
   Safelist.iter
@@ -1166,7 +1166,7 @@ let fastcheck =
        For backward compatibility, \
        \\verb|yes|, \\verb|no|, and \\verb|default| can be used in place \
        of \\verb|true|, \\verb|false|, and \\verb|auto|.  See \
-       \\sectionref{fastcheck}{Fast Checking} for more information.")
+       \\sectionref{fastcheck}{Fast Update Detection} for more information.")
 
 let useFastChecking () =
       Prefs.read fastcheck = `True


### PR DESCRIPTION
Hi.  Some documentation fixes.  It's all typos and dangling section references; nothing substantive.