### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:14.04
+
+RUN apt-get -y update \
+  && apt-get install -y \
+  build-essential \
+  software-properties-common \
+  && add-apt-repository --yes ppa:avsm/ppa \
+  && apt-get update -qq \
+  && apt-get install -y opam build-essential \
+  && eval $(opam config env)
+
+ADD . /tmp/unison
+
+RUN cd /tmp/unison \
+  && make \
+  && cp src/unison /usr/local/bin \
+  && cp src/unison-fsmonitor /usr/local/bin \
+  && rm -rf /tmp/unison
+
+ENTRYPOINT ["unison"]


### PR DESCRIPTION
Hey, I've added a Dockerfile to this repository.

If someone want to use Unison via Docker, it's could be as simple as:

`docker run unison`

This pull-request is a step in the right direction. Granted, you may still want to tag images to specific versions on the Docker Hub. 