### PR TITLE
Follow OCaml 'interface' rule

### DIFF
--- a/src/lwt/lwt_unix_stubs.c
+++ b/src/lwt/lwt_unix_stubs.c
@@ -79,6 +79,7 @@ static value completionCallback;
 
 static void invoke_completion_callback
 (long id, long len, long errCode, long action) {
+  CAMLparam0();
   CAMLlocal2 (err, name);
   value args[4];
   err = Val_long(0);


### PR DESCRIPTION
See the interface guidelines on
http://caml.inria.fr/pub/docs/manual-ocaml-4.04/intfc.html
Paragraph 19.5.1 states the following:

Rule 1 A function that has parameters or local variables of type value must
begin with a call to one of the CAMLparam macros and return with CAMLreturn,
CAMLreturn0, or CAMLreturnT. In particular, CAMLlocal and CAMLxparam can only be
called after CAMLparam.

Although this is a callback function, add a call to CAMLparam(0)

This solves a compile issue on msys2 / mingw64 / OCaml 4.04.0