### PR TITLE
ensure sorted profile list in the macOS UI

### DIFF
--- a/src/uimac14/ProfileController.m
+++ b/src/uimac14/ProfileController.m
@@ -35,6 +35,9 @@ NSString *unisonDirectory()
                 j++;
             }
         }
+        NSSortDescriptor *sort = [NSSortDescriptor sortDescriptorWithKey:nil ascending:YES];
+        [profiles sortUsingDescriptors:[NSArray arrayWithObject:sort]];
+
         if (j > 0)
             [tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
 


### PR DESCRIPTION
On APFS file systems, `NSFileManager` enumerates directories in an unspecified order. To restore the ordering at the UI level, we have to explicitly sort the profile list.