### PR TITLE
[make] Pass correct include options to gtk2 build under OPAM env.

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -293,8 +293,14 @@ ifeq ($(UISTYLE), gtk)
 endif
 
 # Gtk2 GUI
+OCAMLFIND := $(shell command -v ocamlfind 2> /dev/null)
+
 ifeq ($(UISTYLE), gtk2)
-  CAMLFLAGS+=-I +lablgtk2
+  ifndef OCAMLFIND
+    CAMLFLAGS+=-I +lablgtk2
+  else
+    CAMLFLAGS+=$(shell $(OCAMLFIND) query -i-format lablgtk2 )
+  endif
   OCAMLOBJS+=pixmaps.cmo uigtk2.cmo linkgtk2.cmo
   OCAMLLIBS+=lablgtk.cma
 endif


### PR DESCRIPTION
Fixes #9.

Makefile.OCaml hardcoded the GTK include path, which is incorrect
under an OPAM environment. The fix uses `ocamlfind`, if available, to
get the proper cmdline options.

Works for me (TM).