### PR TITLE
Makefile.OCaml: fswatch.cmi depends on ubase/prefs.cmi.

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -427,6 +427,8 @@ win32rc/unison.res.lib: win32rc/unison.res
 	@echo "$(CAMLC): $< ---> $@"
 	$(CAMLC) $(CAMLFLAGS) -c $(CWD)/$<
 
+fswatch.cmi : ubase/prefs.cmi
+
 %.cmo: %.ml
 	@echo "$(OCAMLC): $< ---> $@"
 	$(OCAMLC) $(CAMLFLAGS) -c $(CWD)/$<


### PR DESCRIPTION
  The dependency is needed to build unison in parallel.

Reference: https://bugs.gentoo.org/582666