### PR TITLE
Add -unsafe-string switch, for compatibility with OCaml >=4.06

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -95,7 +95,7 @@ buildexecutable::
 ### Default parameters
 
 # Generate backtrace information for exceptions
-CAMLFLAGS+=-g
+CAMLFLAGS+=-g -unsafe-string
 
 INCLFLAGS=-I lwt -I ubase -I system
 CAMLFLAGS+=$(INCLFLAGS)


### PR DESCRIPTION
(Hopefully this will not break earlier OCaml versions!  Should be fine with the last couple, at least.)
