### PR TITLE
[make] Fix detection of lablgtk2 with OPAM

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -83,8 +83,13 @@ else
   ifeq ($(wildcard $(LABLGTK2LIB)),$(LABLGTK2LIB))
     UISTYLE=gtk2
   else
-    UISTYLE=text
-endif
+    LABLGTK2LIB=$(abspath $(OCAMLLIBDIR)/../lablgtk2)
+    ifeq ($(wildcard $(LABLGTK2LIB)),$(LABLGTK2LIB))
+      UISTYLE=gtk2
+    else
+      UISTYLE=text
+    endif
+  endif
 endif
 buildexecutable::
 	@echo UISTYLE = $(UISTYLE)


### PR DESCRIPTION
Dear Unison developers,

I noticed a slight bug with the compilation of Unison in gtk2 mode using OPAM: if lablgtk2 is available in opam's lib folder **only** (not system-wide at the same time), up to now I could not compile Unison's GUI because `make src` behaved like `make text`.

This PR is thus a follow-up of #95.

I tested it under Debian GNU/Linux stable, in both setups (system-wide or opam-based ocaml).

Hoping this helps