### PR TITLE
uitext: Add a "go back" option to the "proceed" prompt

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -354,6 +354,10 @@ let interact pilist rilist =
                   ("proceed immediately to propagating changes"),
                   (fun() ->
                      (ProceedImmediately, Safelist.rev_append prev ril)));
+                 (["s";"n"],
+                  ("stop the selection"),
+                  (fun() ->
+                     (ConfirmBeforeProceeding, Safelist.rev_append prev ril)));
                  (["q"],
                   ("exit " ^ Uutil.myName ^ " without propagating any changes"),
                   fun () -> raise Sys.Break);

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -539,129 +539,131 @@ let formatStatus major minor =
     lastMajor := major;
     s
 
-let rec interactAndPropagateChanges prevItemList reconItemList
+let interactAndPropagateChanges reconItemList
             : bool * bool * bool * (Path.t list)
               (* anySkipped?, anyPartial?, anyFailures?, failingPaths *) =
-  let (proceed,newReconItemList) = interact prevItemList reconItemList in
-  let (updatesToDo, skipped) =
-    Safelist.fold_left
-      (fun (howmany, skipped) ri ->
-        if problematic ri then (howmany, skipped + 1)
-        else (howmany + 1, skipped))
-      (0, 0) newReconItemList in
-  let doit() =
-    if not (Prefs.read Globals.batch || Prefs.read Trace.terse) then newLine();
-    if not (Prefs.read Trace.terse) then Trace.status "Propagating updates";
-    let timer = Trace.startTimer "Transmitting all files" in
-    let (failedPaths, partialPaths) = doTransport newReconItemList in
-    let failures = Safelist.length failedPaths in
-    let partials = Safelist.length partialPaths in
-    Trace.showTimer timer;
-    if not (Prefs.read Trace.terse) then Trace.status "Saving synchronizer state";
-    Update.commitUpdates ();
-    let trans = updatesToDo - failures in
-    let summary =
-      Printf.sprintf
-       "Synchronization %s at %s  (%d item%s transferred, %s%d skipped, %d failed)"
-       (if failures=0 then "complete" else "incomplete")
-       (let tm = Util.localtime (Util.time()) in
-        Printf.sprintf "%02d:%02d:%02d"
-          tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
-       trans (if trans=1 then "" else "s")
-       (if partials <> 0 then
-          Format.sprintf "%d partially transferred, " partials
-        else
-          "")
-       skipped
-       failures in
-    Trace.log (summary ^ "\n");
-    if skipped>0 then
-      Safelist.iter
-        (fun ri ->
-         match ri.replicas with
-           Problem r
-         | Different {rc1 = _; rc2 = _; direction = Conflict r; default_direction = _} ->
-            alwaysDisplayAndLog (Printf.sprintf "  skipped: %s (%s)"
-                                                (Path.toString ri.path1) r)
-         | _ -> ())
-        newReconItemList;
-    if partials>0 then
-      Safelist.iter
-        (fun p ->
-           alwaysDisplayAndLog ("  partially transferred: " ^ Path.toString p))
-        partialPaths;
-    if failures>0 then
-      Safelist.iter
-        (fun p -> alwaysDisplayAndLog ("  failed: " ^ (Path.toString p)))
-        failedPaths;
-    (skipped > 0, partials > 0, failures > 0, failedPaths) in
-  if not !Update.foundArchives then Update.commitUpdates ();
-  if updatesToDo = 0 then begin
-    (* BCP (3/09): We need to commit the archives even if there are
-       no updates to propagate because some files (in fact, if we've
-       just switched to DST on windows, a LOT of files) might have new
-       modtimes in the archive. *)
-    (* JV (5/09): Don't save the archive in repeat mode as it has some
-       costs and its unlikely there is much change to the archives in
-       this mode. *)
-    if !Update.foundArchives && Prefs.read Uicommon.repeat = "" then
+  let rec loop prevItemList reconItemList =
+    let (proceed,newReconItemList) = interact prevItemList reconItemList in
+    let (updatesToDo, skipped) =
+      Safelist.fold_left
+        (fun (howmany, skipped) ri ->
+          if problematic ri then (howmany, skipped + 1)
+          else (howmany + 1, skipped))
+        (0, 0) newReconItemList in
+    let doit() =
+      if not (Prefs.read Globals.batch || Prefs.read Trace.terse) then newLine();
+      if not (Prefs.read Trace.terse) then Trace.status "Propagating updates";
+      let timer = Trace.startTimer "Transmitting all files" in
+      let (failedPaths, partialPaths) = doTransport newReconItemList in
+      let failures = Safelist.length failedPaths in
+      let partials = Safelist.length partialPaths in
+      Trace.showTimer timer;
+      if not (Prefs.read Trace.terse) then Trace.status "Saving synchronizer state";
       Update.commitUpdates ();
-    display "No updates to propagate\n";
-    if skipped > 0 then begin
+      let trans = updatesToDo - failures in
       let summary =
         Printf.sprintf
-          "Synchronization complete at %s  (0 item transferred, %d skipped, 0 failed)"
-          (let tm = Util.localtime (Util.time()) in
-           Printf.sprintf "%02d:%02d:%02d"
-                          tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
-          skipped in
+         "Synchronization %s at %s  (%d item%s transferred, %s%d skipped, %d failed)"
+         (if failures=0 then "complete" else "incomplete")
+         (let tm = Util.localtime (Util.time()) in
+          Printf.sprintf "%02d:%02d:%02d"
+            tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
+         trans (if trans=1 then "" else "s")
+         (if partials <> 0 then
+            Format.sprintf "%d partially transferred, " partials
+          else
+            "")
+         skipped
+         failures in
       Trace.log (summary ^ "\n");
-      Safelist.iter
-        (fun ri ->
-         match ri.replicas with
-           Problem r
-         | Different {rc1 = _; rc2 = _; direction = Conflict r; default_direction = _} ->
-            alwaysDisplayAndLog (Printf.sprintf "  skipped: %s (%s)"
-                                                (Path.toString ri.path1) r)
-         | _ -> ())
-        newReconItemList
-      end;
-    (skipped > 0, false, false, [])
-  end else if proceed=ProceedImmediately then begin
-    doit()
-  end else begin
-    displayWhenInteractive "\nProceed with propagating updates? ";
-    selectAction
-      (* BCP: I find it counterintuitive that every other prompt except this one
-         would expect <CR> as a default.  But I got talked out of offering a
-         default here, because of safety considerations (too easy to press
-         <CR> one time too many). *)
-      (if Prefs.read Globals.batch then Some "y" else None)
-      [(["y";"g"],
-        "Yes: proceed with updates as selected above",
-        doit);
-       (["n"],
-        "No: go through selections again",
-        (fun () ->
-           Prefs.set Uicommon.auto false;
-           newLine();
-           interactAndPropagateChanges [] newReconItemList));
-       (["p";"b"],
-        "go back to previous item",
-        (fun () ->
-           newLine();
-           match Safelist.rev newReconItemList with
-             [] -> (* do as "n" *)
-               Prefs.set Uicommon.auto false;
-               newLine();
-               interactAndPropagateChanges [] []
-           | lastri::prev -> interactAndPropagateChanges prev [lastri]));
-       (["q"],
-        ("exit " ^ Uutil.myName ^ " without propagating any changes"),
-        fun () -> raise Sys.Break)
-     ]
-      (fun () -> display "Proceed with propagating updates? ")
-  end
+      if skipped>0 then
+        Safelist.iter
+          (fun ri ->
+           match ri.replicas with
+             Problem r
+           | Different {rc1 = _; rc2 = _; direction = Conflict r; default_direction = _} ->
+              alwaysDisplayAndLog (Printf.sprintf "  skipped: %s (%s)"
+                                                  (Path.toString ri.path1) r)
+           | _ -> ())
+          newReconItemList;
+      if partials>0 then
+        Safelist.iter
+          (fun p ->
+             alwaysDisplayAndLog ("  partially transferred: " ^ Path.toString p))
+          partialPaths;
+      if failures>0 then
+        Safelist.iter
+          (fun p -> alwaysDisplayAndLog ("  failed: " ^ (Path.toString p)))
+          failedPaths;
+      (skipped > 0, partials > 0, failures > 0, failedPaths) in
+    if not !Update.foundArchives then Update.commitUpdates ();
+    if updatesToDo = 0 then begin
+      (* BCP (3/09): We need to commit the archives even if there are
+         no updates to propagate because some files (in fact, if we've
+         just switched to DST on windows, a LOT of files) might have new
+         modtimes in the archive. *)
+      (* JV (5/09): Don't save the archive in repeat mode as it has some
+         costs and its unlikely there is much change to the archives in
+         this mode. *)
+      if !Update.foundArchives && Prefs.read Uicommon.repeat = "" then
+        Update.commitUpdates ();
+      display "No updates to propagate\n";
+      if skipped > 0 then begin
+        let summary =
+          Printf.sprintf
+            "Synchronization complete at %s  (0 item transferred, %d skipped, 0 failed)"
+            (let tm = Util.localtime (Util.time()) in
+             Printf.sprintf "%02d:%02d:%02d"
+                            tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
+            skipped in
+        Trace.log (summary ^ "\n");
+        Safelist.iter
+          (fun ri ->
+           match ri.replicas with
+             Problem r
+           | Different {rc1 = _; rc2 = _; direction = Conflict r; default_direction = _} ->
+              alwaysDisplayAndLog (Printf.sprintf "  skipped: %s (%s)"
+                                                  (Path.toString ri.path1) r)
+           | _ -> ())
+          newReconItemList
+        end;
+      (skipped > 0, false, false, [])
+    end else if proceed=ProceedImmediately then begin
+      doit()
+    end else begin
+      displayWhenInteractive "\nProceed with propagating updates? ";
+      selectAction
+        (* BCP: I find it counterintuitive that every other prompt except this one
+           would expect <CR> as a default.  But I got talked out of offering a
+           default here, because of safety considerations (too easy to press
+           <CR> one time too many). *)
+        (if Prefs.read Globals.batch then Some "y" else None)
+        [(["y";"g"],
+          "Yes: proceed with updates as selected above",
+          doit);
+         (["n"],
+          "No: go through selections again",
+          (fun () ->
+             Prefs.set Uicommon.auto false;
+             newLine();
+             loop [] newReconItemList));
+         (["p";"b"],
+          "go back to previous item",
+          (fun () ->
+             newLine();
+             match Safelist.rev newReconItemList with
+               [] -> (* do as "n" *)
+                 Prefs.set Uicommon.auto false;
+                 newLine();
+                 loop [] []
+             | lastri::prev -> loop prev [lastri]));
+         (["q"],
+          ("exit " ^ Uutil.myName ^ " without propagating any changes"),
+          fun () -> raise Sys.Break)
+       ]
+        (fun () -> display "Proceed with propagating updates? ")
+    end in
+  loop [] reconItemList
 
 let checkForDangerousPath dangerousPaths =
   if Prefs.read Globals.confirmBigDeletes then begin
@@ -725,7 +727,7 @@ let synchronizeOnce ?wantWatcher ?skipRecentFiles pathsOpt =
   end else begin
     checkForDangerousPath dangerousPaths;
     let (anySkipped, anyPartial, anyFailures, failedPaths) =
-      interactAndPropagateChanges [] reconItemList in
+      interactAndPropagateChanges reconItemList in
     let exitStatus = Uicommon.exitCode(anySkipped || anyPartial,anyFailures) in
     (exitStatus, failedPaths)
   end

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -645,13 +645,12 @@ let rec interactAndPropagateChanges prevItemList reconItemList
         (fun () ->
            Prefs.set Uicommon.auto false;
            newLine();
-           interactAndPropagateChanges []
-             (Safelist.rev_append prevItemList reconItemList)));
+           interactAndPropagateChanges [] newReconItemList));
        (["p";"b"],
         "go back to previous item",
         (fun () ->
            newLine();
-           match Safelist.rev_append reconItemList prevItemList with
+           match Safelist.rev newReconItemList with
              [] -> (* do as "n" *)
                Prefs.set Uicommon.auto false;
                newLine();


### PR DESCRIPTION
When one mistakenly skips the last item of the "selection" prompt this
option starts again at the last item whereas the existing option "do
again" reprocesses the whole list which can be long.

Add an accumulator to the function interactAndPropagateChanges() that
passes it as a newly added accumulator of the function interact() which
simply passes it as the accumulator of its subfuntion loop().  In
interactAndPropagateChanges() additionally append the accumulator to the
main list when we want to go back to the selection.