### PR TITLE
uitext: let "go back" go across errors in the selection

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -230,6 +230,11 @@ let interact rilist =
   let (host1, host2) = root2hostname r1, root2hostname r2 in
   if not (Prefs.read Globals.batch) then display ("\n" ^ Uicommon.roots2string() ^ "\n");
   let rec loop prev =
+    let rec previous prev ril =
+      match prev with
+        ({ replicas = Problem _ } as pri)::pril -> previous pril (pri::ril)
+      | pri::pril -> loop pril (pri::ril)
+      | [] -> loop prev ril in
     function
       [] -> (ConfirmBeforeProceeding, Safelist.rev prev)
     | ri::rest as ril ->
@@ -347,9 +352,7 @@ let interact rilist =
                   ("go back to previous item"),
                   (fun () ->
                      newLine();
-                     match prev with
-                       [] -> repeat()
-                     | prevri::prevprev -> loop prevprev (prevri :: ril)));
+                     previous prev ril));
                  (["g"],
                   ("proceed immediately to propagating changes"),
                   (fun() ->

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -232,7 +232,9 @@ let interact rilist =
   let rec loop prev =
     let rec previous prev ril =
       match prev with
-        ({ replicas = Problem _ } as pri)::pril -> previous pril (pri::ril)
+        ({ replicas = Problem s } as pri)::pril ->
+          displayri pri; display "\n"; display s; display "\n";
+          previous pril (pri::ril)
       | pri::pril -> loop pril (pri::ril)
       | [] -> loop prev ril in
     function


### PR DESCRIPTION
These simple patches fix #118 and apply cleanly to unison-2.48.  Since it seems that 2.48 is the current stable branch that has maintenance releases, I suggest to include this fix in such a release.