### PR TITLE
Parse the backslash as whitespace escape in sshargs, rshargs and include

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1303,9 +1303,12 @@ Many details of Unison's behavior are configurable by user-settable
 
 Some preferences are boolean-valued; these are often called {\em flags}.
 Others take numeric or string arguments, indicated in the preferences
-list by {\tt n} or {\tt xxx}.  Most of the string preferences can be
-given several times; the arguments are accumulated into a list
-internally.
+list by {\tt n} or {\tt xxx}.  Some string arguments take the backslash as
+an escape to include the next character literally; this is mostly useful
+to escape a space or the backslash; a trailing backslash is ignored and is
+useful to protect a trailing whitespace in the string that would otherwise
+be trimmed.  Most of the string preferences can be given several times;
+the arguments are accumulated into a list internally.
 
 There are two ways to set the values of preferences: temporarily, by
 providing command-line arguments to a particular run of Unison, or
@@ -1369,7 +1372,8 @@ Profiles may also include lines of the form \texttt{include
 \verb+.unison+ directory) to be read at the point, and included as if
 its contents, instead of the \texttt{include} line, was part of the
 profile.  Include lines allows settings common to several profiles to
-be stored in one place.
+be stored in one place.  In \ARG{name} the backslash is an escape
+character.
 
 A profile may include a preference `\texttt{label = \ARG{desc}}' to
 provide a description of the options selected in this profile.  The

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -488,7 +488,8 @@ let rshargs =
     ("The string value of this preference will be passed as additional "
      ^ "arguments (besides the host name and the name of the Unison "
      ^ "executable on the remote system) to the \\verb|rsh| "
-     ^ "command used to invoke the remote server. "
+     ^ "command used to invoke the remote server. The backslash is an "
+     ^ "escape character."
      )
 
 let sshargs =
@@ -497,7 +498,8 @@ let sshargs =
     ("The string value of this preference will be passed as additional "
      ^ "arguments (besides the host name and the name of the Unison "
      ^ "executable on the remote system) to the \\verb|ssh| "
-     ^ "command used to invoke the remote server. "
+     ^ "command used to invoke the remote server. The backslash is an "
+     ^ "escape character."
      )
 
 let serverCmd =

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -399,15 +399,25 @@ let rec trimWhitespace s =
   else
     s
 
-let splitIntoWords (s:string) (c:char) =
-  let rec inword acc start pos =
-    if pos >= String.length(s) || s.[pos] = c then
-      betweenwords ((String.sub s start (pos-start)) :: acc) pos
-    else inword acc start (pos+1)
+let splitIntoWords ?esc:(e='\\') (s:string) (c:char) =
+  let rec inword acc eacc start pos =
+    if pos >= String.length s || s.[pos] = c then
+      let word =
+        String.concat "" (Safelist.rev (String.sub s start (pos-start)::eacc)) in
+      betweenwords (word::acc) pos
+    else if s.[pos] = e then inescape acc eacc start pos
+    else inword acc eacc start (pos+1)
+  and inescape acc eacc start pos =
+    let eword = String.sub s start (pos-start) in
+    if pos+1 >= String.length s
+    then inword acc (eword::eacc) (pos+1) (pos+1) (* ignore final esc *)
+    else (* take any following char *)
+      let echar = String.make 1 (String.get s (pos+1)) in
+      inword acc (echar::eword::eacc) (pos+2) (pos+2)
   and betweenwords acc pos =
-    if pos >= (String.length s) then (Safelist.rev acc)
+    if pos >= String.length s then (Safelist.rev acc)
     else if s.[pos]=c then betweenwords acc (pos+1)
-    else inword acc pos pos
+    else inword acc [] pos pos
   in betweenwords [] 0
 
 let rec splitIntoWordsByString s sep =

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -55,7 +55,7 @@ val replacesubstrings : string -> (string * string) list -> string
 val concatmap : string -> ('a -> string) -> 'a list -> string
 val removeTrailingCR : string -> string
 val trimWhitespace : string -> string
-val splitIntoWords : string -> char -> string list
+val splitIntoWords : ?esc:char -> string -> char -> string list
 val splitIntoWordsByString : string -> string -> string list
 val padto : int -> string -> string
 


### PR DESCRIPTION
These are changes to fix #113.  The fix does not introduce string escapes as mentionned in the discussion but a simple backslash escape that escapes any char following (so that it is not splitting whitespace).

A single function splitIntoWords() is modified.

There is also a commit updating the documentation in Strings.ml.