### PR TITLE
Uitext: catch exception while reading stdin and print error

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -177,7 +177,17 @@ let rec selectAction batch actions tryagain =
   doAction (match batch with
     None   ->
       summarizeChoices();
-      getInput ()
+      begin try getInput () with e ->
+        (* Simply print a slightly more informative message than the exception
+         * itself (e.g. "Uncaught unix error: read failed: Resource temporarily
+         * unavailable" or "Uncaught exception End_of_file") and make sure the
+         * error messages start on their own lines. *)
+        Util.msg "\nError while reading from the standard input\n";
+        (* FIX: Unison should or may have a better or standard way to treat
+         * such exceptions; maybe a cleanup (e.g. restoreTerminal()) should be
+         * made at some point. *)
+        raise e
+      end
   | Some i -> i)
 
 let alwaysDisplayErrors prefix l =

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -836,11 +836,7 @@ let handleException e =
   restoreTerminal();
   let msg = Uicommon.exn2string e in
   Trace.log (msg ^ "\n");
-  if not !Trace.sendLogMsgsToStderr then begin
-    alwaysDisplay "\n";
-    alwaysDisplay msg;
-    alwaysDisplay "\n";
-  end
+  if not !Trace.sendLogMsgsToStderr then alwaysDisplay ("\n" ^ msg ^ "\n")
 
 let rec start interface =
   if interface <> Uicommon.Text then

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -177,16 +177,18 @@ let rec selectAction batch actions tryagain =
   doAction (match batch with
     None   ->
       summarizeChoices();
-      begin try getInput () with e ->
+      let handleExn s =
+        (* Make sure that the error messages start on their own lines and not
+         * after the prompt. *)
+        alwaysDisplay "\n";
+        raise (Util.Fatal ("Failure reading from the standard input ("^s^")\n"))
+      in
+      begin try getInput () with
         (* Simply print a slightly more informative message than the exception
          * itself (e.g. "Uncaught unix error: read failed: Resource temporarily
-         * unavailable" or "Uncaught exception End_of_file") and make sure the
-         * error messages start on their own lines. *)
-        Util.msg "\nError while reading from the standard input\n";
-        (* FIX: Unison should or may have a better or standard way to treat
-         * such exceptions; maybe a cleanup (e.g. restoreTerminal()) should be
-         * made at some point. *)
-        raise e
+         * unavailable" or "Uncaught exception End_of_file"). *)
+          End_of_file -> handleExn "End of file"
+        | Unix.Unix_error (err, _, _) -> handleExn (Unix.error_message err)
       end
   | Some i -> i)
 


### PR DESCRIPTION
This change is related to issue #123 but it only prints an error message without treating the error condition (and the exception is raised again and uncaught).