### PR TITLE
Uitext: keep the modified reconList when restarting the selection process

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -665,7 +665,7 @@ let rec interactAndPropagateChanges reconItemList
         (fun () ->
            Prefs.set Uicommon.auto false;
            newLine();
-           interactAndPropagateChanges reconItemList));
+           interactAndPropagateChanges newReconItemList));
        (["q"],
         ("exit " ^ Uutil.myName ^ " without propagating any changes"),
         fun () -> raise Sys.Break)


### PR DESCRIPTION
This fixes the bug that unignores newly added permanent ignore-patterns
when the selection process is restarted from the "proceed" prompt.  The
change will also make it possible to implement other reconList
modifications like sorting.