### PR TITLE
Uitext: add commands to "stop" to "proceed" and "go back" to "reconcile" selection

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -682,7 +682,7 @@ let rec interactAndPropagateChanges prevItemList reconItemList
        (["q"],
         ("exit " ^ Uutil.myName ^ " without propagating any changes"),
         fun () -> raise Sys.Break)
-     ]
+      ]
       (fun () -> display "Proceed with propagating updates? ")
   end
 

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -665,7 +665,7 @@ let rec interactAndPropagateChanges reconItemList
         (fun () ->
            Prefs.set Uicommon.auto false;
            newLine();
-           interactAndPropagateChanges reconItemList));
+           interactAndPropagateChanges newReconItemList));
        (["q"],
         ("exit " ^ Uutil.myName ^ " without propagating any changes"),
         fun () -> raise Sys.Break)

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -242,9 +242,9 @@ type proceed = ConfirmBeforeProceeding | ProceedImmediately
 
 (* "interact [] rilist" interactively reconciles each list item *)
 let interact prilist rilist =
+  if not (Prefs.read Globals.batch) then display ("\n" ^ Uicommon.roots2string() ^ "\n");
   let (r1,r2) = Globals.roots() in
   let (host1, host2) = root2hostname r1, root2hostname r2 in
-  if not (Prefs.read Globals.batch) then display ("\n" ^ Uicommon.roots2string() ^ "\n");
   let rec loop prev =
     let rec previous prev ril =
       match prev with

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -371,6 +371,11 @@ let interact prilist rilist =
                   (fun () ->
                      newLine();
                      previous prev ril));
+                 (["s";"n"],
+                  ("stop the selection"),
+                  (fun() ->
+                     newLine();
+                     (ConfirmBeforeProceeding, Safelist.rev_append prev ril)));
                  (["g"],
                   ("proceed immediately to propagating changes"),
                   (fun() ->

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -276,7 +276,7 @@ let interact prilist rilist =
         displayri ri;
         match ri.replicas with
           Problem s -> display "\n"; display s; display "\n"; next()
-        | Different ({rc1 = rc1; rc2 = rc2; direction = dir} as diff) ->
+        | Different ({rc1 = _; rc2 = _; direction = dir} as diff) ->
             if Prefs.read Uicommon.auto && not (isConflict dir) then begin
               display "\n"; next()
             end else

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -558,10 +558,10 @@ let formatStatus major minor =
     lastMajor := major;
     s
 
-let rec interactAndPropagateChanges reconItemList
+let rec interactAndPropagateChanges prevItemList reconItemList
             : bool * bool * bool * (Path.t list)
               (* anySkipped?, anyPartial?, anyFailures?, failingPaths *) =
-  let (proceed,newReconItemList) = interact [] reconItemList in
+  let (proceed,newReconItemList) = interact prevItemList reconItemList in
   let (updatesToDo, skipped) =
     Safelist.fold_left
       (fun (howmany, skipped) ri ->
@@ -664,7 +664,7 @@ let rec interactAndPropagateChanges reconItemList
         (fun () ->
            Prefs.set Uicommon.auto false;
            newLine();
-           interactAndPropagateChanges newReconItemList));
+           interactAndPropagateChanges [] newReconItemList));
        (["q"],
         ("exit " ^ Uutil.myName ^ " without propagating any changes"),
         fun () -> raise Sys.Break)
@@ -734,7 +734,7 @@ let synchronizeOnce ?wantWatcher ?skipRecentFiles pathsOpt =
   end else begin
     checkForDangerousPath dangerousPaths;
     let (anySkipped, anyPartial, anyFailures, failedPaths) =
-      interactAndPropagateChanges reconItemList in
+      interactAndPropagateChanges [] reconItemList in
     let exitStatus = Uicommon.exitCode(anySkipped || anyPartial,anyFailures) in
     (exitStatus, failedPaths)
   end

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -240,6 +240,7 @@ let displayri ri =
 
 type proceed = ConfirmBeforeProceeding | ProceedImmediately
 
+(* "interact [] rilist" interactively reconciles each list item *)
 let interact prilist rilist =
   let (r1,r2) = Globals.roots() in
   let (host1, host2) = root2hostname r1, root2hostname r2 in

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -252,7 +252,7 @@ let interact prilist rilist =
           displayri pri; display "\n"; display s; display "\n";
           previous pril (pri::ril)
       | pri::pril -> loop pril (pri::ril)
-      | [] -> loop prev ril in
+      | [] -> display ("\n" ^ Uicommon.roots2string() ^ "\n"); loop prev ril in
     function
       [] -> (ConfirmBeforeProceeding, Safelist.rev prev)
     | ri::rest as ril ->

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -240,7 +240,7 @@ let displayri ri =
 
 type proceed = ConfirmBeforeProceeding | ProceedImmediately
 
-let interact rilist =
+let interact prilist rilist =
   let (r1,r2) = Globals.roots() in
   let (host1, host2) = root2hostname r1, root2hostname r2 in
   if not (Prefs.read Globals.batch) then display ("\n" ^ Uicommon.roots2string() ^ "\n");
@@ -397,8 +397,7 @@ let interact rilist =
                     next()))
                 ]
                 (fun () -> displayri ri)
-  in
-    loop [] rilist
+  in loop prilist rilist
 
 let verifyMerge title text =
   Printf.printf "%s\n" text;
@@ -562,7 +561,7 @@ let formatStatus major minor =
 let rec interactAndPropagateChanges reconItemList
             : bool * bool * bool * (Path.t list)
               (* anySkipped?, anyPartial?, anyFailures?, failingPaths *) =
-  let (proceed,newReconItemList) = interact reconItemList in
+  let (proceed,newReconItemList) = interact [] reconItemList in
   let (updatesToDo, skipped) =
     Safelist.fold_left
       (fun (howmany, skipped) ri ->

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -665,6 +665,14 @@ let rec interactAndPropagateChanges prevItemList reconItemList
            Prefs.set Uicommon.auto false;
            newLine();
            interactAndPropagateChanges [] newReconItemList));
+       (["p";"b"],
+        "go back to the last item of the selection",
+        (fun () ->
+           Prefs.set Uicommon.auto false;
+           newLine();
+           match Safelist.rev newReconItemList with
+             [] -> interactAndPropagateChanges [] []
+           | lastri::prev -> interactAndPropagateChanges prev [lastri]));
        (["q"],
         ("exit " ^ Uutil.myName ^ " without propagating any changes"),
         fun () -> raise Sys.Break)


### PR DESCRIPTION
These new commands avoid to have to go through the entire "reconcile" selection process to change only a few paths at the top or at the bottom.