### PR TITLE
unison-manual.tex: fix the build command

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -323,8 +323,8 @@ from \ONEURL{http://wwwfun.kurims.kyoto-u.ac.jp/soft/olabl/lablgtk.html}.
 (e.g. Ubuntu) the bindings between Pango and OCaml need to be installed
 explicitly (package {\tt liblablgtk-extras-ocaml-dev} on Ubuntu).
 \end{itemize}
-Type {\tt make} to build Unison. If Gtk2 is available on the system, Unison
-with a GUI will be built automatically.
+Type {\tt make src} to build Unison. If Gtk2 is available on the system,
+Unison with a GUI will be built automatically.
 
 Put the \verb|unison| executable somewhere in your search path, either by
 adding the Unison directory to your PATH variable or by copying the


### PR DESCRIPTION
'make src' builds unison with gtk2 and not 'make' anymore since commit
0ec217a ("Revert commit 36a1e98 -- it breaks the Travis build",
2016-09-27).