### PR TITLE
eval opam env before building unison-blob.o

### DIFF
--- a/src/uimac14/uimacnew.xcodeproj/project.pbxproj
+++ b/src/uimac14/uimacnew.xcodeproj/project.pbxproj
@@ -516,7 +516,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Building unison-blob.o...\"\nif [ -x /usr/libexec/path_helper ]; then\n  eval `/usr/libexec/path_helper -s`\nfi\ncd ${PROJECT_DIR}/..\nmake unison-blob.o\necho \"done\"";
+			shellScript = "echo \"Building unison-blob.o...\"\nif [ -x /usr/libexec/path_helper ]; then\n  eval `/usr/libexec/path_helper -s`\nfi\nif [ -x `which opam` ]; then\neval `opam config env`\nfi\ncd ${PROJECT_DIR}/..\nmake unison-blob.o\necho \"done\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
As path-helper **prepends** the system path (see https://stackoverflow.com/questions/12409270/os-x-mountain-lion-how-does-path-helper-work), the system ocaml was called before the opam ones when building `unison-blob.o`. This adds a check if opam is installed, and in that case it evals its environment variables.