### PR TITLE
Merge pull request #121 from g-raud/splitintowords-escape-char

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1317,9 +1317,12 @@ Many details of Unison's behavior are configurable by user-settable
 
 Some preferences are boolean-valued; these are often called {\em flags}.
 Others take numeric or string arguments, indicated in the preferences
-list by {\tt n} or {\tt xxx}.  Most of the string preferences can be
-given several times; the arguments are accumulated into a list
-internally.
+list by {\tt n} or {\tt xxx}.  Some string arguments take the backslash as
+an escape to include the next character literally; this is mostly useful
+to escape a space or the backslash; a trailing backslash is ignored and is
+useful to protect a trailing whitespace in the string that would otherwise
+be trimmed.  Most of the string preferences can be given several times;
+the arguments are accumulated into a list internally.
 
 There are two ways to set the values of preferences: temporarily, by
 providing command-line arguments to a particular run of Unison, or
@@ -1383,7 +1386,8 @@ Profiles may also include lines of the form \texttt{include
 \verb+.unison+ directory) to be read at the point, and included as if
 its contents, instead of the \texttt{include} line, was part of the
 profile.  Include lines allows settings common to several profiles to
-be stored in one place.
+be stored in one place.  In \ARG{name} the backslash is an escape
+character.
 
 A profile may include a preference `\texttt{label = \ARG{desc}}' to
 provide a description of the options selected in this profile.  The

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -483,7 +483,8 @@ let rshargs =
     ("The string value of this preference will be passed as additional "
      ^ "arguments (besides the host name and the name of the Unison "
      ^ "executable on the remote system) to the \\verb|rsh| "
-     ^ "command used to invoke the remote server. "
+     ^ "command used to invoke the remote server. The backslash is an "
+     ^ "escape character."
      )
 
 let sshargs =
@@ -492,7 +493,8 @@ let sshargs =
     ("The string value of this preference will be passed as additional "
      ^ "arguments (besides the host name and the name of the Unison "
      ^ "executable on the remote system) to the \\verb|ssh| "
-     ^ "command used to invoke the remote server. "
+     ^ "command used to invoke the remote server. The backslash is an "
+     ^ "escape character."
      )
 
 let serverCmd =

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -55,7 +55,7 @@ val replacesubstrings : string -> (string * string) list -> string
 val concatmap : string -> ('a -> string) -> 'a list -> string
 val removeTrailingCR : string -> string
 val trimWhitespace : string -> string
-val splitIntoWords : string -> char -> string list
+val splitIntoWords : ?esc:char -> string -> char -> string list
 val splitIntoWordsByString : string -> string -> string list
 val padto : int -> string -> string
 


### PR DESCRIPTION
Parse the backslash as whitespace escape in sshargs, rshargs and include.

I had trouble getting this to compile on OSX with ocaml 4.01.0 (which is what debian jessie and ubuntu 16.04 are on). I think somewhere >2.40.102 broke ocaml 4.01 support.

For my team's current use, I am adding this patch (less some "src/" https://gist.github.com/WyseNynja/f5659eb14d32d9fa6d68b87b5c8b1d6c) to http://www.seas.upenn.edu/~bcpierce/unison/download/releases/unison-2.40.102/unison-2.40.102.tar.gz
