### PR TITLE
Uarg: fix the parsing of command line options' arguments

### DIFF
--- a/src/ubase/prefs.ml
+++ b/src/ubase/prefs.ml
@@ -392,16 +392,15 @@ and parseLines filename lines =
           | _ -> raise (Util.Fatal(Printf.sprintf
                                      "File \"%s\", line %d:\nGarbled 'include' directive: %s"
                                      filename lineNum theLine))
-        else try
-          let pos = String.index theLine '=' in
-          let varName = Util.trimWhitespace (String.sub theLine 0 pos) in
-          let theResult =
-            Util.trimWhitespace (String.sub theLine (pos+1)
-                              (String.length theLine - pos - 1)) in
-          loop rest (lineNum+1) ((filename, lineNum, varName, theResult)::res)
-        with Not_found -> (* theLine does not contain '=' *)
-          raise(Util.Fatal(Printf.sprintf
-                             "File \"%s\", line %d:\nGarbled line (no '='):\n%s" filename lineNum theLine)) in
+        else
+          let l = Util.splitAtFirstChar theLine '=' in
+          match Safelist.map Util.trimWhitespace l with
+            [varName;theResult] ->
+              loop rest (lineNum+1) ((filename, lineNum, varName, theResult)::res)
+          | _ -> (* theLine does not contain '=' *)
+              raise (Util.Fatal(Printf.sprintf
+                                  "File \"%s\", line %d:\nGarbled line (no '='):\n%s"
+                                  filename lineNum theLine)) in
   loop lines 1 []
 
 let processLines lines =

--- a/src/ubase/uarg.ml
+++ b/src/ubase/uarg.ml
@@ -83,6 +83,9 @@ let parse speclist anonfun errmsg =
       let action =
         try assoc3 s speclist
         with Not_found -> stop (Unknown s)
+      and catch f a =
+        try f a
+        with Invalid_argument s -> raise (Failure s)
       in
       begin try
         match action with
@@ -92,11 +95,11 @@ let parse speclist anonfun errmsg =
         | Bool f ->
             begin match args with
               [_] -> f true
-            | _   -> f (arg bool_of_string "a boolean")
+            | _   -> f (arg (catch bool_of_string) "a boolean")
             end
         | String f -> f (arg (fun s-> s) "")
-        | Int f    -> f (arg int_of_string "an integer")
-        | Float f  -> f (arg float_of_string "a float")
+        | Int f    -> f (arg (catch int_of_string) "an integer")
+        | Float f  -> f (arg (catch float_of_string) "a float")
         | Rest f ->
             while !current < l-1 do
               f argv.(!current+1);

--- a/src/ubase/uarg.ml
+++ b/src/ubase/uarg.ml
@@ -69,7 +69,7 @@ let parse speclist anonfun errmsg =
   while !current < l do
     let ss = argv.(!current) in
     if String.length ss >= 1 & String.get ss 0 = '-' then begin
-      let args = Util.splitIntoWords ss '=' in
+      let args = Util.splitAtFirstChar ss '=' in
       let s = Safelist.nth args 0 in
       let arg conv mesg =
         match args with
@@ -79,7 +79,7 @@ let parse speclist anonfun errmsg =
              incr current;
              (try conv a with Failure _ -> stop (Wrong (s, a, mesg)))
         | [_;a] -> (try conv a with Failure _ -> stop (Wrong (s, a, mesg)))
-        | _ -> stop (Message (sprintf "Garbled argument %s" s)) in
+        | _ -> assert false in
       let action =
         try assoc3 s speclist
         with Not_found -> stop (Unknown s)

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -401,6 +401,14 @@ let trimWhitespace s =
    in
    loop 0 (l-1)
 
+let splitAtFirstChar (s:string) (c:char) =
+  try
+    let i = String.index s c in
+    match String.length s with
+      l when l=i+1 -> [String.sub s 0 i] (* do not include the empty string *)
+    | l -> [String.sub s 0 i; String.sub s (i+1) (l-i-1)]
+  with Not_found -> [s]
+
 let splitIntoWords ?esc:(e='\\') (s:string) (c:char) =
   let rec inword acc eacc start pos =
     if pos >= String.length s || s.[pos] = c then

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -403,10 +403,10 @@ let trimWhitespace s =
 
 let splitAtFirstChar (s:string) (c:char) =
   try
-    let i = String.index s c in
-    match String.length s with
-      l when l=i+1 -> [String.sub s 0 i] (* do not include the empty string *)
-    | l -> [String.sub s 0 i; String.sub s (i+1) (l-i-1)]
+    let i = String.index s c
+    and l= String.length s in
+    (* rest is possibly the empty string *)
+    [String.sub s 0 i; String.sub s (i+1) (l-i-1)]
   with Not_found -> [s]
 
 let splitIntoWords ?esc:(e='\\') (s:string) (c:char) =

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -55,6 +55,7 @@ val replacesubstrings : string -> (string * string) list -> string
 val concatmap : string -> ('a -> string) -> 'a list -> string
 val removeTrailingCR : string -> string
 val trimWhitespace : string -> string
+val splitAtFirstChar : string -> char -> string list
 val splitIntoWords : ?esc:char -> string -> char -> string list
 val splitIntoWordsByString : string -> string -> string list
 val padto : int -> string -> string


### PR DESCRIPTION
The '=' has been considered whitespace until now: several following chars are considered as only one; trailing chars are discarded; any non emty sequence of char is splitting.  This is non standard and leads to confusion, for example `-ignore== 'Name .*=*'` is valid when `-ignore='Name .*=*'` is not, and worse `-ignore='Name *='` is the same as `-ignore='Name *'` .

Furthermore with the recent escaping added to splitIntoWords() the parsing of the command line options has been subjected to escaping which should not be necessary and may lead to more confusions (for example `-ignore='Name .*\\='`, `-sshargs='-o ProxyCommand=nc\\ -x\\ localhost:9050\\ %h\\ %p'` when in the file `sshargs = -o ProxyCommand=nc\ -x\ localhost:9050\ %h\ %p'` is used).  In fact #121 shoud have been merged after this PR.