### PR TITLE
'logfile': when relative path then root to home

### DIFF
--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -117,7 +117,7 @@ let logfile =
     "!logfile name"
     "By default, logging messages will be appended to the file
      \\verb|unison.log| in your HOME directory.  Set this preference if
-     you prefer another file."
+     you prefer another file.  It can be relative to your HOME directory."
 
 let logch = ref None
 
@@ -125,7 +125,8 @@ let rec getLogch() =
   Util.convertUnixErrorsToFatal "getLogch" (fun() ->
   match !logch with
     None ->
-      let file = Prefs.read logfile in
+      let prefstr = System.fspathToString (Prefs.read logfile) in
+      let file = Util.fileMaybeRelToHomeDir prefstr in
       let ch =
         System.open_out_gen [Open_wronly; Open_creat; Open_append] 0o600 file in
       logch := Some (ch, file);

--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -117,7 +117,7 @@ let logfile =
     "!logfile name"
     "By default, logging messages will be appended to the file
      \\verb|unison.log| in your HOME directory.  Set this preference if
-     you prefer another file.  It can be relative to your HOME directory."
+     you prefer another file.  It can be a path relative to your HOME directory."
 
 let logch = ref None
 

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -460,6 +460,11 @@ let homeDir () =
 
 let fileInHomeDir n = System.fspathConcat (homeDir ()) n
 
+let fileMaybeRelToHomeDir n =
+  if Filename.is_relative n
+  then fileInHomeDir n
+  else System.fspathFromString n
+
 (*****************************************************************************)
 (*           "Upcall" for building pathnames in the .unison dir              *)
 (*****************************************************************************)

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -79,6 +79,7 @@ val percentageOfTotal :
 val monthname : int -> string
 val percent2string : float -> string
 val fileInHomeDir : string -> System.fspath
+val fileMaybeRelToHomeDir : string -> System.fspath
 val homeDirStr : string
 
 (* Just like the versions in the Unix module, but raising Transient


### PR DESCRIPTION
Unison roots a relative logfile parameter to the current working dir which is wrong 
because:
- first the current working directory can be anywhere with no relation
  whatsoever to unison so unison may corrupt an existing file;
- secondly it can change between each run so that the log is scattered.

There's a slight drawback: on the command line it is customary to have paths relative to the CWD.