### PR TITLE
New preference 'mergenot'

### DIFF
--- a/src/globals.ml
+++ b/src/globals.ml
@@ -284,7 +284,14 @@ let merge =
      ^ "details on Merging functions are present in "
      ^ "\\sectionref{merge}{Merging Conflicting Versions}.")
 
-let shouldMerge p = Pred.test merge (Path.toString p)
+let mergenot =
+  Pred.create "mergenot" ~advanced:true
+    ("This preference overrides {\\tt merge}: the specified paths are "
+    ^ "{\\em not} merged, even if the {\\tt merge} preference selects them.")
+
+let shouldMerge p =
+  let p = Path.toString p in
+  Pred.test merge p && not (Pred.test mergenot p)
 
 let mergeCmdForPath p = Pred.assoc merge (Path.toString p)
 

--- a/src/globals.ml
+++ b/src/globals.ml
@@ -216,7 +216,10 @@ let batch =
   Prefs.createBool "batch" false "batch mode: ask no questions at all"
     ("When this is set to {\\tt true}, the user "
      ^ "interface will ask no questions at all.  Non-conflicting changes "
-     ^ "will be propagated; conflicts will be skipped.")
+     ^ "will be propagated; conflicts will be skipped.  Note that the "
+     ^ "preference {\\tt merge} remains active; some additional "
+     ^ "{\\tt -mergenot} can prevent interactive and/or risky merge "
+     ^ "operations from happening.")
 
 let confirmBigDeletes =
   Prefs.createBool "confirmbigdel" true


### PR DESCRIPTION
The preference `-batch` does not prevent `-merge` programs from running (because those could be interactive or not).  There used to be a preference `-mergebatch` that could be set (on the command line as well as in a profile) to disable unwanted merge programs (or to override them) in batch mode.   At present the merge programs have to be disabled on the command line by something like `-merge Name * -> true`:
```
$ unison -root root1 -root root2 -merge 'Name * -> mymergecmd' -batch -merge 'Name * -> echo SKIP'
Unison 2.51.2 (ocaml 4.02.3): Contacting server...
Looking for changes
Reconciling changes
new file <-M-> new file   file2  
root1        : new file           modified on 2018-02-02 at  8:43:17  size 2         rw-r-----
root2        : new file           modified on 2018-02-02 at  8:43:17  size 2         rw-r-----
Propagating updates
UNISON 2.51.2 (OCAML 4.02.3) started propagating changes at 08:45:56.02 on 02 Feb 2018
Merge command: echo SKIP
Merge result (exited (0)):
SKIP
100%  00:00 ETASKIP
No outputs detected 
No output from merge cmd and both original files are still present
100%  00:00 ETAFailed [file2]: Merge program didn't change either temp file
UNISON 2.51.2 (OCAML 4.02.3) finished propagating changes at 08:45:56.02 on 02 Feb 2018
Saving synchronizer state
Synchronization incomplete at 08:45:56  (0 items transferred, 0 skipped, 1 failed)
  failed: file2
```
Setting the preference `-mergenot` is shorter, clearer and produces a better log:
```
$ unison -root root1 -root root2 -merge 'Name * -> mymergecmd' -batch -mergenot 'Name *'
Unison 2.51.2 (ocaml 4.02.3): Contacting server...
Looking for changes
Reconciling changes
new file <-?-> new file   file2  
root1        : new file           modified on 2018-02-02 at  8:43:17  size 2         rw-r-----
root2        : new file           modified on 2018-02-02 at  8:43:17  size 2         rw-r-----
No updates to propagate
Synchronization complete at 08:46:02  (0 item transferred, 1 skipped, 0 failed)
  skipped: file2 (contents changed on both sides)
```