### PR TITLE
Improve server failure message

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -131,7 +131,7 @@ let catch_all f =
     f ();
     (* Util.msg "Done catch_all...\n"; *)
   with e ->
-    Util.msg "Unison failed: %s\n" (Uicommon.exn2string e); exit 1;;
+    Util.msg "Unison server failed: %s\n" (Uicommon.exn2string e); exit 1;;
 
 let init () = begin
   ignore (Gc.set {(Gc.get ()) with Gc.max_overhead = 150});

--- a/src/main.ml
+++ b/src/main.ml
@@ -127,9 +127,11 @@ let interface =
 
 let catch_all f =
   try
-    (* Util.msg "Starting catch_all...\n"; *)
-    f ();
-    (* Util.msg "Done catch_all...\n"; *)
+    try
+      (* Util.msg "Starting catch_all...\n"; *)
+      f ();
+      (* Util.msg "Done catch_all...\n"; *)
+    with Prefs.IllegalValue str -> raise (Util.Fatal str)
   with e ->
     Util.msg "Unison server failed: %s\n" (Uicommon.exn2string e); exit 1;;
 


### PR DESCRIPTION
This makes unison print "Unison server failed" when it is the server that failed.

It also makes the client catch an exception Prefs.IllegalValue from the server (even if the exception is normally avoided by incompatible version numbers).