### PR TITLE
Clarify how the UNISON environment variable works

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1211,8 +1211,16 @@ for synchronization (or create a new one, if necessary).
 
 Unison stores a variety of information in a private directory on each
 host.  If the environment variable {\tt UNISON} is defined, then its
-value will be used as the name of this directory.  If {\tt UNISON} is
-not defined, then the name of the directory depends on which
+value will be used as the path/folder name for this directory.
+This can be just a name, or a path. 
+
+A name on it's own, for example {\tt UNISON=mytestname} will
+place a folder in the same directory that the Unison binary was run
+in, with that name. Using a path like {\tt UNISON=../mytestname2}
+will place that folder in the folder above where the Unison binary was
+run from.
+
+If {\tt UNISON} is not defined, then the directory depends on which
 operating system you are using.  In Unix, the default is to use
 {\tt \$HOME/.unison}.
 In Windows, if the environment variable

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -457,9 +457,10 @@ let homeDirStr =
 *)
        try System.getenv "USERPROFILE" (* Windows NT/2K standard *)
        with Not_found ->
-       try System.getenv "UNISON" (* Use custom UNISON dir if it is set. 
-       This can be a path or just the name of the folder you want to use in
-       the current directory *)
+       try System.getenv "UNISON" 
+          (* Use custom UNISON dir if it is set.  This can be a path 
+             or just the name of the folder you want to use in the 
+             current directory *)
        with Not_found ->
        "c:/" (* Default *)
      else

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -457,7 +457,9 @@ let homeDirStr =
 *)
        try System.getenv "USERPROFILE" (* Windows NT/2K standard *)
        with Not_found ->
-       try System.getenv "UNISON" (* Use UNISON dir if it is set *)
+       try System.getenv "UNISON" (* Use custom UNISON dir if it is set. 
+       This can be a path or just the name of the folder you want to use in
+       the current directory *)
        with Not_found ->
        "c:/" (* Default *)
      else


### PR DESCRIPTION
Added documentation that shows how the `UNISON` environment variable can be used to just customize the name of the Unison directory, as well as change the location with a path.

Resolves https://github.com/bcpierce00/unison/issues/160