### PR TITLE
Ui fix: refuse to choose merge when preference not set

### DIFF
--- a/src/files.ml
+++ b/src/files.ml
@@ -757,8 +757,7 @@ let ls dir pattern =
 ************************************************************************)
 
 let formatMergeCmd p f1 f2 backup out1 out2 outarch =
-  if not (Globals.shouldMerge p) then
-    raise (Util.Transient ("'merge' preference not set for "^(Path.toString p)));
+  assert (Globals.shouldMerge p); (* the UI should guarantee that *)
   let raw =
     try Globals.mergeCmdForPath p
     with Not_found ->

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -352,6 +352,10 @@ let dangerousPathMsg dangerousPaths =
          (Safelist.map (fun p -> "'" ^ (Path.toString p) ^ "'")
             dangerousPaths))
 
+let cannotMergeMsg ~path = match path with
+      None -> "'merge' preference not set for this path"
+    | Some p -> "'merge' preference not set for "^(Path.toString p)
+
 (**********************************************************************
                   Useful patterns for ignoring paths
  **********************************************************************)

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -74,6 +74,7 @@ val showDiffs :
   -> unit
 
 val dangerousPathMsg : Path.t list -> string
+val cannotMergeMsg : path:(Path.t option) -> string
 
 (* Utilities for adding ignore patterns *)
 val ignorePath : Path.t -> string

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -320,7 +320,9 @@ Callback.register "unisonRiSetConflict" unisonRiSetConflict;;
 let unisonRiSetMerge ri =
   match ri.ri.replicas with
     Problem _ -> ()
-  | Different diff -> diff.direction <- Merge;;
+  | Different diff -> if Globals.shouldMerge ri.path1
+      then diff.direction <- Merge
+      else Util.warn (Uicommon.cannotMergeMsg ~path:(Some ri.path1));;
 Callback.register "unisonRiSetMerge" unisonRiSetMerge;;
 let unisonRiForceOlder ri =
   Recon.setDirection ri.ri `Older `Force;;

--- a/src/uimacbridgenew.ml
+++ b/src/uimacbridgenew.ml
@@ -471,7 +471,9 @@ Callback.register "unisonRiSetConflict" unisonRiSetConflict;;
 let unisonRiSetMerge ri =
   match ri.ri.replicas with
     Problem _ -> ()
-  | Different diff -> diff.direction <- Merge;;
+  | Different diff -> if Globals.shouldMerge ri.path1
+      then diff.direction <- Merge
+      else Util.warn (Uicommon.cannotMergeMsg ~path:(Some ri.path1));;
 Callback.register "unisonRiSetMerge" unisonRiSetMerge;;
 let unisonRiForceOlder ri =
   Recon.setDirection ri.ri `Older `Force;;

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -544,7 +544,11 @@ let interact prilist rilist =
                  (["m"],
                   ("merge the versions (curr or match)"),
                   (fun () ->
-                     actOnMatching (setdir Merge)));
+                     actOnMatching
+                       ~fail:(Some (fun() ->
+                           display ((Uicommon.cannotMergeMsg ~path:None)^"\n")))
+                       (fun ri -> if Globals.shouldMerge ri.path1
+                                  then setdir Merge ri else false)));
                  ([">";"."],
                   ("propagate from " ^ descr ^ " (curr or match)"),
                   (fun () ->


### PR DESCRIPTION
This is to avoid a sure failure during the propagation as mentioned in #183.

The Mac UI has not been tested so please test if it compiles and works as expected by trying to choose merge in the UI.

I may add commits later to warn that the merge command is not provided (but still select merging because it is what happens by default).