### PR TITLE
UI: merge selection requires merge command instead of preference

### DIFF
--- a/src/files.ml
+++ b/src/files.ml
@@ -757,12 +757,10 @@ let ls dir pattern =
 ************************************************************************)
 
 let formatMergeCmd p f1 f2 backup out1 out2 outarch =
-  assert (Globals.shouldMerge p); (* the UI should guarantee that *)
+  assert (Globals.mayMerge p); (* the UI should guarantee that *)
   let raw =
     try Globals.mergeCmdForPath p
-    with Not_found ->
-      raise (Util.Transient ("'merge' preference does not provide a command "
-                             ^ "template for " ^ (Path.toString p)))
+    with Not_found -> assert false (* mayMerge guarantees that *)
   in
   let cooked = raw in
   let cooked = Util.replacesubstring cooked "CURRENT1" f1 in

--- a/src/files.ml
+++ b/src/files.ml
@@ -757,8 +757,7 @@ let ls dir pattern =
 ************************************************************************)
 
 let formatMergeCmd p f1 f2 backup out1 out2 outarch =
-  if not (Globals.shouldMerge p) then
-    raise (Util.Transient ("'merge' preference not set for "^(Path.toString p)));
+  assert (Globals.shouldMerge p); (* the UI should guarantee that *)
   let raw =
     try Globals.mergeCmdForPath p
     with Not_found ->

--- a/src/globals.ml
+++ b/src/globals.ml
@@ -285,11 +285,11 @@ let merge =
      ^ "details on Merging functions are present in "
      ^ "\\sectionref{merge}{Merging Conflicting Versions}.")
 
-let shouldMerge p =
-  Pred.test merge (Path.toString p) &&
-  try let _ = mergeCmdForPath p in true with Not_found -> false
-
 let mergeCmdForPath p = Pred.assoc merge (Path.toString p)
+
+let mayMerge p = try let _ = mergeCmdForPath p in true with Not_found -> false
+
+let shouldMerge p = Pred.test merge (Path.toString p) && mayMerge p
 
 let someHostIsRunningWindows =
   Prefs.createBool "someHostIsRunningWindows" false "*" ""

--- a/src/globals.ml
+++ b/src/globals.ml
@@ -285,7 +285,9 @@ let merge =
      ^ "details on Merging functions are present in "
      ^ "\\sectionref{merge}{Merging Conflicting Versions}.")
 
-let shouldMerge p = Pred.test merge (Path.toString p)
+let shouldMerge p =
+  Pred.test merge (Path.toString p) &&
+  try let _ = mergeCmdForPath p in true with Not_found -> false
 
 let mergeCmdForPath p = Pred.assoc merge (Path.toString p)
 

--- a/src/globals.mli
+++ b/src/globals.mli
@@ -78,6 +78,7 @@ val confirmBigDeletes : bool Prefs.t
 (* Predicates on paths *)
 val shouldIgnore : 'a Path.path -> bool
 val shouldMerge : 'a Path.path -> bool
+val mayMerge : 'a Path.path -> bool
 val ignorePred : Pred.t
 val ignorenotPred : Pred.t
 val atomic : Pred.t

--- a/src/globals.mli
+++ b/src/globals.mli
@@ -77,8 +77,8 @@ val confirmBigDeletes : bool Prefs.t
 
 (* Predicates on paths *)
 val shouldIgnore : 'a Path.path -> bool
-val shouldMerge : 'a Path.path -> bool
-val mayMerge : 'a Path.path -> bool
+val shouldMerge : 'a Path.path -> bool (* merge conflicts by default *)
+val mayMerge : 'a Path.path -> bool (* can UI choose to merge *)
 val ignorePred : Pred.t
 val ignorenotPred : Pred.t
 val atomic : Pred.t

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -353,8 +353,8 @@ let dangerousPathMsg dangerousPaths =
             dangerousPaths))
 
 let cannotMergeMsg ~path = match path with
-      None -> "'merge' preference not set for this path"
-    | Some p -> "'merge' preference not set for "^(Path.toString p)
+      None -> "'merge' command not provided for this path"
+    | Some p -> "'merge' command not provided for "^(Path.toString p)
 
 (**********************************************************************
                   Useful patterns for ignoring paths

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -352,6 +352,10 @@ let dangerousPathMsg dangerousPaths =
          (Safelist.map (fun p -> "'" ^ (Path.toString p) ^ "'")
             dangerousPaths))
 
+let cannotMergeMsg ~path = match path with
+      None -> "'merge' preference not set for this path"
+    | Some p -> "'merge' preference not set for "^(Path.toString p)
+
 (**********************************************************************
                   Useful patterns for ignoring paths
  **********************************************************************)

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -74,6 +74,7 @@ val showDiffs :
   -> unit
 
 val dangerousPathMsg : Path.t list -> string
+val cannotMergeMsg : path:(Path.t option) -> string
 
 (* Utilities for adding ignore patterns *)
 val ignorePath : Path.t -> string

--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -3780,7 +3780,7 @@ lst_store#set ~row ~column:c_path path;
     doAction (fun _ diff -> diff.direction <- Replica1ToReplica2) in
   let questionAction _ = doAction (fun _ diff -> diff.direction <- Conflict "") in
   let mergeAction    _ =
-    let checkAndMerge ri diff = if Globals.shouldMerge ri.path1
+    let checkAndMerge ri diff = if Globals.mayMerge ri.path1
       then diff.direction <- Merge
       else okBox ~parent:toplevelWindow ~title:"Cannot merge" ~typ:`ERROR
           ~message:(Uicommon.cannotMergeMsg ~path:(Some ri.path1)) in

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -320,7 +320,7 @@ Callback.register "unisonRiSetConflict" unisonRiSetConflict;;
 let unisonRiSetMerge ri =
   match ri.ri.replicas with
     Problem _ -> ()
-  | Different diff -> if Globals.shouldMerge ri.path1
+  | Different diff -> if Globals.mayMerge ri.path1
       then diff.direction <- Merge
       else Util.warn (Uicommon.cannotMergeMsg ~path:(Some ri.path1));;
 Callback.register "unisonRiSetMerge" unisonRiSetMerge;;

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -320,7 +320,9 @@ Callback.register "unisonRiSetConflict" unisonRiSetConflict;;
 let unisonRiSetMerge ri =
   match ri.ri.replicas with
     Problem _ -> ()
-  | Different diff -> diff.direction <- Merge;;
+  | Different diff -> if Globals.shouldMerge ri.path1
+      then diff.direction <- Merge
+      else Util.warn (Uicommon.cannotMergeMsg ~path:(Some ri.path1));;
 Callback.register "unisonRiSetMerge" unisonRiSetMerge;;
 let unisonRiForceOlder ri =
   Recon.setDirection ri.ri `Older `Force;;

--- a/src/uimacbridgenew.ml
+++ b/src/uimacbridgenew.ml
@@ -471,7 +471,9 @@ Callback.register "unisonRiSetConflict" unisonRiSetConflict;;
 let unisonRiSetMerge ri =
   match ri.ri.replicas with
     Problem _ -> ()
-  | Different diff -> diff.direction <- Merge;;
+  | Different diff -> if Globals.shouldMerge ri.path1
+      then diff.direction <- Merge
+      else Util.warn (Uicommon.cannotMergeMsg ~path:(Some ri.path1));;
 Callback.register "unisonRiSetMerge" unisonRiSetMerge;;
 let unisonRiForceOlder ri =
   Recon.setDirection ri.ri `Older `Force;;

--- a/src/uimacbridgenew.ml
+++ b/src/uimacbridgenew.ml
@@ -471,7 +471,7 @@ Callback.register "unisonRiSetConflict" unisonRiSetConflict;;
 let unisonRiSetMerge ri =
   match ri.ri.replicas with
     Problem _ -> ()
-  | Different diff -> if Globals.shouldMerge ri.path1
+  | Different diff -> if Globals.mayMerge ri.path1
       then diff.direction <- Merge
       else Util.warn (Uicommon.cannotMergeMsg ~path:(Some ri.path1));;
 Callback.register "unisonRiSetMerge" unisonRiSetMerge;;

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -544,7 +544,11 @@ let interact prilist rilist =
                  (["m"],
                   ("merge the versions (curr or match)"),
                   (fun () ->
-                     actOnMatching (setdir Merge)));
+                     actOnMatching
+                       ~fail:(Some (fun() ->
+                           display ((Uicommon.cannotMergeMsg ~path:None)^"\n")))
+                       (fun ri -> if Globals.shouldMerge ri.path1
+                                  then setdir Merge ri else false)));
                  ([">";"."],
                   ("propagate from " ^ descr ^ " (curr or match)"),
                   (fun () ->

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -547,7 +547,7 @@ let interact prilist rilist =
                      actOnMatching
                        ~fail:(Some (fun() ->
                            display ((Uicommon.cannotMergeMsg ~path:None)^"\n")))
-                       (fun ri -> if Globals.shouldMerge ri.path1
+                       (fun ri -> if Globals.mayMerge ri.path1
                                   then setdir Merge ri else false)));
                  ([">";"."],
                   ("propagate from " ^ descr ^ " (curr or match)"),


### PR DESCRIPTION
This change depends on PR #184 and is part of a solution to the issue #183 
("UI: cannot forcibly merge path from UI if merge option not already set").
Together with assoc patterns (PR #178) and with its dependency (PR #184) that 
makes the mergeability be verified by the UI it fixes the issue (implementing 
solution 2. to the sub-issue 1.).

It prevents paths not having merge commands from being selected for merging 
(either by default or in the UI) but do not require the merge preference to be 
set anymore.

It can be merged wihtout/before PR #178 and its dependencies to simply make 
the verification of mergeability stricter (as without del/assoc patterns when 
a command is provided, the merge preference is also set).