### PR TITLE
[build] Preliminary support for building with Dune.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ TAGS
 build
 logmsg
 xcuserdata
+
+_build
+.merlin
+*.install

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.3)
+(name unison)

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,27 @@
+(library
+ (name unison_lib)
+ (wrapped false)
+ (modules :standard \ linktext linkgtk linkgtk2 uigtk2 uimacbridge uimacbridgenew test)
+ (modules_without_implementation ui)
+ (flags :standard
+        -w -3-6-9-10-26-27-32-34-35-38-39-50-52
+        -warn-error -3-6-9-10-26-27-32-34-35-39-50-52
+        -unsafe-string -no-strict-sequence)
+ (c_names bytearray_stubs osxsupport pty)
+ (c_library_flags -lutil)
+ (libraries str unix lwt_lib bigarray))
+
+(include_subdirs unqualified)
+
+(executable
+ (name linktext)
+ (public_name unison)
+ (modules linktext)
+ (libraries unison_lib))
+
+(executable
+ (name linkgtk2)
+ (public_name unison-gtk2)
+ (flags :standard -w -3-6-9-27-32-52 -unsafe-string)
+ (modules linkgtk2 uigtk2)
+ (libraries threads unison_lib lablgtk2))

--- a/src/fsmonitor/dune
+++ b/src/fsmonitor/dune
@@ -1,0 +1,1 @@
+(include_subdirs no)

--- a/src/fsmonitor/linux/dune
+++ b/src/fsmonitor/linux/dune
@@ -1,0 +1,16 @@
+(copy_files# ../watchercommon.ml{,i})
+
+(library
+ (name fswatcher)
+ (wrapped false)
+ (modules :standard \ watcher)
+ (flags :standard -w -3-27-39 -unsafe-string)
+ (c_names inotify_stubs)
+ (libraries unix lwt_lib))
+
+(executable
+ (name watcher)
+ (public_name unison-fsmonitor)
+ (modules watcher)
+ (flags :standard -w -27)
+ (libraries fswatcher))

--- a/src/lwt/dune
+++ b/src/lwt/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+(copy_files# generic/lwt_unix_impl.ml)
+
+(library
+ (name lwt_lib)
+ (wrapped false)
+ (flags :standard -warn-error -3-27-39 -no-strict-sequence -unsafe-string)
+ ; (modules :standard \ editor relay)
+ (libraries))
+

--- a/src/lwt/win/dune
+++ b/src/lwt/win/dune
@@ -1,0 +1,1 @@
+(include_subdirs no)

--- a/src/props.ml
+++ b/src/props.ml
@@ -708,7 +708,7 @@ let strip p =
 
 let toString p =
   Printf.sprintf
-    "modified on %s  size %-9.f %s%s%s%s"
+    "modified on %s  size %-9.0f %s%s%s%s"
     (Time.toString p.time)
     (Uutil.Filesize.toFloat p.length)
     (Perm.toString p.perm)
@@ -719,7 +719,7 @@ let toString p =
 let syncedPartsToString p =
   let tm = Time.syncedPartsToString p.time in
   Printf.sprintf
-    "%s%s  size %-9.f %s%s%s%s"
+    "%s%s  size %-9.0f %s%s%s%s"
     (if tm = "" then "" else "modified at ")
     tm
     (Uutil.Filesize.toFloat p.length)

--- a/src/system/win/dune
+++ b/src/system/win/dune
@@ -1,0 +1,1 @@
+(include_subdirs no)

--- a/src/ubase/dune
+++ b/src/ubase/dune
@@ -1,0 +1,19 @@
+; Not possible to refine more
+(rule
+ (targets projectInfo.ml)
+ (deps ../Makefile.ProjectInfo)
+ (action
+   (with-outputs-to projectInfo.ml
+    (bash
+      ". ../Makefile.ProjectInfo && \
+       echo \"let myName = \\\"$NAME\\\";;\" && \
+       echo \"let myVersion = \\\"$VERSION\\\";;\" && \
+       echo \"let myMajorVersion = \\\"00\\\";;\""))))
+
+; echo 'let myName = "'$(NAME)'";;' > $@
+; echo 'let myVersion = "'$(VERSION)'";;' >> $@
+; echo 'let myMajorVersion = "'$(MAJORVERSION)'";;' >> $@
+
+; (library
+;  (name ubase)
+;  (flags :standard -warn-error -9-27-32-39-50))

--- a/src/update.ml
+++ b/src/update.ml
@@ -2139,7 +2139,7 @@ let commitUpdates () =
      Remote.Thread.unwindProtect
        (fun () ->
           let magic =
-            Format.sprintf "%s\000%.f.%d"
+            Format.sprintf "%s\000%.0f.%d"
               ((Case.ops ())#modeDesc) (Unix.gettimeofday ()) (Unix.getpid ())
           in
           Globals.allRootsMap (fun r -> prepareCommitOnRoot r magic)


### PR DESCRIPTION
Dune is a domain-specific build system that has become the standard
in the OCaml ecosystem.

This PR adds preliminary support for building Unison with Dune; the PR
itself is quite simple and doesn't modify the make-based system.

It has been tested in Linux and does work correctly. Among the new
features this PR provides are:

- automatic developer tools setup [merlin, etc...]
- Unison can now become supported in the OCaml platform,
- builds tested from 4.02.3 to 4.07.1,
- automatic generation of OPAM package / install files,
- automatic generation of API documentation [if so wished],
- massive linting of the codebase suggested [see warnings],
- compositional builds, easy library vendoring,
- hygienic builds.

I do believe this PR is important to bring Unison closer to the modern
OCaml toolchain. Additionally, some important platform changes are
upcoming, for example lablgtk2 is deprecated, and this PR will allow
to compose the Dune build with lablgtk3, greatly facilitating the
porting.

This PR opens up the question of what the supported OCaml version
are. 4.02.3 -- 4.07.1 seems like a sensible choice as of today.
Depending on the answer, we could then address:

- `-safe-string`: unison should be ported to -safe-string, however
  this usually places a lower-bound on OCaml 4.02.3.

- warnings: the codebase could benefit from the massive linting
  suggested by the compiler, however to make the warning system happy
  precise compiler version bounds have to be established.

TODO:

- Update CI
- Documentation ?
- OSX support:
  it shouldn't be too hard using the foreign sandboxing described at
  https://dune.readthedocs.io/en/latest/foreign-code.html#foreign-build-sandboxing
  unfortunately, I am not a Mac user.