### PR TITLE
Update clroot.ml

### DIFF
--- a/src/clroot.ml
+++ b/src/clroot.ml
@@ -112,14 +112,23 @@ let getUser s =
     (Some beforeAt,afterAt)
   else (None,s)
 
+(*ipv6 support*)
+let hostWithBracketsRegexp = Str.regexp "\[.*\]"
 let hostRegexp = Str.regexp "[-_a-zA-Z0-9.]+"
 let getHost s =
-  if Str.string_match hostRegexp s 0
+  if Str.string_match hostWithBracketsRegexp s 0
+  then
+    let host' = Str.matched_string s in
+    let s' = Str.string_after s (String.length host') in
+    let host = String.sub host' 1 ((String.length host')-2) in
+    (Some host,s')
+  else if Str.string_match hostRegexp s 0
   then
     let host = Str.matched_string s in
     let s' = Str.string_after s (String.length host) in
     (Some host,s')
-  else (None,s)
+  else
+     (None,s)
 
 let colonPortRegexp = Str.regexp ":[^/]+"
 let getPort s =


### PR DESCRIPTION
Currently unison not supporting ipv6 in url "ssh://tjim@[fd00:4888:1::10]/hello/world".

Added regex to extract ip which is passed in "[]".

with this change users can use urls with ipv6 address as follows.
"ssh://tjim@[fd00:4888:1::10]:22/hello/world".
"ssh://tjim@[ipv6]:port/hello/world".
