### PR TITLE
Ignore unison.log file by default?

### DIFF
--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -137,6 +137,7 @@ let unisonInit1 profileName =
      have checked that the named one exists). *)
    if not(System.file_exists (Prefs.profilePathname profileName)) then
      Prefs.addComment "Unison preferences file";
+     Prefs.addComment "ignore = Name unison.log";
 
   (* Load the profile *)
   (Trace.debug "" (fun() -> Util.msg "about to load prefs");


### PR DESCRIPTION
Sorry for incomplete PR, this is more of an idea.

My friend created an infinite loop by accidentally backing up `unison.log`, would it be worth ignoring files named `unison.log` by default or do you think that's too much of an edge case?