### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,3 +46,8 @@ jobs:
       - run: opam exec -- make
 
       - run: make test
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: binary for ${{ matrix.os }} OCaml ${{ matrix.ocaml-version }}
+          path: src/unison

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,35 @@
+name: Main workflow
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        ocaml-version:
+          - 4.10.0
+          - 4.09.1
+          - 4.08.1
+          - 4.08.0
+          - 4.07.0
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+
+      - run: opam exec -- make
+
+      - run: make test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Cache opam files
+        id: cache-opam
+        uses: actions/cache@v2
+        if: runner.os != 'Windows'
+        with:
+          path: ~/.opam
+          key: ${{ matrix.os }}-ocaml_${{ matrix.ocaml-version }}-opam
+
+      - name: Set up opam on macOS
+        if: steps.cache-opam.outputs.cache-hit == 'true' && runner.os == 'macOS'
+        run: /usr/local/bin/brew install opam
+
       - name: Use OCaml ${{ matrix.ocaml-version }}
+        if: steps.cache-opam.outputs.cache-hit != 'true' || runner.os == 'Linux'
         uses: avsm/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Unison File Synchronizer
 ========================
 
 [![Build Status](https://travis-ci.org/bcpierce00/unison.svg?branch=master)](https://travis-ci.org/bcpierce00/unison)
+![Main workflow](https://github.com/bcpierce00/unison/workflows/Main%20workflow/badge.svg)
 
 Unison is a file-synchronization tool for OSX, Unix, and Windows. It allows two
 replicas of a collection of files and directories to be stored on different


### PR DESCRIPTION
Enables multi-OS, multi-OCaml-version build.

Windows build is [failing](https://github.com/liyishuai/unison/runs/774389737), not sure why:
> ocamlopt: ubase/rx.mli ---> ubase/rx.cmi
ocamlopt -g -unsafe-string -I lwt -I ubase -I system -I fsmonitor -I fsmonitor/linux -I fsmonitor/windows -I system/generic -I lwt/generic -c /cygdrive/d/a/unison/unison/src/ubase/rx.mli
File "/cygdrive/d/a/unison/unison/src/ubase/rx.mli", line 1:
Error: I/O error: /cygdrive/d/a/unison/unison/src/ubase/rx.mli: No such file or directory

The build also fails with default installation of OCaml 4.10:
> ocamlopt: OCaml has been configured with -force-safe-string: -unsafe-string is not available.