### PR TITLE
Add ANSI color to text UI

### DIFF
--- a/src/ubase/trace.mli
+++ b/src/ubase/trace.mli
@@ -88,6 +88,11 @@ val statusDetail : string -> unit
    one explicitly if you want one) *)
 val log : string -> unit
 
+(* Like 'log', but strips all ANSI color escapes in the input before
+   writing to log file. Log output to stdout and stderr will keep
+   ANSI color escapes intact *)
+val log_color : string -> unit
+
 (* Like 'log', but only send message to log file if -terse preference is set *)
 val logverbose : string -> unit
 


### PR DESCRIPTION
Closes #345 
Respects `NO_COLOR` environment variable.
In addition to the synchronization status, also syncrhonization actions and output of unified diff are colored. If using a PAGER then users may have to change pager options, e.g. `less -R`.