### PR TITLE
Add profile selection to text UI

### DIFF
--- a/src/TODO.txt
+++ b/src/TODO.txt
@@ -867,7 +867,7 @@ The scroll bar is not usable during transport: every time a line changes
   user to control the colors of all the arrows individually.
 
 Text mode user interface should be brought up to date with graphical
-  interface (it should prompt for profile selection, creation, root
+  interface (it should prompt for profile creation, root
   entry, etc.; command characters should be the same; ...)
 
 Since the manual is pretty big, it would be nice if the on-line version

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -40,6 +40,8 @@ val retry : int Prefs.t
 (* User preference: confirmation before committing merge results *)
 val confirmmerge : bool Prefs.t
 
+val runTestsPrefName : string
+
 (* Format the information about current contents of a path in one replica (the second argument
    is used as a separator) *)
 val details2string : Common.reconItem -> string -> string
@@ -115,3 +117,12 @@ val exitCode: bool * bool -> int
 
 (* Initialization *)
 val testFunction : (unit->unit) ref
+
+(* Profile scanning and selection *)
+type profileInfo = {roots:string list; label:string option; key:string option}
+
+val profileKeymap : (string * profileInfo) option array
+
+val profilesAndRoots : (string * profileInfo) list ref
+
+val scanProfiles : unit -> unit


### PR DESCRIPTION
### Description

If profile or roots are not specified on the command line, provide interactive profile selection to user. Also respects the `key` preference used in GUI, but only for initial profile selection.
Moved `scanProfiles` and `provideProfileKey` from `uigtk2.ml` to `uicommon.ml`

Based on the ANSI color pull request #360. This PR can be rebased once that one is merged.