### PR TITLE
Add signal handler for SIGUSR1 to close logfile

### DIFF
--- a/src/strings.ml
+++ b/src/strings.ml
@@ -1738,7 +1738,9 @@ let docs =
       \032         By default, logging messages will be appended to the file\n\
       \032         unison.log in your HOME directory. Set this preference if you\n\
       \032         prefer another file. It can be a path relative to your HOME\n\
-      \032         directory.\n\
+      \032         directory. Sending SIGUSR1 to the unison process will close the\n\
+      \032         logfile; the logfile will be re-opened (and created, if needed)\n\
+      \032         automatically, to allow for log rotation.\n\
       \n\
       \032  maxbackups n\n\
       \032         This preference specifies the number of backup versions that\n\

--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -121,6 +121,16 @@ let logfile =
 
 let logch = ref None
 
+let closelog _ =
+  match !logch with
+    None -> ()
+  | Some(ch,file) ->
+      close_out ch;
+      logch := None;
+  ;;
+
+Sys.signal Sys.sigusr1 (Signal_handle closelog);;
+
 let rec getLogch() =
   Util.convertUnixErrorsToFatal "getLogch" (fun() ->
   match !logch with

--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -117,7 +117,9 @@ let logfile =
     "!logfile name"
     "By default, logging messages will be appended to the file
      \\verb|unison.log| in your HOME directory.  Set this preference if
-     you prefer another file.  It can be a path relative to your HOME directory."
+     you prefer another file.  It can be a path relative to your HOME directory.
+     Sending SIGUSR1 will close the logfile; the logfile will be re-opened (and
+     created, if needed) automatically, to allow for log rotation."
 
 let logch = ref None
 


### PR DESCRIPTION
The logfile will be re-opened automatically as soon as something is
logged. This allows for log rotation, by first renaming existing log
file(s) and then performing:

    killall -USR1 unison

In case no log file has been opened (yet), the signal is ignored.

This feature is intended for cases where unison is running continuously
as a background (daemon) process, e.g.

    unison -repeat watch