### PR TITLE
Add extended attributes (xattr) synchronization support

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -2180,6 +2180,70 @@ group of the server process.
 \end{itemize}
 
 
+\SUBSECTION{Extended Attributes - xattrs}{xattrs}
+
+Unison allows synchronizing extended attributes on platforms and
+filesystems that support them. System attributes are not synchronized.
+What exactly is considered a system attribute is platform-dependent.
+Synchronization is possible cross-platform, but see caveats below.
+
+If one of the replicas does not support extended attributes then
+Unison will not attempt attribute synchronization. If the other
+replica does support extended attributes then those will remain intact.
+
+If both replicas support extended attributes then you can request
+Unison to try attribute synchronization (\verb|xattrs| preference).
+Extended attributes from both replicas will not be merged, all extended
+attributes are propagated as a set from one replica to another.
+
+Unison currently supports extended attributes on the following platforms:
+\begin{itemize}
+\item {\em Linux}
+Attributes in user, trusted and security namespaces. Synchronization of
+the latter two namespaces depends on \verb|unison| process privileges
+and is disabled by default. To sync one or more attributes in the security
+namespace, for example, you can set the preference
+\verb|xattrignorenot| to \verb|Path !security.*| (for all) or to
+\verb|Path !security.selinux| (for one specific attribute).
+\item {\em Solaris, OpenSolaris and illumos-based OS (OpenIndiana, SmartOS,
+  OmniOS, etc.)}
+\item {\em FreeBSD, NetBSD}
+Attributes in user namespace.
+\item {\em Darwin (macOS)}
+\end{itemize}
+Not all filesystems on the listed platforms may support extended attributes.
+
+\noindent {\it Caveats:}
+\begin{itemize}
+\item Some platforms and file systems support very large extended attribute
+values. Unison synchronizes only up to 16 MB of each attribute value.
+\item Attributes are synchronized as simple name-value pairs. More complex
+extended attribute concepts supported by some platforms are not synchronized.
+\item On Linux, attribute names always have a fully qualified form
+(\texttt{namespace.attribute}). Other platforms do not have the same constraint.
+The consequence of this is that Unison will sync the attribute names on Linux
+as follows: an \verb|!| is prepended to the namespace name, except for the
+\verb|user| namespace; the \verb|user.| prefix is stripped from attribute names
+instead. This allows syncing extended attributes from Linux to other platforms.
+These transformations are reversed when syncing {\em to} Linux, resulting in
+correct fully qualified attribute names.
+The \verb|xattrignore| and \verb|xattrignorenot| preferences work on the
+transformed attribute names. This means that any patterns for the user
+namespace must be specified without the \verb|user.| prefix and any patterns
+intended for other namespaces must begin with an \verb|!|.
+\end{itemize}
+
+The \verb|xattrignore| preference can be used to filter the names of extended
+attributes that will be synchronized. The most useful ignore patterns can
+be constructed with the \verb|Path| form (where shell wildcards \verb|*| and
+\verb|?| are supported) and with the \verb|Regex| form. The
+\verb|xattrignorenot| preference can be used to override \verb|xattrignore|.
+
+Disabling the security and trusted namespaces on Linux is achieved by setting
+a default \verb|xattrignore| pattern of
+\texttt{Regex !(security|trusted)[.].*}.
+
+
 \SUBSECTION{Cross-Platform Synchronization}{crossplatform}
 
 If you use Unison to synchronize files between Windows and Unix

--- a/src/.depend
+++ b/src/.depend
@@ -817,6 +817,7 @@ props.cmi : \
     uutil.cmi \
     ubase/umarshal.cmi \
     ubase/prefs.cmi \
+    pred.cmi \
     path.cmi \
     osx.cmi \
     fspath.cmi

--- a/src/.depend
+++ b/src/.depend
@@ -787,6 +787,7 @@ props.cmo : \
     ubase/umarshal.cmi \
     system.cmi \
     ubase/safelist.cmi \
+    propsdata.cmi \
     ubase/prefs.cmi \
     pred.cmi \
     path.cmi \
@@ -803,6 +804,7 @@ props.cmx : \
     ubase/umarshal.cmx \
     system.cmx \
     ubase/safelist.cmx \
+    propsdata.cmx \
     ubase/prefs.cmx \
     pred.cmx \
     path.cmx \
@@ -821,6 +823,15 @@ props.cmi : \
     path.cmi \
     osx.cmi \
     fspath.cmi
+propsdata.cmo : \
+    ubase/util.cmi \
+    ubase/safelist.cmi \
+    propsdata.cmi
+propsdata.cmx : \
+    ubase/util.cmx \
+    ubase/safelist.cmx \
+    propsdata.cmi
+propsdata.cmi :
 recon.cmo : \
     uutil.cmi \
     ubase/util.cmi \

--- a/src/.depend
+++ b/src/.depend
@@ -785,24 +785,32 @@ props.cmo : \
     uutil.cmi \
     ubase/util.cmi \
     ubase/umarshal.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
     ubase/prefs.cmi \
+    pred.cmi \
     path.cmi \
     osx.cmi \
     lwt/lwt_unix.cmi \
     fspath.cmi \
     fs.cmi \
+    features.cmi \
     external.cmi \
     props.cmi
 props.cmx : \
     uutil.cmx \
     ubase/util.cmx \
     ubase/umarshal.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
     ubase/prefs.cmx \
+    pred.cmx \
     path.cmx \
     osx.cmx \
     lwt/lwt_unix.cmx \
     fspath.cmx \
     fs.cmx \
+    features.cmx \
     external.cmx \
     props.cmi
 props.cmi : \

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -232,7 +232,7 @@ OCAMLOBJS += \
           \
           features.cmo uutil.cmo case.cmo pred.cmo \
           fileutil.cmo name.cmo path.cmo fspath.cmo fs.cmo fingerprint.cmo \
-          abort.cmo osx.cmo external.cmo fswatch.cmo \
+          abort.cmo osx.cmo external.cmo fswatch.cmo propsdata.cmo \
           props.cmo fileinfo.cmo os.cmo lock.cmo clroot.cmo common.cmo \
           tree.cmo checksum.cmo terminal.cmo transfer.cmo xferhint.cmo \
           remote.cmo negotiate.cmo globals.cmo fswatchold.cmo \

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -247,7 +247,7 @@ OCAMLOBJS+=main.cmo
 OCAMLLIBS+=unix.cma str.cma
 INCLFLAGS+=-I +unix -I +str
 
-COBJS+=osxsupport$(OBJ_EXT) pty$(OBJ_EXT) bytearray_stubs$(OBJ_EXT) hash_compat$(OBJ_EXT)
+COBJS+=osxsupport$(OBJ_EXT) pty$(OBJ_EXT) bytearray_stubs$(OBJ_EXT) hash_compat$(OBJ_EXT) props_xattr$(OBJ_EXT)
 
 ########################################################################
 ### User Interface setup

--- a/src/copy.ml
+++ b/src/copy.ml
@@ -345,6 +345,51 @@ let setFileinfo fspathTo pathTo realPathTo update desc =
 
 (****)
 
+(* This unfortunate complexity is here to reduce network round-trips
+   and calls to [Update.translatePath], primarily in [Files.setProp]. *)
+let mxpath = Umarshal.(sum2 Path.mlocal Path.m)
+               (function `Local p -> I21 p | `Global p -> I22 p)
+               (function I21 p -> `Local p | I22 p -> `Global p)
+
+let loadPropsExtDataLocal (fspath, path, desc) =
+  let localPath = match path with
+    | `Local p -> p
+    | `Global p -> Update.translatePathLocal fspath p in
+  (Some localPath, Props.loadExtData fspath localPath desc)
+
+let loadPropsExtDataOnServer = Remote.registerServerCmd "propsExtData"
+  Umarshal.(prod3 Fspath.m mxpath Props.m id id)
+  Umarshal.(prod2 (option Path.mlocal) Props.mx id id)
+  (fun connFrom args -> Lwt.return (loadPropsExtDataLocal args))
+
+let propsWithExtDataLocal fspath path desc =
+  if not (Props.missingExtData desc) then (None, Props.withExtData desc)
+  else loadPropsExtDataLocal (fspath, path, desc)
+
+let propsWithExtDataConn connFrom fspath path desc =
+  if not (Props.missingExtData desc) then Lwt.return (None, Props.withExtData desc)
+  else loadPropsExtDataOnServer connFrom (fspath, path, desc)
+
+let propsExtDataOnRoot root path desc =
+  match root with
+  | (Common.Local, fspath) ->
+      Lwt.return (propsWithExtDataLocal fspath path desc)
+  | (Remote _, fspath) ->
+      propsWithExtDataConn (Remote.connectionToRoot root) fspath path desc
+
+let propsWithExtData connFrom fspath path desc =
+  propsWithExtDataConn connFrom fspath (`Local path) desc >>= fun x ->
+  Lwt.return (snd x)
+
+let readPropsExtData root path desc =
+  propsExtDataOnRoot root (`Local path) desc >>= fun x ->
+  Lwt.return (snd x)
+
+let readPropsExtDataG root path desc =
+  propsExtDataOnRoot root (`Global path) desc
+
+(****)
+
 let copyContents fspathFrom pathFrom fspathTo pathTo fileKind fileLength ido =
   let use_id f = match ido with Some id -> f id | None -> () in
   let inFd = openFileIn fspathFrom pathFrom fileKind in
@@ -365,8 +410,7 @@ let copyContents fspathFrom pathFrom fspathTo pathTo fileKind fileLength ido =
          (fun () -> close_out_noerr outFd))
     (fun () -> close_in_noerr inFd)
 
-let localFile
-     fspathFrom pathFrom fspathTo pathTo realPathTo update desc ressLength ido =
+let localFileContents fspathFrom pathFrom fspathTo pathTo desc ressLength ido =
   Util.convertUnixErrorsToTransient
     "copying locally"
     (fun () ->
@@ -379,19 +423,26 @@ let localFile
         fspathFrom pathFrom fspathTo pathTo `DATA (Props.length desc) ido;
       if ressLength > Uutil.Filesize.zero then
         copyContents
-          fspathFrom pathFrom fspathTo pathTo `RESS ressLength ido;
-      setFileinfo fspathTo pathTo realPathTo update desc)
+          fspathFrom pathFrom fspathTo pathTo `RESS ressLength ido)
+
+let localFile
+     fspathFrom pathFrom fspathTo pathTo realPathTo update desc ressLength ido =
+  Util.convertUnixErrorsToTransient "copying locally" (fun () ->
+    localFileContents fspathFrom pathFrom fspathTo pathTo desc ressLength ido;
+    let (_, desc) = propsWithExtDataLocal fspathFrom (`Local pathFrom) desc in
+    setFileinfo fspathTo pathTo realPathTo update desc)
 
 (****)
 
-let tryCopyMovedFile fspathTo pathTo realPathTo update desc fp ress id =
-  if not (Prefs.read Xferhint.xferbycopying) then None else
+let tryCopyMovedFile connFrom fspathFrom pathFrom fspathTo pathTo realPathTo
+      update desc fp ress id =
+  if not (Prefs.read Xferhint.xferbycopying) then Lwt.return None else
   Util.convertUnixErrorsToTransient "tryCopyMovedFile" (fun() ->
     debug (fun () -> Util.msg "tryCopyMovedFile: -> %s /%s/\n"
       (Path.toString pathTo) (Os.fullfingerprint_to_string fp));
     match Xferhint.lookup fp with
       None ->
-        None
+        Lwt.return None
     | Some (candidateFspath, candidatePath, hintHandle) ->
         debug (fun () ->
           Util.msg
@@ -408,9 +459,10 @@ let tryCopyMovedFile fspathTo pathTo realPathTo update desc fp ress id =
             info.Fileinfo.typ <> `ABSENT &&
             Props.length info.Fileinfo.desc = Props.length desc
           then begin
-            localFile
-              candidateFspath candidatePath fspathTo pathTo realPathTo
-              update desc (Osx.ressLength ress) (Some id);
+            localFileContents candidateFspath candidatePath fspathTo pathTo desc
+              (Osx.ressLength ress) (Some id);
+            propsWithExtData connFrom fspathFrom pathFrom desc >>= fun desc ->
+            setFileinfo fspathTo pathTo realPathTo update desc;
             let (info, isTransferred) =
               fileIsTransferred fspathTo pathTo desc fp ress in
             if isTransferred then begin
@@ -423,29 +475,29 @@ let tryCopyMovedFile fspathTo pathTo realPathTo update desc fp ress id =
                  (Fspath.toPrintString candidateFspath)
                  (Path.toString candidatePath)
               in
-              Some (info, msg)
+              Lwt.return (Some (info, msg))
             end else begin
               debug (fun () ->
                 Util.msg "tryCopyMoveFile: candidate file %s modified!\n"
                   (Path.toString candidatePath));
               Xferhint.deleteEntry hintHandle;
-              None
+              Lwt.return None
             end
           end else begin
             debug (fun () ->
               Util.msg "tryCopyMoveFile: candidate file %s disappeared!\n"
                 (Path.toString candidatePath));
             Xferhint.deleteEntry hintHandle;
-            None
+            Lwt.return None
           end
         with
           Util.Transient s ->
             debug (fun () ->
               Util.msg
-                "tryCopyMovedFile: local copy from %s didn't work [%s]"
+                "tryCopyMovedFile: local copy from %s didn't work [%s]\n"
                 (Path.toString candidatePath) s);
             Xferhint.deleteEntry hintHandle;
-            None)
+            Lwt.return None)
 
 (****)
 
@@ -725,6 +777,7 @@ let transferResourceForkAndSetFileinfo
   end else
     Lwt.return ()
   end >>= fun () ->
+  propsWithExtData connFrom fspathFrom pathFrom desc >>= fun desc ->
   setFileinfo fspathTo pathTo realPathTo update desc;
   debug (fun() -> Util.msg "Resource fork transferred for %s; doing last paranoid check\n"
     (Path.toString realPathTo));
@@ -1016,16 +1069,16 @@ let transferFileLocal connFrom
         (Fspath.toDebugString fspathTo) (Path.toString realPathTo) in
     let len = Uutil.Filesize.add (Props.length desc) (Osx.ressLength ress) in
     Uutil.showProgress id len "alr";
+    propsWithExtData connFrom fspathFrom pathFrom desc >>= fun desc ->
     setFileinfo fspathTo pathTo realPathTo update desc;
     Xferhint.insertEntry fspathTo pathTo fp;
     Lwt.return (`DONE (TransferSucceeded tempInfo, Some msg))
   end else
     registerFileTransfer pathTo fp
       (fun () ->
-         match
-           tryCopyMovedFile fspathTo pathTo realPathTo update desc fp ress id
-         with
-           Some (info, msg) ->
+         tryCopyMovedFile connFrom fspathFrom pathFrom
+           fspathTo pathTo realPathTo update desc fp ress id >>= function
+         | Some (info, msg) ->
              (* Transfer was performed by copying *)
              Xferhint.insertEntry fspathTo pathTo fp;
              Lwt.return (`DONE (TransferSucceeded info, Some msg))

--- a/src/copy.ml
+++ b/src/copy.ml
@@ -363,12 +363,12 @@ let loadPropsExtDataOnServer = Remote.registerServerCmd "propsExtData"
   (fun connFrom args -> Lwt.return (loadPropsExtDataLocal args))
 
 let propsWithExtDataLocal fspath path desc =
-  if not (Props.missingExtData desc) then (None, Props.withExtData desc)
-  else loadPropsExtDataLocal (fspath, path, desc)
+  try (None, Props.withExtData desc)
+  with Not_found -> loadPropsExtDataLocal (fspath, path, desc)
 
 let propsWithExtDataConn connFrom fspath path desc =
-  if not (Props.missingExtData desc) then Lwt.return (None, Props.withExtData desc)
-  else loadPropsExtDataOnServer connFrom (fspath, path, desc)
+  try Lwt.return (None, Props.withExtData desc)
+  with Not_found -> loadPropsExtDataOnServer connFrom (fspath, path, desc)
 
 let propsExtDataOnRoot root path desc =
   match root with

--- a/src/copy.mli
+++ b/src/copy.mli
@@ -33,3 +33,16 @@ val recursively :
  -> Fspath.t             (* fspath of target *)
  -> Path.local           (* path of target *)
  -> unit
+
+val readPropsExtData :
+    Common.root          (* root of source *)
+ -> Path.local           (* path of source *)
+ -> Props.t              (* props of source *)
+ -> Props.x Lwt.t        (* props with all ext data included *)
+
+val readPropsExtDataG :
+    Common.root          (* root of source *)
+ -> Path.t               (* path of source *)
+ -> Props.t              (* props of source *)
+ -> (Path.local option * Props.x) Lwt.t (* props with all ext data included
+                                           and path translated to local path *)

--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,7 @@
         -no-strict-sequence)
  (foreign_stubs
   (language c)
-  (names bytearray_stubs osxsupport pty hash_compat))
+  (names bytearray_stubs osxsupport pty hash_compat props_xattr))
  (c_library_flags -lutil)
  (libraries str unix lwt_lib bigarray))
 

--- a/src/fileinfo.ml
+++ b/src/fileinfo.ml
@@ -162,8 +162,10 @@ let getBasic fromRoot fspath path =
 let getBasicWithRess fromRoot fspath path =
   getAux fromRoot fspath path (fun _ _ st i -> Props.getWithRess st i)
 
-let get fromRoot fspath path =
-  getAux fromRoot fspath path Props.get
+let get ?(archProps = Props.dummy) fromRoot fspath path =
+  let getProps fspath path stats typ =
+    Props.get ~archProps fspath path stats typ in
+  getAux fromRoot fspath path getProps
 
 let basic x =
   { typ = x.typ;
@@ -256,7 +258,7 @@ let ressStamp info = Osx.stamp info.osX
 let unchanged fspath path info =
   (* The call to [Util.time] must be before the call to [get] *)
   let t0 = Util.time () in
-  let info' = get true fspath path in
+  let info' = get ~archProps:info.desc true fspath path in
   let dataUnchanged =
     Props.same_time info.desc info'.desc
       &&

--- a/src/fileinfo.ml
+++ b/src/fileinfo.ml
@@ -144,7 +144,7 @@ let getAux fromRoot fspath path getProps =
            inode    = (* The inode number is truncated so that
                          it fits in a 31 bit ocaml integer *)
                       stats.Unix.LargeFile.st_ino land 0x3FFFFFFF;
-           desc     = getProps stats osxInfos;
+           desc     = getProps fspath path stats osxInfos;
            osX      = osxInfos }
        with
          Unix.Unix_error((Unix.ENOENT | Unix.ENOTDIR),_,_) ->
@@ -154,13 +154,13 @@ let getAux fromRoot fspath path getProps =
            osX      = Osx.getFileInfos fspath path `ABSENT })
 
 let getType fromRoot fspath path =
-  (getAux fromRoot fspath path (fun _ _ -> Props.dummy)).typ
+  (getAux fromRoot fspath path (fun _ _ _ _ -> Props.dummy)).typ
 
 let getBasic fromRoot fspath path =
-  getAux fromRoot fspath path (fun st _ -> Props.get' st)
+  getAux fromRoot fspath path (fun _ _ st _ -> Props.get' st)
 
 let getBasicWithRess fromRoot fspath path =
-  getAux fromRoot fspath path Props.getWithRess
+  getAux fromRoot fspath path (fun _ _ st i -> Props.getWithRess st i)
 
 let get fromRoot fspath path =
   getAux fromRoot fspath path Props.get

--- a/src/fileinfo.mli
+++ b/src/fileinfo.mli
@@ -23,7 +23,7 @@ val of_compat251 : t251 -> basic
 val getType : bool (* fromRoot *) -> Fspath.t -> Path.local -> typ
 val getBasic : bool (* fromRoot *) -> Fspath.t -> Path.local -> basic
 val getBasicWithRess : bool (* fromRoot *) -> Fspath.t -> Path.local -> bress
-val get : bool (* fromRoot *) -> Fspath.t -> Path.local -> t
+val get : ?archProps:Props.t -> bool (* fromRoot *) -> Fspath.t -> Path.local -> t
 val set : Fspath.t -> Path.local ->
           [`Set of Props.basic | `Copy of Path.local | `Update of Props.t] ->
           Props.x -> unit

--- a/src/fileinfo.mli
+++ b/src/fileinfo.mli
@@ -26,7 +26,7 @@ val getBasicWithRess : bool (* fromRoot *) -> Fspath.t -> Path.local -> bress
 val get : bool (* fromRoot *) -> Fspath.t -> Path.local -> t
 val set : Fspath.t -> Path.local ->
           [`Set of Props.basic | `Copy of Path.local | `Update of Props.t] ->
-          Props.t -> unit
+          Props.x -> unit
 
 (* IF THIS CHANGES, MAKE SURE TO INCREMENT THE ARCHIVE VERSION NUMBER!       *)
 type stamp251 =

--- a/src/files.ml
+++ b/src/files.ml
@@ -1234,7 +1234,7 @@ let merge root1 path1 ui1 root2 path2 ui2 id showMergeFn =
                 Current props, desc1 and desc2, can't be compared before having
                 same time and length (taken from the merge result). *)
              let fixup_desc desc n =
-               let desc' = Props.setTime desc (Props.time n) in
+               let desc' = Props.setTime desc n in
                Props.setLength desc' (Props.length n)
              in
              let desc1' = fixup_desc desc1 merge_desc
@@ -1262,8 +1262,8 @@ let merge root1 path1 ui1 root2 path2 ui2 id showMergeFn =
              | Some new_arch_desc ->
                  Some (Update.ArchiveFile (new_arch_desc, fp,
                    Fileinfo.stamp infoarch, Osx.stamp infoarch.osX)) in
-           (Props.setTime desc1 (Props.time infoarch.Fileinfo.desc),
-            Props.setTime desc2 (Props.time infoarch.Fileinfo.desc),
+           (Props.setTime desc1 infoarch.Fileinfo.desc,
+            Props.setTime desc2 infoarch.Fileinfo.desc,
             new_archive_entry)
          end else
            (desc1, desc2, None)

--- a/src/files.ml
+++ b/src/files.ml
@@ -177,6 +177,7 @@ let setPropLocal (fspath, (path, ui, newDesc, oldDesc)) =
   let localPath = Update.translatePathLocal fspath path in
   let (workingDir,realPath) = Fspath.findWorkingDir fspath localPath in
   Fileinfo.set workingDir realPath (`Update oldDesc) newDesc;
+  let newDesc = Props.purgeExtData newDesc in
   if fileUpdated ui then Stasher.stashCurrentVersion fspath localPath None;
   (* Archive update must be done last *)
   Update.updateProps fspath localPath (Some newDesc) ui;
@@ -191,7 +192,7 @@ let convV0 = Remote.makeConvV0FunArg
          Props.of_compat251 newDesc, Props.of_compat251 oldDesc)))
 
 let setPropOnRoot = Remote.registerRootCmd "setProp" ~convV0
-  Umarshal.(prod4 Path.m Common.mupdateItem Props.m Props.m id id) Umarshal.unit
+  Umarshal.(prod4 Path.m Common.mupdateItem Props.mx Props.m id id) Umarshal.unit
   setPropLocal
 
 let propOpt_to_compat251 = function
@@ -204,17 +205,21 @@ let propOpt_of_compat251 = function
 
 let convV0 = Remote.makeConvV0FunArg
   (fun (fspath, (path, propOpt, ui)) ->
-       (fspath, (path, propOpt_to_compat251 propOpt, Common.ui_to_compat251 ui)))
+       (fspath, (Path.makeGlobal path, propOpt_to_compat251 propOpt,
+         Common.ui_to_compat251 ui)))
   (fun (fspath, (path, propOpt, ui)) ->
-       (fspath, (path, propOpt_of_compat251 propOpt, Common.ui_of_compat251 ui)))
+       (fspath, (Path.forceLocal path,
+         propOpt_of_compat251 propOpt, Common.ui_of_compat251 ui)))
 
 let updatePropsOnRoot =
   Remote.registerRootCmd
    "updateProps" ~convV0
-   Umarshal.(prod3 Path.m (option Props.m) Common.mupdateItem id id)
+   Umarshal.(prod3 Path.mlocal (option Props.m) Common.mupdateItem id id)
    Umarshal.unit
      (fun (fspath, (path, propOpt, ui)) ->
-        let localPath = Update.translatePathLocal fspath path in
+        (* Previous versions of this function received a global path as input *)
+        let localPath = if Props.xattrEnabled () then path
+          else Update.translatePathLocal fspath (Path.makeGlobal path) in
         (* Archive update must be done first *)
         Update.updateProps fspath localPath propOpt ui;
         if fileUpdated ui then
@@ -234,8 +239,12 @@ let setProp rootFrom pathFrom rootTo pathTo newDesc oldDesc uiFrom uiTo =
       (Props.toString newDesc)
       (root2string rootTo) (Path.toString pathTo)
       (Props.toString oldDesc));
+  Copy.readPropsExtDataG rootFrom pathFrom newDesc >>= fun (p, newDesc) ->
   setPropOnRoot rootTo (pathTo, uiTo, newDesc, oldDesc) >>= fun _ ->
-  updateProps rootFrom pathFrom None uiFrom
+  (match p with
+  | None -> Update.translatePath rootFrom pathFrom
+  | Some path -> Lwt.return path) >>= fun localPathFrom ->
+  updateProps rootFrom localPathFrom None uiFrom
 
 (* ------------------------------------------------------------ *)
 
@@ -275,7 +284,7 @@ let convV0 = Remote.makeConvV0FunArg
 let setDirPropOnRoot =
   Remote.registerRootCmd
     "setDirProp" ~convV0
-    Umarshal.(prod4 Fspath.m Path.mlocal Props.mbasic Props.m id id)
+    Umarshal.(prod4 Fspath.m Path.mlocal Props.mbasic Props.mx id id)
     Umarshal.unit
     (fun (_, (workingDir, path, initialDesc, newDesc)) ->
       Fileinfo.set workingDir path (`Set initialDesc) newDesc;
@@ -508,9 +517,18 @@ let convV0 = Remote.makeConvV0FunArg
 
 let setupTargetPathsAndCreateParentDirectory =
   Remote.registerRootCmd "setupTargetPathsAndCreateParentDirectory" ~convV0
-    Umarshal.(prod2 Path.m (list Props.m) id id)
+    Umarshal.(prod2 Path.m (list Props.mx) id id)
     Umarshal.(prod4 Fspath.m Path.mlocal Path.mlocal Path.mlocal id id)
     setupTargetPathsAndCreateParentDirectoryLocal
+
+let rec readParentsExtData rootFrom pathFrom acc = function
+  | [] -> Safelist.rev acc |> Lwt.return
+  | desc :: rem ->
+      match Path.deconstructRev pathFrom with
+      | None -> assert false
+      | Some (_, parentPath) ->
+          Copy.readPropsExtData rootFrom parentPath desc >>= fun desc' ->
+          readParentsExtData rootFrom parentPath (desc' :: acc) rem
 
 (* ------------------------------------------------------------ *)
 
@@ -606,9 +624,13 @@ let copy
       "copy %s %s ---> %s %s \n"
       (root2string rootFrom) (Path.toString pathFrom)
       (root2string rootTo) (Path.toString pathTo));
+  (* Calculate source path *)
+  Update.translatePath rootFrom pathFrom >>= fun localPathFrom ->
   (* Calculate target paths *)
+  normalizeProps propsFrom propsTo
+  |> readParentsExtData rootFrom localPathFrom [] >>= fun parentProps ->
   setupTargetPathsAndCreateParentDirectory rootTo
-    (pathTo, normalizeProps propsFrom propsTo)
+    (pathTo, parentProps)
      >>= fun (workingDir, realPathTo, tempPathTo, localPathTo) ->
   (* When in Unicode case-insensitive mode, we want to create files
      with NFC normal-form filenames. *)
@@ -623,8 +645,6 @@ let copy
         | Some (name, parentPath) ->
             Path.child parentPath (Name.normalize name)
   in
-  (* Calculate source path *)
-  Update.translatePath rootFrom pathFrom >>= fun localPathFrom ->
   let errors = ref [] in
   (* Inner loop for recursive copy... *)
   let rec copyRec pFrom      (* Path to copy from *)
@@ -700,11 +720,12 @@ let copy
              else
                Lwt.return ()
              end >>= fun () ->
+             Copy.readPropsExtData rootFrom pFrom desc >>= fun desc' ->
              Lwt_util.run_in_region copyReg 1 (fun () ->
                (* We use the actual file permissions so as to preserve
                   inherited bits *)
                setDirPropOnRoot rootTo
-                 (workingDir, pTo, initialDesc, desc)) >>= fun () ->
+                 (workingDir, pTo, initialDesc, desc')) >>= fun () ->
              Lwt.return (Update.ArchiveDir (desc, newChildren),
                          List.flatten pathl)
          | Update.NoArchive ->

--- a/src/fpcache.ml
+++ b/src/fpcache.ml
@@ -302,7 +302,7 @@ let fingerprint ?(newfile=false) fastCheck currfspath path info optFp =
         if Prefs.read fastercheckUNSAFE && newfile then begin
           debug (fun()-> Util.msg "skipping initial fingerprint of %s\n"
                             (Fspath.toDebugString (Fspath.concat currfspath path)));
-          (Fileinfo.get false currfspath path,
+          (Fileinfo.get ~archProps:info.desc false currfspath path,
            Os.pseudoFingerprint path (Props.length info.Fileinfo.desc))
         end else begin
           Os.safeFingerprint currfspath path info optFp

--- a/src/fs.ml
+++ b/src/fs.ml
@@ -68,6 +68,17 @@ let file_exists f =
 
 (****)
 
+exception XattrNotSupported = System.XattrNotSupported
+
+let xattr_list f = System.xattr_list (path f)
+let xattr_get f n = System.xattr_get (path f) n
+let xattr_set f n v = System.xattr_set (path f) n v
+let xattr_remove f n = System.xattr_remove (path f) n
+
+let xattrUpdatesCTime = System.xattrUpdatesCTime
+
+(****)
+
 let fingerprint f = System.fingerprint (path f)
 
 let hasInodeNumbers () = System.hasInodeNumbers ()

--- a/src/fsmonitor/windows/Makefile
+++ b/src/fsmonitor/windows/Makefile
@@ -12,7 +12,8 @@ FSMOCAMLOBJS = \
    fsmonitor/watchercommon.cmo $(DIR)/watcher.cmo
 FSMCOBJS = \
    bytearray_stubs$(OBJ_EXT) \
-   system/system_win_stubs$(OBJ_EXT) lwt/lwt_unix_stubs$(OBJ_EXT)
+   system/system_win_stubs$(OBJ_EXT) lwt/lwt_unix_stubs$(OBJ_EXT) \
+   props_xattr$(OBJ_EXT)
 FSMOCAMLLIBS=unix.cma
 
 ifeq ($(NATIVE), true)

--- a/src/props.mli
+++ b/src/props.mli
@@ -49,8 +49,12 @@ val dirDefault : basic
 val syncModtimes : bool Prefs.t
 val permMask : int Prefs.t
 val dontChmod : bool Prefs.t
+val syncXattrs : bool Prefs.t
 
 val xattrEnabled : unit -> bool
+
+val xattrIgnorePred : Pred.t
+val xattrIgnorenotPred : Pred.t
 
 (* We are reusing the directory length to store a flag indicating that
    the directory is unchanged *)

--- a/src/props.mli
+++ b/src/props.mli
@@ -22,7 +22,7 @@ val toString : t -> string
 val syncedPartsToString : t -> string
 val set : Fspath.t -> Path.local -> [`Set | `Update] -> t -> unit
 val get' : Unix.LargeFile.stats -> basic
-val get : Unix.LargeFile.stats -> Osx.info -> t
+val get : Fspath.t -> Path.local -> Unix.LargeFile.stats -> Osx.info -> t
 val getWithRess : Unix.LargeFile.stats -> Osx.info -> basic
 val check : Fspath.t -> Path.local -> Unix.LargeFile.stats -> t -> unit
 val init : bool -> unit

--- a/src/props.mli
+++ b/src/props.mli
@@ -7,25 +7,32 @@ type t251
 type _ props
 type basic = [`Basic] props
 type t = [`Full] props
+type x = [`ExtLoaded] props
 val m : t Umarshal.t
 val mbasic : basic Umarshal.t
+val mx : x Umarshal.t
 val to_compat251 : _ props -> t251
 val of_compat251 : t251 -> _ props
 val dummy : _ props
 val hash : t -> int -> int
 val hash251 : t251 -> int -> int
 val similar : t -> t -> bool
-val override : _ props -> t -> t
+val override : _ props -> 'a props -> 'a props
 val strip : t -> t
-val diff : t -> t -> t
+val diff : t -> x -> x
 val toString : t -> string
 val syncedPartsToString : t -> string
-val set : Fspath.t -> Path.local -> [`Set | `Update] -> t -> unit
+val set : Fspath.t -> Path.local -> [`Set | `Update] -> x -> unit
 val get' : Unix.LargeFile.stats -> basic
 val get : Fspath.t -> Path.local -> Unix.LargeFile.stats -> Osx.info -> t
 val getWithRess : Unix.LargeFile.stats -> Osx.info -> basic
-val check : Fspath.t -> Path.local -> Unix.LargeFile.stats -> t -> unit
+val check : Fspath.t -> Path.local -> Unix.LargeFile.stats -> x -> unit
 val init : bool -> unit
+
+val missingExtData : t -> bool
+val loadExtData : Fspath.t -> Path.local -> t -> x
+val purgeExtData : x -> t
+val withExtData : t -> x
 
 val same_time : _ props -> t -> bool
 val length : _ props -> Uutil.Filesize.t
@@ -41,6 +48,8 @@ val dirDefault : basic
 val syncModtimes : bool Prefs.t
 val permMask : int Prefs.t
 val dontChmod : bool Prefs.t
+
+val xattrEnabled : unit -> bool
 
 (* We are reusing the directory length to store a flag indicating that
    the directory is unchanged *)

--- a/src/props.mli
+++ b/src/props.mli
@@ -29,10 +29,11 @@ val getWithRess : Unix.LargeFile.stats -> Osx.info -> basic
 val check : Fspath.t -> Path.local -> Unix.LargeFile.stats -> x -> unit
 val init : bool -> unit
 
-val missingExtData : t -> bool
 val loadExtData : Fspath.t -> Path.local -> t -> x
 val purgeExtData : x -> t
 val withExtData : t -> x
+(* [withExtData] will raise Not_found if some ext data is missing. In that
+   case, [loadExtData] must be used to load any missing ext data. *)
 
 val same_time : _ props -> t -> bool
 val same_ctime : _ props -> t -> bool
@@ -66,3 +67,20 @@ val setDirChangeFlag : t -> dirChangedStamp -> int -> t * bool
 val dirMarkedUnchanged : t -> dirChangedStamp -> int -> bool
 
 val validatePrefs: unit -> unit
+
+module Data : sig
+  type e
+  type d = e list
+
+  val m : d Umarshal.t
+
+  val enabled : unit -> bool
+
+  val extern : [`New] -> d
+  val intern : d -> unit
+  val merge : d -> unit
+
+  val gcInit : unit -> unit
+  val gcKeep : t -> unit
+  val gcDone : unit -> d
+end

--- a/src/props.mli
+++ b/src/props.mli
@@ -24,7 +24,7 @@ val toString : t -> string
 val syncedPartsToString : t -> string
 val set : Fspath.t -> Path.local -> [`Set | `Update] -> x -> unit
 val get' : Unix.LargeFile.stats -> basic
-val get : Fspath.t -> Path.local -> Unix.LargeFile.stats -> Osx.info -> t
+val get : ?archProps:t -> Fspath.t -> Path.local -> Unix.LargeFile.stats -> Osx.info -> t
 val getWithRess : Unix.LargeFile.stats -> Osx.info -> basic
 val check : Fspath.t -> Path.local -> Unix.LargeFile.stats -> x -> unit
 val init : bool -> unit
@@ -35,10 +35,11 @@ val purgeExtData : x -> t
 val withExtData : t -> x
 
 val same_time : _ props -> t -> bool
+val same_ctime : _ props -> t -> bool
 val length : _ props -> Uutil.Filesize.t
 val setLength : t -> Uutil.Filesize.t -> t
 val time : _ props -> float
-val setTime : t -> float -> t
+val setTime : t -> _ props -> t
 val perms : _ props -> int
 
 val fileDefault : basic

--- a/src/props_xattr.c
+++ b/src/props_xattr.c
@@ -1,0 +1,765 @@
+/* Unison file synchronizer: src/props_xattr.c */
+/* Copyright 2020-2022, Tõivo Leedjärv
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* Conceptually, here, an extended attribute is just a name-value pair,
+ * where name is a text string and value is a binary string. This matches
+ * well the concept of extended attributes on some platforms (notably,
+ * Linux and BSDs), while some platforms provide more sophisticated
+ * extended attributes.
+ *
+ * The external interface is defined as follows. Every supported platform
+ * must implement this interface. xattr format can be platform-specific,
+ * which may prevent cross-platform synchronization but still allows
+ * synchronization within the platform. Cross-platform synchronization may
+ * still be possible in some cases, even if one platform will not
+ * understand the xattrs; the attribute values are treated as blobs then.
+ *
+ *
+ * SET the value of one xattr
+ * ==========================
+ * unit unison_xattr_set(String path, String xattrname, String xattrvalue)
+ *
+ *   Create the requested extended attribute on the requested file or
+ *   directory and set the attribute value.
+ *   If the attribute already exists then its value is overwritten.
+ *   Symbolic links are followed.
+ *
+ * Input parameters
+ *   path       - absolute path of a file or directory
+ *   xattrname  - name of attribute to set on the path
+ *   xattrvalue - value of attribute to set on the path
+ *
+ * Return value
+ *   No return value.
+ *
+ * Exceptions
+ *   There are no mandatory exception conditions.
+ *   OCaml exception defined by macro UNSN_XATTR_NOT_SUPPORTED_EX
+ *   MAY be raised when extended attributes are not supported on
+ *   the requested path.
+ *   Failure MAY voluntarily be raised for example when:
+ *     Can't access file to set the attribute
+ *     Error creating the attribute (invalid name, permission error, etc.)
+ *     Error setting the attribute value
+ *
+ *
+ * REMOVE one xattr
+ * ================
+ * unit unison_xattr_remove(String path, String xattrname)
+ *
+ *   Remove the requested extended attribute on the requested file or
+ *   directory. Symbolic links are followed.
+ *
+ * Input parameters
+ *   path      - absolute path of a file or directory
+ *   xattrname - name of attribute to remove on the path
+ *
+ * Return value
+ *   No return value.
+ *
+ * Exceptions
+ *   There are no mandatory exception conditions.
+ *   OCaml exception defined by macro UNSN_XATTR_NOT_SUPPORTED_EX
+ *   MAY be raised when extended attributes are not supported on
+ *   the requested path.
+ *   Failure MAY voluntarily be raised for example when:
+ *     Can't access file to remove the attribute
+ *     Error removing the attribute
+ *
+ *
+ * GET the value of one xattr
+ * ==========================
+ * String unison_xattr_get(String path, String xattrname)
+ *
+ *   Get the value of the requested extended attribute on the requested
+ *   file or directory. The entire value is returned in full length.
+ *   Symbolic links are followed.
+ *
+ * Input parameters
+ *   path      - absolute path of a file or directory
+ *   xattrname - name of attribute to get on the path
+ *
+ * Return value
+ *   The value of the requested extended attribute, as a binary string.
+ *
+ * Exceptions
+ *   OCaml exception defined by macro UNSN_XATTR_NOT_SUPPORTED_EX
+ *   MAY be raised when extended attributes are not supported on
+ *   the requested path.
+ *   Failure MUST be raised when:
+ *     The attribute value does not fit in an OCaml string on a 32-bit
+ *     platform (approx. 16 MB)
+ *     Can't access file to read the attribute
+ *     Error reading the attribute value or attribute not found
+ *
+ *
+ * GET the list of xattrs with value lengths
+ * =========================================
+ * List of (String * Int) unison_xattrs_list(String path)
+ *
+ *   Get the list of all extended attributes on the requested file or
+ *   directory. Attributes names are returned together with the length
+ *   of attribute values.
+ *   Attributes in the list can be returned in any order and the order
+ *   does not have to be stable (i.e. it can be different on every
+ *   invocation on the same path).
+ *   Symbolic links are followed.
+ *
+ * Input parameters
+ *   path - absolute path of a file or directory
+ *
+ * Return value
+ *   The list of name-length pairs, with each pair representing the
+ *   name and length of value of one extended attribute.
+ *
+ * Exceptions
+ *   OCaml exception defined by macro UNSN_XATTR_NOT_SUPPORTED_EX
+ *   MUST be raised when extended attributes are not supported on
+ *   the requested path, or should not otherwise be returned.
+ *   Failure MAY voluntarily be raised for example when:
+ *     Can't access file to get the attributes
+ *     Error reading attribute values
+ *
+ *
+ * Indicate platform/system capabilities
+ * =====================================
+ * Boolean unison_xattr_updates_ctime()
+ *
+ *   Indicate whether the platform/system updates file ctime when
+ *   extended attributes change on the file. Not all platforms do this
+ *   (Solaris/illumos are known to not update any stat times of the
+ *   file/directory when its extended attributes are modified).
+ *   The capabilities of the system are important to know because
+ *   detecting updates quickly yet correctly relies on knowing when to
+ *   get the list of xattrs with values.
+ *
+ * Input parameters
+ *   none
+ *
+ * Return value
+ *   True if file ctime is updated at xattr changes. False otherwise.
+ *   For a platform that does not support ctime, true can be returned
+ *   if xattr changes update file mtime.
+ *
+ * Exceptions
+ *   none
+ *
+ */
+
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+
+
+#if defined(sun) || defined(__sun)  /* Solarish, all illumos-based OS,   */
+#define __Solaris__                 /* OpenIndiana, OmniOS, SmartOS, ... */
+#endif
+
+#undef UNSN_HAS_XATTR
+#if defined(__Solaris__) || defined(__FreeBSD__) || defined(__NetBSD__) \
+    || defined(__APPLE__) || defined(__linux)
+#define UNSN_HAS_XATTR
+#endif
+
+#define UNSN_XATTR_NOT_SUPPORTED_EX "XattrNotSupported"
+
+
+static void unsn_xattr_not_supported()
+{
+  static const value *ex = NULL;
+
+  if (ex == NULL) {
+    ex = caml_named_value(UNSN_XATTR_NOT_SUPPORTED_EX);
+  }
+
+  caml_raise_constant(*ex);
+}
+
+
+#ifndef UNSN_HAS_XATTR
+
+CAMLprim void unison_xattr_set(value path, value xattrname, value xattr)
+{
+  unsn_xattr_not_supported();
+}
+
+CAMLprim void unison_xattr_remove(value path, value xattrname)
+{
+  unsn_xattr_not_supported();
+}
+
+CAMLprim void unison_xattr_get(value path, value xattrname)
+{
+  unsn_xattr_not_supported();
+}
+
+CAMLprim void unison_xattrs_list(value path)
+{
+  unsn_xattr_not_supported();
+}
+
+CAMLprim value unison_xattr_updates_ctime(value unit)
+{
+  CAMLparam0();
+  CAMLreturn(Val_true);
+}
+
+#else /* UNSN_HAS_XATTR */
+
+
+#if defined(__Solaris__)
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#endif
+
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/extattr.h>
+#include <string.h>
+#include <stdio.h>
+#endif
+
+#if defined(__FreeBSD__)
+#define ENOTSUP EOPNOTSUPP
+#endif
+
+#if defined(__APPLE__)
+#include <errno.h>
+#include <sys/xattr.h>
+#include <string.h>
+#include <stdio.h>
+#endif
+
+#if defined(__linux)
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <string.h>
+#include <stdio.h>
+
+/* Attribute names on Linux must be mangled to make cross-platform
+ * synchronization possible. When listing attributes, the "user."
+ * prefix is removed for user namespace attributes and an "!" is
+ * prepended to attribute names in all other namespaces (or more
+ * accurately, it is prepended to the namespace name).
+ *
+ * When feeding the attribute names to get, set, remove and other
+ * syscalls, the reverse is done. */
+
+#define XN_BUF_LEN 261
+#define XN_LEN (XN_BUF_LEN - 6)
+
+static value val_of_attrname(char *attrname)
+{
+  char buf[XN_BUF_LEN] = "!";
+
+  if (attrname != NULL) {
+    if (strncmp(attrname, "user.", 5) == 0) {
+      attrname += 5;
+    } else {
+      attrname = strncat(buf, attrname, XN_LEN);
+    }
+  }
+
+  return caml_copy_string(attrname != NULL ? attrname : "");
+}
+
+static const char *attrname_of_val(const char *attrname, char *buf)
+{
+  if (attrname != NULL) {
+    if (attrname[0] == '!') {
+      return attrname + 1;
+    } else {
+      return strncat(strcpy(buf, "user."), attrname, XN_LEN);
+    }
+  } else {
+    return attrname;
+  }
+}
+#endif /* defined(__linux) */
+
+
+#if defined(__linux)
+
+#define XATTRNAME_VAL(a, n) char xnb_[XN_BUF_LEN];\
+                            const char *a = attrname_of_val(String_val(n), xnb_)
+#define VAL_XATTRNAME val_of_attrname
+
+#else
+
+#define XATTRNAME_VAL(a, n) const char *a = String_val(n)
+#define VAL_XATTRNAME caml_copy_string
+
+#endif /* defined(__linux) */
+
+
+static void unsn_xattr_fail(const char *fmtmsg)
+{
+  char buf[512];
+  char *errmsg;
+
+#if defined(_WIN32)
+  errmsg = strerror(errno);
+#else
+  int errnum = errno;
+  if (strerror_r(errnum, buf, sizeof(buf)) != 0) {
+    snprintf(buf, sizeof(buf), "(error code %d)", errnum);
+  }
+  errmsg = buf;
+#endif /* defined(_WIN32) */
+
+  caml_failwith_value(caml_alloc_sprintf(fmtmsg, errmsg));
+}
+
+static int unsn_is_system_attr_os(const char *attrname)
+{
+#if defined(__linux)
+  return (strncmp(attrname, "system.", 7) == 0);
+#elif defined(__APPLE__)
+  return (strcmp(attrname, XATTR_FINDERINFO_NAME) == 0 ||
+          strcmp(attrname, XATTR_RESOURCEFORK_NAME) == 0);
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+  return 0;
+#elif defined(__Solaris__)
+  /* Special system "extensible attributes" xattrs are defined in sys/attr.h
+   * as VIEW_READONLY = "SUNWattr_ro" and VIEW_READWRITE = "SUNWattr_rw" */
+  return (strcmp(attrname, ".") == 0 || strcmp(attrname, "..") == 0 ||
+          strncmp(attrname, "SUNWattr_", 9) == 0);
+#endif
+}
+
+
+/************************************
+ *            Set xattr
+ ************************************/
+static int unsn_set_xattr_os(const char *path, const char *attrname,
+                             const void *attrvalue, size_t valuesize)
+{
+#if defined(__linux)
+  return setxattr(path, attrname, attrvalue, valuesize, 0);
+#elif defined(__APPLE__)
+  return setxattr(path, attrname, attrvalue, valuesize, 0, 0);
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+  return (int) extattr_set_file(path, EXTATTR_NAMESPACE_USER, attrname,
+                                attrvalue, valuesize);
+#elif defined(__Solaris__)
+  if (pathconf(path, _PC_XATTR_ENABLED) < 1) {
+    unsn_xattr_not_supported();
+  }
+
+  /* This is a simplified implementation that just creates/opens
+   * the xattr and writes the value into it.
+   *
+   * Extended attributes in Solaris and illumos are much more
+   * flexible. In most ways they are like normal files/directories.
+   * They have owner/group, mode, utimes, even ACL, and can have
+   * their own extended attributes, etc.
+   *
+   * This implementation does not synchronize any of those params,
+   * as xattrs are conceptually treated as name-value pairs.
+   * It is unknown if this will cause problems with real use cases. */
+  int fd = attropen(path, attrname, O_CREAT|O_WRONLY|O_TRUNC);
+  if (fd == -1) {
+    unsn_xattr_fail("Error opening extended attribute for writing: %s");
+  }
+
+  ssize_t written = 0, c;
+  do {
+    c = write(fd, attrvalue + written, valuesize - written);
+    written += c;
+  } while (c > 0 && written < valuesize);
+
+  close(fd);
+
+  return c == -1 ? c : 0;
+#endif
+}
+
+CAMLprim value unison_xattr_set(value path, value xattrname, value xattr)
+{
+  CAMLparam3(path, xattrname, xattr);
+  const char *name = String_val(path);
+  XATTRNAME_VAL(attr, xattrname);
+  const char *attrvalue = String_val(xattr);
+  unsigned int len;
+
+  /* Ignore system extended attributes */
+  if (unsn_is_system_attr_os(attr)) {
+    CAMLreturn(Val_unit);
+  }
+
+  len = caml_string_length(xattr);
+
+  int error = unsn_set_xattr_os(name, attr, attrvalue, len);
+  if (error == -1) {
+    if (errno == ENOTSUP) {
+      unsn_xattr_not_supported();
+    } else {
+      unsn_xattr_fail("Error writing extended attribute: %s");
+    }
+  }
+
+  CAMLreturn(Val_unit);
+}
+
+
+/************************************
+ *           Remove xattr
+ ************************************/
+static int unsn_remove_xattr_os(const char *path, const char *attrname)
+{
+#if defined(__linux)
+  return removexattr(path, attrname);
+#elif defined(__APPLE__)
+  return removexattr(path, attrname, 0);
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+  return (int) extattr_delete_file(path, EXTATTR_NAMESPACE_USER, attrname);
+#elif defined(__Solaris__)
+  if (pathconf(path, _PC_XATTR_ENABLED) < 1) {
+    unsn_xattr_not_supported();
+  }
+
+  int fd = attropen(path, ".", O_RDONLY);
+  if (fd == -1) {
+    unsn_xattr_fail("Error opening extended attribute for removing: %s");
+  }
+  int error = unlinkat(fd, attrname, 0);
+  close(fd);
+
+  return error;
+#endif
+}
+
+CAMLprim value unison_xattr_remove(value path, value xattrname)
+{
+  CAMLparam2(path, xattrname);
+  const char *name = String_val(path);
+  XATTRNAME_VAL(attr, xattrname);
+
+  /* Ignore system extended attributes */
+  if (unsn_is_system_attr_os(attr)) {
+    CAMLreturn(Val_unit);
+  }
+
+  int error = unsn_remove_xattr_os(name, attr);
+  if (error == -1 && errno == ENOTSUP) {
+    unsn_xattr_not_supported();
+  }
+
+  CAMLreturn(Val_unit);
+}
+
+
+/************************************
+ *         Length of xattr
+ ************************************/
+static ssize_t unsn_length_xattr_os(const char *path, const char *attrname)
+{
+#if defined(__linux)
+  return getxattr(path, attrname, NULL, 0);
+#elif defined(__APPLE__)
+  return getxattr(path, attrname, NULL, 0, 0, 0);
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+  return extattr_get_file(path, EXTATTR_NAMESPACE_USER, attrname, NULL, 0);
+#elif defined(__Solaris__)
+  int fd = attropen(path, attrname, O_RDONLY);
+  if (fd == -1) {
+    unsn_xattr_fail("Error opening extended attribute for querying length: %s");
+  }
+
+  struct stat buf;
+  int error;
+
+  error = fstat(fd, &buf);
+  close(fd);
+
+  return error == -1 ? error : buf.st_size;
+#endif
+}
+
+
+/************************************
+ *            Get xattrs
+ ************************************/
+static ssize_t unsn_get_xattr_os(const char *path, const char *attrname,
+                                 void *buf, size_t size)
+{
+#if defined(__linux)
+  return getxattr(path, attrname, buf, size);
+#elif defined(__APPLE__)
+  return getxattr(path, attrname, buf, size, 0, 0);
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+  return extattr_get_file(path, EXTATTR_NAMESPACE_USER, attrname, buf, size);
+#elif defined(__Solaris__)
+  int fd = attropen(path, attrname, O_RDONLY);
+  if (fd == -1) {
+    unsn_xattr_fail("Error opening extended attribute for reading: %s");
+  }
+
+  ssize_t rd = 0, c;
+  do {
+    c = read(fd, buf + rd, size - rd);
+    rd += c;
+  } while (c > 0 && rd < size);
+
+  close(fd);
+
+  return c == -1 ? c : rd;
+#endif
+}
+
+CAMLprim value unison_xattr_get(value path, value xattrname)
+{
+  CAMLparam2(path, xattrname);
+  CAMLlocal1(v);
+  const char *name = String_val(path);
+  XATTRNAME_VAL(attr, xattrname);
+
+  int len = 0, tries = 0;
+
+  do {
+    if (++tries > 10) {
+      caml_failwith("Error reading contents of extended attribute; "
+        "it keeps changing");
+    }
+
+    len = unsn_length_xattr_os(name, attr);
+    if (len == -1 && errno == ENOTSUP) {
+      unsn_xattr_not_supported();
+    } else if (len == -1) {
+      unsn_xattr_fail("Error reading length of extended attribute: %s");
+    }
+
+    if (len == 0) {
+      v = caml_alloc_string(0);
+    } else if (len > 16777211) { // Max OCaml string length on 32 bit platforms
+      caml_failwith_value(caml_alloc_sprintf(
+        "Extended attribute value is too big (%d bytes)", len));
+    } else {
+      char *buf = malloc(len);
+
+      len = unsn_get_xattr_os(name, attr, buf, len);
+      if (len == -1 && errno == ENOTSUP) {
+        free(buf);
+        unsn_xattr_not_supported();
+      } else if (len == -1 && errno != ERANGE) {
+        free(buf);
+        unsn_xattr_fail("Error reading contents of extended attribute: %s");
+      } else if (len != -1) {
+        v = caml_alloc_initialized_string(len, buf);
+      }
+
+      free(buf);
+    }
+  } while (len == -1 && errno == ERANGE);
+  /* ERANGE error produced on Linux and Darwin; other platforms
+   * truncate the value if buffer is too small. */
+
+  CAMLreturn(v);
+}
+
+
+/************************************
+ *           List xattrs
+ ************************************/
+static void unsn_list_xattr_fail(void)
+{
+  unsn_xattr_fail("Error getting list of extended attributes: %s");
+}
+
+#if !defined(__Solaris__)
+
+static ssize_t unsn_list_xattr_os(const char *path, char *buf, size_t size)
+{
+#if defined(__linux)
+  return listxattr(path, buf, size);
+#elif defined(__APPLE__)
+  return listxattr(path, buf, size, 0);
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+  return extattr_list_file(path, EXTATTR_NAMESPACE_USER, buf, size);
+#endif
+}
+
+static ssize_t unsn_list_xattr_aux(const char *path, char **buf)
+{
+  ssize_t namelen;
+
+  namelen = unsn_list_xattr_os(path, NULL, 0);
+
+  if (namelen == -1) {
+    if (errno == ENOTSUP) {
+      unsn_xattr_not_supported();
+    }
+    unsn_list_xattr_fail();
+  }
+  if (namelen == 0) {
+    return 0;
+  }
+
+  *buf = malloc(namelen);
+  if (*buf == NULL) {
+    unsn_list_xattr_fail();
+  }
+
+  namelen = unsn_list_xattr_os(path, *buf, namelen);
+  if (namelen == -1) {
+    free(*buf);
+    unsn_list_xattr_fail();
+  }
+  if (namelen == 0) {
+    free(*buf);
+    return 0;
+  }
+
+  return namelen;
+}
+
+#else
+
+static ssize_t unsn_list_xattr_aux(const char *path, DIR **dirp)
+{
+  if (pathconf(path, _PC_XATTR_ENABLED) < 1) {
+    unsn_xattr_not_supported();
+  }
+
+  if (pathconf(path, _PC_XATTR_EXISTS) < 1) {
+    return 0;
+  }
+
+  int fd = attropen(path, ".", O_RDONLY);
+  if (fd == -1) {
+    unsn_list_xattr_fail();
+  }
+
+  *dirp = fdopendir(fd);
+  if (*dirp == NULL) {
+    int real_err = errno;
+    close(fd);
+    errno = real_err;
+    unsn_list_xattr_fail();
+  }
+
+  return 1;
+}
+
+#endif /* !__Solaris__ */
+
+CAMLprim value unison_xattrs_list(value path)
+{
+  CAMLparam1(path);
+  CAMLlocal3(result, p, l);
+  /* Use a static buffer because memory management for the path would become
+   * much too complex. Use a constant length because PATH_MAX is not reliable
+   * and pathconf() is out of question. */
+  char name[32768];
+#if !defined(__Solaris__)
+  char *xattrs;
+#else
+  DIR *xattrs;
+  struct dirent *dp;
+  char *xattrname;
+#endif
+  ssize_t namelen, len;
+
+  if (caml_string_length(path) > 32767) {
+    caml_failwith("The path is too long");
+  }
+  strcpy(name, String_val(path));
+
+  result = Val_emptylist;
+
+  namelen = unsn_list_xattr_aux(name, &xattrs);
+  if (namelen == 0) {
+    CAMLreturn(result);
+  }
+
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+  size_t nl = 0;
+  char xattrname[256];
+
+  for (char *xattrnamep = xattrs; xattrnamep < xattrs + namelen;
+                                  xattrnamep += nl + 1) {
+    nl = *xattrnamep & 255;
+    memcpy(xattrname, xattrnamep + 1, nl);
+    xattrname[nl] = '\0';
+#elif !defined(__Solaris__)
+  /* For safety */
+  *(xattrs + namelen - 1) = '\0';
+
+  for (char *xattrname = xattrs; xattrname < xattrs + namelen;
+                                 xattrname += strlen(xattrname) + 1) {
+#elif defined(__Solaris__)
+  while (dp = readdir(xattrs)) {
+    /* Note: NULL is returned for both end of dir and an error condition.
+     * Error conditions are silently ignored. */
+    xattrname = dp->d_name;
+#endif
+
+    /* Ignore system extended attributes */
+    if (unsn_is_system_attr_os(xattrname)) {
+      continue;
+    }
+
+    len = unsn_length_xattr_os(name, xattrname);
+    if (len == -1) {
+      continue; /* Ignore silently */
+    }
+
+    p = caml_alloc_tuple(2);
+    Store_field(p, 0, VAL_XATTRNAME(xattrname));
+    Store_field(p, 1, Val_int(len));
+
+    l = caml_alloc_small(2, Tag_cons);
+    Field(l, 0) = p;
+    Field(l, 1) = result;
+
+    result = l;
+  }
+
+#if defined(__Solaris__)
+  closedir(xattrs);
+#else
+  free(xattrs);
+#endif
+
+  CAMLreturn(result);
+}
+
+
+/************************************
+ *        ctime capabilities
+ ************************************/
+CAMLprim value unison_xattr_updates_ctime(value unit)
+{
+  CAMLparam0();
+#if defined(__Solaris__)
+  CAMLreturn(Val_false);
+#else
+  CAMLreturn(Val_true);
+#endif
+}
+
+
+#endif /* UNSN_HAS_XATTR */

--- a/src/propsdata.ml
+++ b/src/propsdata.ml
@@ -1,0 +1,105 @@
+(* Unison file synchronizer: src/propsdata.ml *)
+(* Copyright 2020-2022, Tõivo Leedjärv
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+
+module type S = sig
+  val get : [< `All | `New | `Kept] -> (string * string) list
+  val set : (string * string) list -> unit
+  val merge : (string * string) list -> unit
+  val clear : [`Kept] -> unit
+end
+
+
+module KVStore (V : sig val initSize : int end) = struct
+
+(* Key-value store with a relatively low number of entries (in the tens
+   or hundreds, or at most in low thousands).
+
+   This is not a generic key-value store; this is specifically intended
+   for use by [Props.Data].
+
+   Several simple implementations are possible (for example, a Map or an
+   association list). There seems to be very little difference in terms
+   of performance. Hashtbl has been chosen as it may have a slight scaling
+   advantage. In practice, there probably are no tangile differences
+   between these simple implementations in most scenarios. *)
+let mainStore = Hashtbl.create V.initSize
+let newStore = Hashtbl.create V.initSize
+let keepStore = Hashtbl.create V.initSize
+
+let getStore = function
+  | `All -> mainStore
+  | `New -> newStore
+  | `Kept -> keepStore
+
+let exists key = Hashtbl.mem mainStore key
+
+let find_opt key = Hashtbl.find_opt mainStore key
+
+let associate key value = Hashtbl.add mainStore key value
+
+let associateNew key value =
+  associate key value;
+  Hashtbl.add newStore key value
+
+let add key value =
+  if not (exists key) then associateNew key value
+
+let find key =
+  match find_opt key with
+  | Some v -> v
+  | None -> assert false (* Indicates a bug *)
+
+let get kind =
+  Hashtbl.fold (fun key value acc -> (key, value) :: acc) (getStore kind) []
+
+let set d =
+  Hashtbl.clear mainStore;
+  Hashtbl.clear newStore;
+  Safelist.iter (fun (key, value) -> associate key value) d
+
+let associate_cmp key value =
+  match find_opt key with
+  | None -> associate key value
+  | Some v when v = value -> ()
+  | Some v ->
+      raise (Util.Fatal ("Internal integrity error (propsdata). Key " ^ key
+        ^ " returns different results:\n  (existing) " ^ v
+        ^ "\nand\n  (new) " ^ value ^ "\n"))
+
+let merge d =
+  Safelist.iter (fun (key, value) -> associate_cmp key value) d
+
+let clear kind =
+  Hashtbl.clear (getStore kind)
+
+let keep key =
+  if Hashtbl.mem keepStore key then ()
+  else Hashtbl.add keepStore key (find key)
+
+end (* module KVStore *)
+
+
+(* ------------------------------------------------------------------------- *)
+(*                       Extended attributes (xattr)                         *)
+(* ------------------------------------------------------------------------- *)
+
+module Xattr = struct
+  include KVStore (struct let initSize = 200 end)
+
+  let length () = Hashtbl.length mainStore
+end

--- a/src/propsdata.mli
+++ b/src/propsdata.mli
@@ -1,0 +1,17 @@
+(* Unison file synchronizer: src/propsdata.mli *)
+(* Copyright 2022, Tõivo Leedjärv (see COPYING for details) *)
+
+module type S = sig
+  val get : [< `All | `New | `Kept] -> (string * string) list
+  val set : (string * string) list -> unit
+  val merge : (string * string) list -> unit
+  val clear : [`Kept] -> unit
+end
+
+module Xattr : sig
+  include S
+
+  val add : string -> string -> unit
+  val find_opt : string -> string option
+  val length : unit -> int
+end

--- a/src/system/system_generic.ml
+++ b/src/system/system_generic.ml
@@ -122,3 +122,28 @@ let fingerprint f =
   let d = Digest.channel ic (-1) in
   close_in ic;
   d
+
+(****)
+
+exception XattrNotSupported
+let _ = Callback.register_exception "XattrNotSupported" XattrNotSupported
+
+external xattr_list : string -> (string * int) list = "unison_xattrs_list"
+external xattr_get_ : string -> string -> string = "unison_xattr_get"
+external xattr_set_ : string -> string -> string -> unit = "unison_xattr_set"
+external xattr_remove_ : string -> string -> unit = "unison_xattr_remove"
+external xattr_updates_ctime : unit -> bool = "unison_xattr_updates_ctime"
+
+let xattrUpdatesCTime = xattr_updates_ctime ()
+
+let xattr_get p n =
+  try xattr_get_ p n with
+  | Failure e -> failwith ("(attr: " ^ n ^ ") " ^ e)
+
+let xattr_set p n v =
+  try xattr_set_ p n v with
+  | Failure e -> failwith ("(attr: " ^ n ^ ") " ^ e)
+
+let xattr_remove p n =
+  try xattr_remove_ p n with
+  | Failure e -> failwith ("(attr: " ^ n ^ ") " ^ e)

--- a/src/system/system_intf.ml
+++ b/src/system/system_intf.ml
@@ -55,6 +55,21 @@ val hasSymlink : unit -> bool
  * [hasCorrectCTime] can have a different value on different systems. *)
 val hasCorrectCTime : bool
 
+(****)
+
+exception XattrNotSupported
+
+val xattr_list : fspath -> (string * int) list
+val xattr_get : fspath -> string -> string
+val xattr_set : fspath -> string -> string -> unit
+val xattr_remove : fspath -> string -> unit
+
+(* [xattrUpdatesCTime] is true if changes to extended attributes update the
+ * file ctime. This means that extended attribute changes can be quickly
+ * detected by looking at ctime change. If file ctime is not updated then
+ * xattrs have to be scanned every time to detect changes. *)
+val xattrUpdatesCTime : bool
+
 end
 
 module type Full = sig

--- a/src/ubase/umarshal.ml
+++ b/src/ubase/umarshal.ml
@@ -591,6 +591,18 @@ let sum6 ma mb mc md me mf f g =
       );
   }
 
+let cond c d m =
+  {
+    read =
+      (fun recv ->
+        if c () then m.read recv else d
+      );
+    write =
+      (fun send x ->
+        if c () then m.write send x else ()
+      );
+  }
+
 module type PROPLIST_S = sig
   type key = string
   type value = Obj.t

--- a/src/ubase/umarshal.mli
+++ b/src/ubase/umarshal.mli
@@ -100,6 +100,8 @@ val sum5 : 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> ('r -> ('a, 'b, 'c, 'd, 'e) s
 type ('a, 'b, 'c, 'd, 'e, 'f) sum6 = I61 of 'a | I62 of 'b | I63 of 'c | I64 of 'd | I65 of 'e | I66 of 'f
 val sum6 : 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> 'f t -> ('r -> ('a, 'b, 'c, 'd, 'e, 'f) sum6) -> (('a, 'b, 'c, 'd, 'e, 'f) sum6 -> 'r) -> 'r t
 
+val cond : (unit -> bool) -> 'a -> 'a t -> 'a t
+
 module type PROPLIST_S = sig
   type key = string
   type value = Obj.t


### PR DESCRIPTION
### Description

xattr synchronization support. This would also solve #291.

I've used the same method as for ACL synchronization, i.e. use `Props`. This is easy to do and it works. To prevent a potentially large number of potentially large-sized attributes from consuming memory and increasing archive size on disk, a fingerprinting and on-demand reading approach is used (see discussion below in comments).

### Platform support

Almost all platforms support extended attributes in some form. The OCaml code in `props.ml` is essentially universal synchronization of a list of name=value pairs. Platform-specific code is in `props_xattr.c`. Platforms don't have to understand other platforms' xattrs, as long as the names don't clash and other constraints are not violated. This is useful for hub-spoke synchronization.