### PR TITLE
Remove explicit reference to Stdlib and Pervasives

### DIFF
--- a/src/fswatchold.ml
+++ b/src/fswatchold.ml
@@ -60,7 +60,7 @@ let watchercmd archHash root =
 module StringSet= Set.Make (String)
 module RootMap = Map.Make (String)
 type watcherinfo = {file: System.fspath;
-                    mutable ch:Stdlib.in_channel option;
+                    mutable ch:in_channel option;
                     chars: Buffer.t;
                     mutable lines: string list}
 let watchers : watcherinfo RootMap.t ref = ref RootMap.empty

--- a/src/lwt/generic/lwt_unix_impl.ml
+++ b/src/lwt/generic/lwt_unix_impl.ml
@@ -351,18 +351,20 @@ let intern_out_channel ch =
 let wait_inchan ic = wait_read (Unix.descr_of_in_channel ic)
 let wait_outchan oc = wait_write (Unix.descr_of_out_channel oc)
 
+let stdlib_input_char = input_char
 let rec input_char ic =
   try
-    Lwt.return (Stdlib.input_char ic)
+    Lwt.return (stdlib_input_char ic)
   with
     Sys_blocked_io ->
       Lwt.bind (wait_inchan ic) (fun () -> input_char ic)
   | e ->
       Lwt.fail e
 
+let stdlib_input = input
 let rec input ic s ofs len =
   try
-    Lwt.return (Stdlib.input ic s ofs len)
+    Lwt.return (stdlib_input ic s ofs len)
   with
     Sys_blocked_io ->
       Lwt.bind (wait_inchan ic) (fun () -> input ic s ofs len)

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -326,7 +326,7 @@ let interact prilist rilist =
     | ri::rest as ril ->
         let next() = loop (ri::prev) rest in
         let repeat() = loop prev ril in
-        let ignore pat rest what =
+        let ignore_pref pat rest what =
           display "  ";
           Uicommon.addIgnorePattern pat;
           display ("  Permanently ignoring " ^ what ^ "\n");
@@ -582,7 +582,7 @@ let interact prilist rilist =
                  (["%"],
                   ("skip all the following"),
                   (fun () -> newLine();
-                     Safelist.iter (fun ri -> Stdlib.ignore (setskip ri); ()) rest;
+                     Safelist.iter (fun ri -> ignore (setskip ri); ()) rest;
                      repeat()));
                  (["-"],
                   ("skip and discard for this session (curr or match)"),
@@ -595,17 +595,17 @@ let interact prilist rilist =
                  (["I"],
                   ("ignore this path permanently"),
                   (fun () -> newLine();
-                     ignore (Uicommon.ignorePath ri.path1) rest
+                     ignore_pref (Uicommon.ignorePath ri.path1) rest
                        "this path"));
                  (["E"],
                   ("permanently ignore files with this extension"),
                   (fun () -> newLine();
-                     ignore (Uicommon.ignoreExt ri.path1) rest
+                     ignore_pref (Uicommon.ignoreExt ri.path1) rest
                        "files with this extension"));
                  (["N"],
                   ("permanently ignore paths ending with this name"),
                   (fun () -> newLine();
-                     ignore (Uicommon.ignoreName ri.path1) rest
+                     ignore_pref (Uicommon.ignoreName ri.path1) rest
                        "files with this name"));
                  (["s"],
                   ("stop reconciling and go to the proceed menu"),


### PR DESCRIPTION
Referencing Stdlib or Pervasives explicitly may cause an unintentional dependency on OCaml version. Name `Stdlib` was introduced in OCaml 4.07 and name `Pervasives` has been deprecated. Without any explicit references to these names, the code remains compatible with all OCaml versions.