### PR TITLE
Report time taken propagating changes

### DIFF
--- a/src/transport.ml
+++ b/src/transport.ml
@@ -175,9 +175,12 @@ let transportItem reconItem id showMergeFn =
 
 (* ---------------------------------------------------------------------- *)
 
+let lastLogStart = ref 0.
+
 let logStart () =
   Abort.reset ();
   let t = Unix.gettimeofday () in
+  lastLogStart := t;
   let tm = Util.localtime t in
   let m =
     Printf.sprintf
@@ -195,11 +198,12 @@ let logFinish () =
   let tm = Util.localtime t in
   let m =
     Printf.sprintf
-      "%s finished propagating changes at %02d:%02d:%02d.%02d on %02d %s %04d\n%s"
+      "%s finished propagating changes at %02d:%02d:%02d.%02d on %02d %s %04d, %.3f s\n%s"
       (String.capitalize_ascii Uutil.myNameAndVersion)
       tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
       (min 99 (truncate (mod_float t 1. *. 100.)))
       tm.Unix.tm_mday (Util.monthname tm.Unix.tm_mon)
       (tm.Unix.tm_year+1900)
+      ( t -. !lastLogStart )
       (if Prefs.read Trace.terse || Prefs.read Globals.batch then "" else "\n\n") in
   Trace.logverbose m


### PR DESCRIPTION
Although logging is already quite verbose, the time taken to propagate changes is not logged. In our case it is typically in the subsecond range, which is why the duration is printed in ms.

In cases where unison is running as a daemon, monitoring filesystems and keeping them in sync, this is a valuable metric.