### PR TITLE
Put -custom in CAMLLIBS instead of CAMLFLAGS

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -375,6 +375,7 @@ ifeq ($(NATIVE), true)
     CAMLFLAGS+=-p
     CLIBS+=-cclib -ldl
   endif
+  CAMLLDFLAGS=
 
   CAMLOBJS=$(subst .cmo,.cmx, $(subst .cma,.cmxa, $(OCAMLOBJS)))
   CAMLLIBS=$(subst .cma,.cmxa, $(OCAMLLIBS))
@@ -383,10 +384,10 @@ else
   ## Set up for bytecode compilation
 
   CAMLC=$(OCAMLC)
-  CAMLFLAGS+=-custom
   ifeq ($(DEBUGGING), true)
     CAMLFLAGS+=-g
   endif
+  CAMLLDFLAGS=-custom
 
   CAMLOBJS=$(OCAMLOBJS)
   CAMLLIBS=$(OCAMLLIBS)
@@ -426,7 +427,7 @@ fswatch.cmi : ubase/prefs.cmi
 
 $(NAME)$(EXEC_EXT): $(CAMLOBJS) $(COBJS)
 	@echo Linking $@
-	$(CAMLC) -verbose $(CAMLFLAGS) -o $@ $(CFLAGS) $(CAMLLIBS) $^ $(CLIBS)
+	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CFLAGS) $(CAMLLIBS) $^ $(CLIBS)
 
 # Unfortunately -output-obj does not put .o files into the output, only .cmx
 # files, so we have to use $(LD) to take care of COBJS.

--- a/src/fsmonitor/linux/Makefile
+++ b/src/fsmonitor/linux/Makefile
@@ -22,7 +22,7 @@ buildexecutable:: $(FSMONITOR)$(EXEC_EXT)
 
 $(FSMONITOR)$(EXEC_EXT): $(FSMCAMLOBJS) $(FSMCOBJS)
 	@echo Linking $@
-	$(CAMLC) -verbose $(CAMLFLAGS) -o $@ $(CFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
+	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
 
 clean::
 	rm -f $(DIR)/*.cm[iox] $(DIR)/*.o $(DIR)/*~

--- a/src/fsmonitor/windows/Makefile
+++ b/src/fsmonitor/windows/Makefile
@@ -25,7 +25,7 @@ buildexecutable:: $(FSMONITOR)$(EXEC_EXT)
 
 $(FSMONITOR)$(EXEC_EXT): $(FSMCAMLOBJS) $(FSMCOBJS)
 	@echo Linking $@
-	$(CAMLC) -verbose $(CAMLFLAGS) -o $@ $(CFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
+	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
 
 clean::
 	rm -f $(DIR)/*.cm[iox] $(DIR)/*.o $(DIR)/*~


### PR DESCRIPTION
This affects only bytecode compilation.

The -custom option should not be used combined with -c. Moreover, in
Debian, -custom is an alias to -output-complete-exe (since OCaml
4.11.1), which cannot be used combined with -c. Hence, without this
patch, unison fails to build on bytecode-only architectures.