### PR TITLE
Skip user actions after reconciliation in batch mode

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -398,6 +398,7 @@ let interact prilist rilist =
                 if not (Prefs.read Trace.terse) then
                   displayDetails ri
               end;
+              if Prefs.read Globals.batch then next () else
               selectAction
                 (if Prefs.read Globals.batch then Some " " else None)
                 [((if (isConflict dir) && not (Prefs.read Globals.batch)


### PR DESCRIPTION
No change of functionality. With large number of updates, this will reduce unnecessary memory allocation, see https://github.com/bcpierce00/unison/issues/399#issuecomment-710240817.