### PR TITLE
Fix const-related warnings

### DIFF
--- a/src/bytearray.ml
+++ b/src/bytearray.ml
@@ -39,10 +39,10 @@ external unsafe_blit_from_string : string -> int -> t -> int -> int -> unit
   = "ml_blit_string_to_bigarray" [@@noalloc]
 
 external unsafe_blit_from_bytes : bytes -> int -> t -> int -> int -> unit
-  = "ml_blit_string_to_bigarray" [@@noalloc]
+  = "ml_blit_bytes_to_bigarray" [@@noalloc]
 
 external unsafe_blit_to_bytes : t -> int -> bytes -> int -> int -> unit
-  = "ml_blit_bigarray_to_string" [@@noalloc]
+  = "ml_blit_bigarray_to_bytes" [@@noalloc]
 
 let to_string a =
   let l = length a in

--- a/src/bytearray_stubs.c
+++ b/src/bytearray_stubs.c
@@ -19,6 +19,10 @@ CAMLprim value ml_marshal_to_bigarray(value v, value flags)
 
 #define Array_data(a, i) (((char *) a->data) + Long_val(i))
 
+#ifndef Bytes_val
+#define Bytes_val(x) ((unsigned char *) Bp_val(x))
+#endif
+
 
 CAMLprim value ml_unmarshal_from_bigarray(value b, value ofs)
 {
@@ -33,17 +37,26 @@ CAMLprim value ml_unmarshal_from_bigarray(value b, value ofs)
 CAMLprim value ml_blit_string_to_bigarray
 (value s, value i, value a, value j, value l)
 {
-  char *src = String_val(s) + Long_val(i);
+  const char *src = String_val(s) + Long_val(i);
   char *dest = Array_data(Bigarray_val(a), j);
   memcpy(dest, src, Long_val(l));
   return Val_unit;
 }
 
-CAMLprim value ml_blit_bigarray_to_string
+CAMLprim value ml_blit_bytes_to_bigarray
+(value s, value i, value a, value j, value l)
+{
+  char *src = Bytes_val(s) + Long_val(i);
+  char *dest = Array_data(Bigarray_val(a), j);
+  memcpy(dest, src, Long_val(l));
+  return Val_unit;
+}
+
+CAMLprim value ml_blit_bigarray_to_bytes
 (value a, value i, value s, value j, value l)
 {
   char *src = Array_data(Bigarray_val(a), i);
-  char *dest = String_val(s) + Long_val(j);
+  char *dest = Bytes_val(s) + Long_val(j);
   memcpy(dest, src, Long_val(l));
   return Val_unit;
 }

--- a/src/fsmonitor/linux/inotify_stubs.c
+++ b/src/fsmonitor/linux/inotify_stubs.c
@@ -58,7 +58,7 @@ static int inotify_return_table[] = {
 
 static void raise_inotify_error(char const *msg)
 {
-        static value *inotify_err = NULL;
+        static const value *inotify_err = NULL;
         value args[2];
 
         if (!inotify_err)

--- a/src/lwt/lwt_unix_stubs.c
+++ b/src/lwt/lwt_unix_stubs.c
@@ -45,20 +45,33 @@ extern void get_sockaddr (value mladdr,
 
 #define Array_data(a, i) (((char *) a->data) + Long_val(i))
 
+#ifndef Bytes_val
+#define Bytes_val(x) ((unsigned char *) Bp_val(x))
+#endif
+
 CAMLprim value ml_blit_string_to_buffer
 (value s, value i, value a, value j, value l)
 {
-  char *src = String_val(s) + Int_val(i);
+  const char *src = String_val(s) + Int_val(i);
   char *dest = Array_data(Bigarray_val(a), j);
   memcpy(dest, src, Long_val(l));
   return Val_unit;
 }
 
-CAMLprim value ml_blit_buffer_to_string
+CAMLprim value ml_blit_bytes_to_buffer
+(value s, value i, value a, value j, value l)
+{
+  char *src = Bytes_val(s) + Int_val(i);
+  char *dest = Array_data(Bigarray_val(a), j);
+  memcpy(dest, src, Long_val(l));
+  return Val_unit;
+}
+
+CAMLprim value ml_blit_buffer_to_bytes
 (value a, value i, value s, value j, value l)
 {
   char *src = Array_data(Bigarray_val(a), i);
-  char *dest = String_val(s) + Long_val(j);
+  char *dest = Bytes_val(s) + Long_val(j);
   memcpy(dest, src, Long_val(l));
   return Val_unit;
 }

--- a/src/lwt/win/lwt_unix_impl.ml
+++ b/src/lwt/win/lwt_unix_impl.ml
@@ -17,9 +17,9 @@ let buffer_create l = Bigarray.Array1.create Bigarray.char Bigarray.c_layout l
 external unsafe_blit_string_to_buffer :
   string -> int -> buffer -> int -> int -> unit = "ml_blit_string_to_buffer"
 external unsafe_blit_bytes_to_buffer :
-  bytes -> int -> buffer -> int -> int -> unit = "ml_blit_string_to_buffer"
+  bytes -> int -> buffer -> int -> int -> unit = "ml_blit_bytes_to_buffer"
 external unsafe_blit_buffer_to_bytes :
-  buffer -> int -> bytes -> int -> int -> unit = "ml_blit_buffer_to_string"
+  buffer -> int -> bytes -> int -> int -> unit = "ml_blit_buffer_to_bytes"
 
 let buffer_length = Bigarray.Array1.dim
 


### PR DESCRIPTION
This is not technically required for the 2.51.3 release, but fixes something that may be broken with future versions of OCaml (or C) compiler, so it should be merged eventually.