### PR TITLE
Assume documentation strings are in UTF-8

### DIFF
--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -2522,7 +2522,6 @@ let documentation sect =
   ignore (t#event#connect#delete ~callback:(fun _ -> dismiss (); true));
 
   let (name, docstr) = Safelist.assoc sect Strings.docs in
-  let docstr = transcodeDoc docstr in
   let hb = GPack.hbox ~packing:(t#vbox#pack ~expand:false ~padding:2) () in
   let optionmenu =
     GMenu.option_menu ~packing:(hb#pack ~expand:true ~fill:false) () in
@@ -2541,7 +2540,6 @@ let documentation sect =
       if shortname = sect then sect_idx := !idx;
       incr idx;
       let item = GMenu.menu_item ~label:name ~packing:menu#append () in
-      let docstr = transcodeDoc docstr in
       ignore
         (item#connect#activate ~callback:(fun () -> t_text#insert docstr))
     end


### PR DESCRIPTION
This removes calls to transcodeDoc on documentation strings. The
transcodeDoc function transcodes from Windows Codepage 1252 to
Unicode, and assumes that the strings in strings.ml are in the former
encoding. Actually, they are in the encoding of the locale used to
generate strings.ml, which should be UTF-8 on most systems these days
(and was during the preparation of 2.51.3). Therefore, the call to
transcodeDoc is no longer needed.

Without this, the documentation (windows spawned by the "Help" menu)
contains corrupted characters.