### PR TITLE
WIP: GHA: Enable manual build and user-selected make target

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,8 +6,20 @@ env:
   PROJECT_EXES: "unison unison-fsmonitor"
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'OS (e.g. ubuntu-18.04, ubuntu-latest, windows-latest, macos-10.15)'
+        required: false
+      ocaml:
+        description: 'OCaml version (e.g. 4.03.0, 4.11.1)'
+        required: false
+      target:
+        description: 'Make target (e.g. -C src test)'
+        required: false
+        default: 'test'
 
 jobs:
   build:
@@ -163,6 +175,9 @@ jobs:
     - if: runner.os != 'Windows' ## [2020-09] Windows builds fail self-testing
       shell: bash --login --norc --noprofile -e -o pipefail -c "dos2unix '{0}' 2>/dev/null ; source '{0}' ;"
       run: opam exec -- make OSTYPE=$OSTYPE STATIC=${{ steps.vars.outputs.STATIC }} test
+
+    - if: github.event_name == 'workflow_dispatch'
+      run: opam exec -- make ${{ github.event.inputs.target }}
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This PR is for discussion of the concept and for figuring out the details.

This will make it possible to manually trigger CICD build and to optionally enter a freely chosen make target to run after regular build and test targets.

This can be used to manually run ad hoc test targets or the docs target, for example.

Additionally, I was hoping to enable user entry of ad hoc OS and OCaml version (you can see this in the `inputs`) but I could not figure out how to change the job matrix to follow the user input (it is simple in a separate manual build-only workflow). @rivy do you have any suggestions? It may not be that relevant in the end but it seems unnecessary to run the manual make target for all OS-OCaml combinations.

I did not add the line
``` yml
shell: bash --login --norc --noprofile -e -o pipefail -c "dos2unix '{0}' 2>/dev/null ; source '{0}' ;"
```
I don't know if it is needed.