### PR TITLE
Fix incompatible type on 64-bit platforms

### DIFF
--- a/src/bytearray_stubs.c
+++ b/src/bytearray_stubs.c
@@ -10,7 +10,7 @@
 CAMLprim value ml_marshal_to_bigarray(value v, value flags)
 {
   char *buf;
-  long len;
+  intnat len;
   output_value_to_malloc(v, flags, &buf, &len);
   return alloc_bigarray(BIGARRAY_UINT8 | BIGARRAY_C_LAYOUT | BIGARRAY_MANAGED,
                         1, buf, &len);


### PR DESCRIPTION
Fix a type in C stub code which is not the same for OCaml on some 32 and 64-bit platforms. The problem only manifests itself on Windows platforms with MinGW 64-bit compiler. This caused the marshaling code to produce invalid output.

Closes #166 