### PR TITLE
Fix more safe strings-related compiler warnings

### DIFF
--- a/src/bytearray_stubs.c
+++ b/src/bytearray_stubs.c
@@ -46,7 +46,7 @@ CAMLprim value ml_blit_string_to_bigarray
 CAMLprim value ml_blit_bytes_to_bigarray
 (value s, value i, value a, value j, value l)
 {
-  char *src = Bytes_val(s) + Long_val(i);
+  unsigned char *src = Bytes_val(s) + Long_val(i);
   char *dest = Array_data(Bigarray_val(a), j);
   memcpy(dest, src, Long_val(l));
   return Val_unit;
@@ -56,7 +56,7 @@ CAMLprim value ml_blit_bigarray_to_bytes
 (value a, value i, value s, value j, value l)
 {
   char *src = Array_data(Bigarray_val(a), i);
-  char *dest = Bytes_val(s) + Long_val(j);
+  unsigned char *dest = Bytes_val(s) + Long_val(j);
   memcpy(dest, src, Long_val(l));
   return Val_unit;
 }

--- a/src/fsmonitor/windows/shortnames_stubs.c
+++ b/src/fsmonitor/windows/shortnames_stubs.c
@@ -34,7 +34,7 @@ static value copy_wstring(LPCWSTR s)
 
   len = 2 * wcslen(s) + 2;  /* NULL character included */
   res = caml_alloc_string(len);
-  memmove(String_val(res), s, len);
+  memmove((char *)String_val(res), s, len);
   return res;
 }
 

--- a/src/lwt/lwt_unix_stubs.c
+++ b/src/lwt/lwt_unix_stubs.c
@@ -670,7 +670,7 @@ CAMLprim value win_parse_directory_changes (value buf_val) {
     entry = (FILE_NOTIFY_INFORMATION *)pos;
     elt = caml_alloc_tuple(2);
     filename = caml_alloc_string(entry->FileNameLength);
-    memmove(String_val(filename), entry->FileName, entry->FileNameLength);
+    memmove((char *)String_val(filename), entry->FileName, entry->FileNameLength);
     Store_field (elt, 0, filename);
     Store_field (elt, 1, Val_long(entry->Action - 1));
     tmp = caml_alloc_tuple(2);

--- a/src/osxsupport.c
+++ b/src/osxsupport.c
@@ -64,8 +64,8 @@ CAMLprim value getFileInfos (value path, value need_size) {
       unix_error (EINVAL, "getattrlist", path);
   }
 
-  fInfo = alloc_string (32);
-  memcpy (String_val (fInfo), attrBuf.finderInfo, 32);
+  fInfo = caml_alloc_string (32);
+  memcpy ((char *) String_val (fInfo), attrBuf.finderInfo, 32);
   if (Bool_val (need_size))
     length = copy_int64 (attrBuf.rsrcLength);
   else

--- a/src/system/system_win_stubs.c
+++ b/src/system/system_win_stubs.c
@@ -30,7 +30,7 @@ static value copy_wstring(LPCWSTR s)
 
   len = 2 * wcslen(s) + 2;  /* NULL character included */
   res = caml_alloc_string(len);
-  memmove(String_val(res), s, len);
+  memmove((char *)String_val(res), s, len);
   return res;
 }
 


### PR DESCRIPTION
More C code changes related to OCaml safe strings becoming default.