### PR TITLE
Fix self-tests on Windows

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -151,6 +151,9 @@ jobs:
           fi
         done
 
+    - shell: bash --login --norc --noprofile -e -o pipefail -c "dos2unix '{0}' 2>/dev/null ; source '{0}' ;"
+      run: opam exec -- make test
+
     - if: steps.vars.outputs.STATIC != 'true' ## unable to build static gtk for linux or windows/Cygwin MinGW platforms
       shell: bash --login --norc --noprofile -e -o pipefail -c "dos2unix '{0}' 2>/dev/null ; source '{0}' ;"
       run: |
@@ -159,10 +162,6 @@ jobs:
         # * copy only main/first project binary
         project_exe_stem=${PROJECT_EXES%% *}
         cp "src/${project_exe_stem}${{ steps.vars.outputs.EXE_suffix }}" "${{ steps.vars.outputs.PKG_DIR }}/bin/${project_exe_stem}-gtk2${{ steps.vars.outputs.EXE_suffix }}"
-
-    - if: runner.os != 'Windows' ## [2020-09] Windows builds fail self-testing
-      shell: bash --login --norc --noprofile -e -o pipefail -c "dos2unix '{0}' 2>/dev/null ; source '{0}' ;"
-      run: opam exec -- make OSTYPE=$OSTYPE STATIC=${{ steps.vars.outputs.STATIC }} test
 
     - uses: actions/upload-artifact@v2
       with:

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -506,10 +506,11 @@ let promptForRoots getFirstRoot getSecondRoot =
 (* ---- *)
 
 let makeTempDir pattern =
-  let ic = Unix.open_process_in (Printf.sprintf "(mktemp --tmpdir -d %s.XXXXXX || mktemp -d -t %s) 2>/dev/null" pattern pattern) in
-  let path = input_line ic in
-  ignore (Unix.close_process_in ic);
-  path
+  let path = Filename.temp_file pattern "" in
+  let fspath = System.fspathFromString path in
+  System.unlink fspath; (* Remove file created by [temp_file]... *)
+  System.mkdir fspath 0o755; (* ... and create a dir instead. *)
+  path ^ Filename.dir_sep
 
 (* The first time we load preferences, we also read the command line
    arguments; if we re-load prefs (because the user selected a new profile)


### PR DESCRIPTION
Fix self-tests on Windows and enable them in CICD workflow.

I've moved the test step before the gtk2 build as the gtk2 executable on Windows doesn't run on GHA environment with current workflow scripts (can't find required dll-s).