### PR TITLE
Remove unused value Watchercommon.really_write

### DIFF
--- a/src/fsmonitor/watchercommon.ml
+++ b/src/fsmonitor/watchercommon.ml
@@ -101,13 +101,6 @@ let split_on_space s =
 
 let (>>=) = Lwt.bind
 
-let rec really_write o s pos len =
-  Lwt_unix.write o s pos len >>= fun l ->
-  if l = len then
-    Lwt.return ()
-  else
-    really_write o s (pos + l) (len - l)
-
 let rec really_write_substring o s pos len =
   Lwt_unix.write_substring o s pos len >>= fun l ->
   if l = len then

--- a/src/fswatch.ml
+++ b/src/fswatch.ml
@@ -81,13 +81,6 @@ let debugverbose = Trace.debug "fswatch+"
 
 let (>>=) = Lwt.bind
 
-let rec really_write o s pos len =
-  Lwt_unix.write o s pos len >>= fun l ->
-  if l = len then
-    Lwt.return ()
-  else
-    really_write o s (pos + l) (len - l)
-
 let rec really_write_substring o s pos len =
   Lwt_unix.write_substring o s pos len >>= fun l ->
   if l = len then


### PR DESCRIPTION
Found from a warning when building with dune