### PR TITLE
Always commit archive updates

### DIFF
--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -3378,14 +3378,14 @@ lst_store#set ~row ~column:c_path path;
     let (reconItemList, thereAreEqualUpdates, dangerousPaths) =
       reconcile (findUpdates ()) in
     if not !Update.foundArchives then commitUpdates ();
-    if reconItemList = [] then
-      if thereAreEqualUpdates then begin
-        if !Update.foundArchives then commitUpdates ();
+    if reconItemList = [] then begin
+      if !Update.foundArchives then commitUpdates ();
+      if thereAreEqualUpdates then
         Trace.status
           "Replicas have been changed only in identical ways since last sync"
-      end else
+      else
         Trace.status "Everything is up to date"
-    else
+    end else
       Trace.status "Check and/or adjust selected actions; then press Go";
     theState :=
       Array.of_list

--- a/src/uimacbridgenew.ml
+++ b/src/uimacbridgenew.ml
@@ -365,14 +365,14 @@ let do_unisonInit2 () =
   let (reconItemList, thereAreEqualUpdates, dangerousPaths) =
     reconcile (findUpdates ()) in
   if not !Update.foundArchives then commitUpdates ();
-  if reconItemList = [] then
-    if thereAreEqualUpdates then begin
-      if !Update.foundArchives then commitUpdates ();
+  if reconItemList = [] then begin
+    if !Update.foundArchives then commitUpdates ();
+    if thereAreEqualUpdates then
       Trace.status
         "Replicas have been changed only in identical ways since last sync"
-    end else
+    else
       Trace.status "Everything is up to date"
-  else
+  end else
     Trace.status "Check and/or adjust selected actions; then press Go";
   Trace.status (Printf.sprintf "There are %d reconitems" (Safelist.length reconItemList));
   let stateItemList =

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -914,7 +914,6 @@ let rec interactAndPropagateChanges prevItemList reconItemList
         (fun p -> alwaysDisplayAndLog ("  failed: " ^ (Path.toString p)))
         failedPaths;
     (skipped > 0, partials > 0, failures > 0, failedPaths) in
-  if not !Update.foundArchives then Update.commitUpdates ();
   if updatesToDo = 0 then begin
     (* BCP (3/09): We need to commit the archives even if there are
        no updates to propagate because some files (in fact, if we've
@@ -1060,7 +1059,10 @@ let synchronizeOnce ?wantWatcher ?skipRecentFiles pathsOpt =
   let (reconItemList, anyEqualUpdates, dangerousPaths) =
     Recon.reconcileAll ~allowPartial:true updates in
 
+  if not !Update.foundArchives then Update.commitUpdates ();
   if reconItemList = [] then begin
+    if !Update.foundArchives && Prefs.read Uicommon.repeat = "" then
+      Update.commitUpdates ();
     (if anyEqualUpdates then
       Trace.status ("Nothing to do: replicas have been changed only "
                     ^ "in identical ways since last sync.")


### PR DESCRIPTION
### Description

Unison uses files' mtime for fast update detection (among other checks). This means that mtime is stored in archive even if the value itself is not synchronized.

As mtime can have changed without file contents or other synchronized properties having changed compared to the archive (or between replicas), it is beneficial to record all updated mtimes in the archive also when there were no updates synchronized. This will speed up update detection the next time.
This is also mentioned in this comment in the current code:
``` ocaml
    (* BCP (3/09): We need to commit the archives even if there are
       no updates to propagate because some files (in fact, if we've
       just switched to DST on windows, a LOT of files) might have new
       modtimes in the archive. *)
```

The current code thus already includes calls to commit archives even with no updates to propagate. But current code misses some cases. In text UI it misses cases where replicas have changed in equal way (this case is covered in gtk2 and mac UIs). All UIs miss case when there were no updates detected at all. It is important to know that "no update" here means that file contents has not changed and synchronized properties have not changed. But mtime could have changed nevertheless (either file contents changed and reverted back, or non-synchronized properties changed).

Additionally, all UIs have the following check
``` ocaml
if not !Update.foundArchives then Update.commitUpdates ();
```
but while GUIs include it in a common code path, text UI included this only in updates-detected code path. This is now moved to common code path.

All UIs are now consistent in this logic.

### Why is this important?

In (probably vast) majority of cases, I don't expect that merging this change will have a tangible impact (at least on POSIX platforms). Merging the change might make update detection faster in some cases (where there are a lot of changes that don't result in synchronizable updates; or where mtime of large files has changed without contents changing).

This change can be considered a bug fix but it is also done in preparation of another change coming later which will introduce using ctime for fast update detection of extended file metadata. Some metadata that is not directly available via POSIX stat function can be relatively time consuming to extract. ctime can then be used for metadata the same way as mtime is currently used for file contents update detection.