### PR TITLE
Make logfile default location .unison rather than $HOME

### DIFF
--- a/src/fswatchold.ml
+++ b/src/fswatchold.ml
@@ -25,7 +25,7 @@ let debug = Util.debug "fswatch"
 
 let watchinterval = 5
 
-let watcherTemp archHash n = Os.fileInUnisonDir (n ^ archHash)
+let watcherTemp archHash n = Util.fileInUnisonDir (n ^ archHash)
 
 let watchercmd archHash root =
   let fsmonfile =

--- a/src/main.ml
+++ b/src/main.ml
@@ -191,12 +191,6 @@ let init () = begin
     exit 0
   with Not_found -> () end;
 
-  (* Install an appropriate function for finding preference files.  (We put
-     this here just because the Prefs module lives below the Os module in the
-     dependency hierarchy, so Prefs can't call Os directly.) *)
-  Util.supplyFileInUnisonDirFn
-    (fun n -> Os.fileInUnisonDir(n));
-
   (* Start a server if requested *)
   if Util.StringMap.mem serverPrefName argv then begin
     catch_all (fun () ->

--- a/src/os.ml
+++ b/src/os.ml
@@ -305,19 +305,10 @@ let fullfingerprintEqual (fp, rfp) (fp', rfp') =
 
 (* Gives the fspath of the archive directory on the machine, depending on    *)
 (* which OS we use                                                           *)
-let unisonDir =
-  try
-    System.fspathFromString (System.getenv "UNISON")
-  with Not_found ->
-    let genericName =
-      Util.fileInHomeDir (Printf.sprintf ".%s" Uutil.myName) in
-    if Osx.isMacOSX && not (System.file_exists genericName) then
-      Util.fileInHomeDir "Library/Application Support/Unison"
-    else
-      genericName
+let unisonDir = Util.unisonDir
 
 (* build a fspath representing an archive child path whose name is given     *)
-let fileInUnisonDir str = System.fspathConcat unisonDir str
+let fileInUnisonDir = Util.fileInUnisonDir
 
 (* Make sure archive directory exists                                        *)
 let createUnisonDir() =

--- a/src/os.ml
+++ b/src/os.ml
@@ -303,22 +303,15 @@ let fullfingerprintEqual (fp, rfp) (fp', rfp') =
 (*                           UNISON DIRECTORY                                *)
 (*****************************************************************************)
 
-(* Gives the fspath of the archive directory on the machine, depending on    *)
-(* which OS we use                                                           *)
-let unisonDir = Util.unisonDir
-
-(* build a fspath representing an archive child path whose name is given     *)
-let fileInUnisonDir = Util.fileInUnisonDir
-
 (* Make sure archive directory exists                                        *)
 let createUnisonDir() =
-  try ignore (System.stat unisonDir)
+  try ignore (System.stat Util.unisonDir)
   with Unix.Unix_error(_) ->
     Util.convertUnixErrorsToFatal
       (Printf.sprintf "creating unison directory %s"
-         (System.fspathToPrintString unisonDir))
+         (System.fspathToPrintString Util.unisonDir))
       (fun () ->
-         ignore (System.mkdir unisonDir 0o700))
+         ignore (System.mkdir Util.unisonDir 0o700))
 
 (*****************************************************************************)
 (*                           TEMPORARY FILES                                 *)

--- a/src/os.mli
+++ b/src/os.mli
@@ -11,8 +11,6 @@ val includeInTempNames : string -> unit
 val exists : Fspath.t -> Path.local -> bool
 
 val createUnisonDir : unit -> unit
-val fileInUnisonDir : string -> System.fspath
-val unisonDir : System.fspath
 
 val childrenOf : Fspath.t -> Path.local -> Name.t list
 val readLink : Fspath.t -> Path.local -> string

--- a/src/stasher.ml
+++ b/src/stasher.ml
@@ -139,7 +139,7 @@ let backupDirectory () =
         if Prefs.read backupdir <> ""
         then Fspath.canonize (Some (Prefs.read backupdir))
         else Fspath.canonize
-               (Some (System.fspathToString (Os.fileInUnisonDir "backup"))))
+               (Some (System.fspathToString (Util.fileInUnisonDir "backup"))))
 
 let backupcurrent =
   Pred.create "backupcurr" ~advanced:true

--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -113,10 +113,10 @@ let logging =
 
 let logfile =
   Prefs.createFspath "logfile"
-    (Util.fileInHomeDir "unison.log")
+    (Util.fileInUnisonDir "unison.log")
     "!logfile name"
     "By default, logging messages will be appended to the file
-     \\verb|unison.log| in your HOME directory.  Set this preference if
+     \\verb|unison.log| in your .unison directory.  Set this preference if
      you prefer another file.  It can be a path relative to your HOME directory.
      Sending SIGUSR1 will close the logfile; the logfile will be re-opened (and
      created, if needed) automatically, to allow for log rotation."

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -493,7 +493,7 @@ let fileMaybeRelToHomeDir n =
   else System.fspathFromString n
 
 (*****************************************************************************)
-(*           "Upcall" for building pathnames in the .unison dir              *)
+(*                       .unison dir                                         *)
 (*****************************************************************************)
 
 external isMacOSXPred : unit -> bool = "isMacOSX"

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -496,11 +496,19 @@ let fileMaybeRelToHomeDir n =
 (*           "Upcall" for building pathnames in the .unison dir              *)
 (*****************************************************************************)
 
-let fileInUnisonDirFn = ref None
+external isMacOSXPred : unit -> bool = "isMacOSX"
 
-let supplyFileInUnisonDirFn f = fileInUnisonDirFn := Some(f)
+let isMacOSX = isMacOSXPred ()
 
-let fileInUnisonDir n =
-   match !fileInUnisonDirFn with
-     None -> assert false
-   | Some(f) -> f n
+let unisonDir =
+  try
+    System.fspathFromString (System.getenv "UNISON")
+  with Not_found ->
+    let genericName =
+      fileInHomeDir (Printf.sprintf ".%s" ProjectInfo.myName) in
+    if isMacOSX && not (System.file_exists genericName) then
+      fileInHomeDir "Library/Application Support/Unison"
+    else
+      genericName
+
+let fileInUnisonDir str = System.fspathConcat unisonDir str

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -103,7 +103,11 @@ val debug : string -> (unit->unit) -> unit
 val warnPrinter : (string -> unit) option ref
 val warn : string -> unit
 
+(* Gives the fspath of the archive directory on the machine, depending on    *)
+(* which OS we use                                                           *)
 val unisonDir : System.fspath
+
+(* build a fspath representing an archive child path whose name is given     *)
 val fileInUnisonDir : string -> System.fspath
 
 (* Printing and formatting functions *)

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -103,10 +103,7 @@ val debug : string -> (unit->unit) -> unit
 val warnPrinter : (string -> unit) option ref
 val warn : string -> unit
 
-(* Someone should supply a function here that will convert a simple filename
-   to a filename in the unison directory *)
-val supplyFileInUnisonDirFn : (string -> System.fspath) -> unit
-(* Use it like this: *)
+val unisonDir : System.fspath
 val fileInUnisonDir : string -> System.fspath
 
 (* Printing and formatting functions *)

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -546,7 +546,7 @@ let scanProfiles () =
           (f, info))
        (Safelist.filter (fun name -> not (   Util.startswith name ".#"
                                           || Util.startswith name Os.tempFilePrefix))
-          (Files.ls Os.unisonDir "*.prf")))
+          (Files.ls Util.unisonDir "*.prf")))
 
 (* ---- *)
 

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -19,7 +19,7 @@ type stateItem = { mutable ri : reconItem;
 let theState = ref [| |];;
 let unsynchronizedPaths = ref None;;
 
-let unisonDirectory() = System.fspathToPrintString Os.unisonDir
+let unisonDirectory() = System.fspathToPrintString Util.unisonDir
 ;;
 Callback.register "unisonDirectory" unisonDirectory;;
 

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -58,11 +58,6 @@ Callback.register "unisonGetVersion" unisonGetVersion;;
 (* Returns a string option: command line profile, if any *)
 let unisonInit0() =
   ignore (Gc.set {(Gc.get ()) with Gc.max_overhead = 150});
-  (* Install an appropriate function for finding preference files.  (We put
-     this in Util just because the Prefs module lives below the Os module in the
-     dependency hierarchy, so Prefs can't call Os directly.) *)
-  Util.supplyFileInUnisonDirFn
-    (fun n -> Os.fileInUnisonDir(n));
   (* Display status in GUI instead of on stderr *)
   let formatStatus major minor = (Util.padto 30 (major ^ "  ")) ^ minor in
   Trace.messageDisplayer := displayStatus;

--- a/src/uimacbridgenew.ml
+++ b/src/uimacbridgenew.ml
@@ -20,7 +20,7 @@ type stateItem = { mutable ri : reconItem;
 let theState = ref [| |];;
 let unsynchronizedPaths = ref None;;
 
-let unisonDirectory() = System.fspathToString Os.unisonDir
+let unisonDirectory() = System.fspathToString Util.unisonDir
 ;;
 Callback.register "unisonDirectory" unisonDirectory;;
 

--- a/src/uimacbridgenew.ml
+++ b/src/uimacbridgenew.ml
@@ -142,11 +142,6 @@ Callback.register "unisonGetVersion" unisonGetVersion;;
 (* Returns a string option: command line profile, if any *)
 let unisonInit0() =
   ignore (Gc.set {(Gc.get ()) with Gc.max_overhead = 150});
-  (* Install an appropriate function for finding preference files.  (We put
-     this in Util just because the Prefs module lives below the Os module in the
-     dependency hierarchy, so Prefs can't call Os directly.) *)
-  Util.supplyFileInUnisonDirFn
-    (fun n -> Os.fileInUnisonDir(n));
   (* Display status in GUI instead of on stderr *)
   let formatStatus major minor = (Util.padto 30 (major ^ "  ")) ^ minor in
   Trace.messageDisplayer := displayStatus;

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1225,7 +1225,7 @@ let getProfile default =
     Trace.log (Format.sprintf "You have too many profiles in %s \
                 for interactive selection. Please specify profile \
                 or roots on command line.\n"
-                (System.fspathToPrintString Os.unisonDir));
+                (System.fspathToPrintString Util.unisonDir));
     Trace.log "The profile names are:\n";
     Safelist.iter (fun (p, _) -> Trace.log (Format.sprintf "  %s\n" p))
       !Uicommon.profilesAndRoots;


### PR DESCRIPTION
Addresses #318

Accessing the unison directory was not initially possible from ubase/trace.ml—where
the logfile preference is defined—because unisonDir was defined in Os. Currently,
to access the unison directory from Util, Util defines a function reference where top-level
modules supply Os.fileInUnisonDir to it (via Util.supplyFileInUnisonDirFn).

Instead of moving the logfile preference from trace.ml to some module above ubase,
this PR moves the definition of Os.unisonDir and Os.fileInUnisonDir to Util. This has the
added benefit of being able to delete three existing duplicated calls to
Util.supplyFileInUnisonDirFn. The unisonDir and fileInUnisonDir values now reference
those in Util.