### PR TITLE
Fix Makefile printing the wrong compiler

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -427,7 +427,7 @@ fswatch.cmi : ubase/prefs.cmi
 	$(OCAMLOPT) $(CAMLFLAGS) -c $(CWD)/$<
 
 %.o %.obj: %.c
-	@echo "$(OCAMLOPT): $< ---> $@"
+	@echo "$(CAMLC): $< ---> $@"
 	$(CAMLC) $(CAMLFLAGS) -ccopt $(OUTPUT_SEL)$(CWD)/$@ -c $(CWD)/$<
 
 $(NAME)$(EXEC_EXT): $(CAMLOBJS) $(COBJS)


### PR DESCRIPTION
In one of its targets, Makefile.OCaml would always print usage of ocamlopt when ocamlc could be in use.