### PR TITLE
[RFC] CICD: Initialize opam with requested OCaml version

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -92,6 +92,8 @@ jobs:
         mkdir -p '${{ steps.vars.outputs.STAGING_DIR }}'
         mkdir -p '${{ steps.vars.outputs.PKG_DIR }}'
         mkdir -p '${{ steps.vars.outputs.PKG_DIR }}'/bin
+        # initial opam config
+        echo "default-compiler: \"ocaml-system\" { = \"${{ steps.vars.outputs.OCAML_VARIANT }}\" } | \"ocaml-base-compiler\" { = \"${{ steps.vars.outputs.OCAML_VARIANT }}\" }" > ~/.opamrc
 
     - name: Enable/config MSVC environment (if/when needed)
       uses: ilammy/msvc-dev-cmd@v1.3.0

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -106,7 +106,7 @@ jobs:
       id: cache-opam
       with:
         path: ~/.opam
-        key: v1-${{ matrix.job.os }}-opam-${{ matrix.job.ocaml-version }}
+        key: v2-${{ matrix.job.os }}-opam-${{ matrix.job.ocaml-version }}
 
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
       uses: CICD-tools/ghactions-ocaml.toolchain@dev


### PR DESCRIPTION
This PR is intended for discussion.

There is exactly one benefit from this change, and that is conservation of resources by not having to compile an entire ocaml compiler twice and by halving the size of opam cache that needs to be compressed/decompressed, stored and uploaded/downloaded.

I would argue that this change belongs upstream in the action that sets up OCaml in GHA but I don't know how that action works (and I don't know how the Windows setup works). @rivy you can possibly help here.

Incidentally, this change did uncover an issue with OCaml < 4.06 (this is what you see as the failed run). It is fixed since 4.06 by https://github.com/ocaml/ocaml/commit/adcb4497968dbdc1b0db97998488ad20c02fe225#diff-d8b9301c9b040433303c891069704b2eff356f3b6d1756ff2d9b761192f05a16

### Background

OCaml compiler in GHA workflow is set up with opam, but this commonly includes an unnecessary step of building an entire ocaml compiler twice. First, opam init will use the system ocaml compiler, or if that is lacking, build the latest ocaml release. Then, opam switch will build the requested version of ocaml compiler.

This PR creates an opam configuration file indicating default-compiler with requested OCaml version. Setting default opam configuration instructs opam to use the correct version of ocaml compiler already during opam init, thereby skipping the building step during opam switch.