### PR TITLE
prevent collapsed toolbar on Big Sur

### DIFF
--- a/src/uimac/English.lproj/MainMenu.xib
+++ b/src/uimac/English.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
                 <outlet property="delegate" destination="209" id="571"/>
             </connections>
         </customObject>
-        <window title="Unison" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="mainWindow" animationBehavior="default" id="21" userLabel="Window">
+        <window title="Unison" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="mainWindow" animationBehavior="default" toolbarStyle="expanded" id="21" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="0.0" y="364" width="480" height="360"/>


### PR DESCRIPTION
MacOS Big Sur features a new toolbar design, where the window title gets inlined as the leftmost toolbar item. This causes window layout issues with the Unison macOS app, because the window sizes and toolbar button arrangements only work well for the pre-Big-Sur toolbar style.

This change will configure toolbars to always use the pre-Big-Sur style. I have tested on Big Sur and it works well there. I have **not** tested on previous macOS versions, since I no longer have access to any. The CI run seems to be unaffected by this change when building for macOS 10.15.