### PR TITLE
uimac: Disable Xcode cross-compiling for other archs

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -178,6 +178,7 @@ endif
 MINOSXVERSION=10.6
 ifeq ($(OSARCH),osx)
   CAMLFLAGS+=-ccopt -mmacosx-version-min=$(MINOSXVERSION)
+  XCODEFLAGS=-arch $(shell uname -m)
 endif
 
 .PHONY: macexecutable


### PR DESCRIPTION
GHA has upgraded the default Xcode version and while GHA build environments are x86_64, the new Xcode attemps to cross-compile for the new M1 (arm64).

Disable cross-compilation as it will fail due to OCaml code not being cross-compiled. This will remove CICD errors you've been seeing lately. I don't know if this is the correct approach but it seems to get the job done.