### PR TITLE
Add new directories as 'unchanged'

### DIFF
--- a/src/update.ml
+++ b/src/update.ml
@@ -1696,8 +1696,15 @@ and buildUpdateRec archive currfspath path scanInfo =
         let (newChildren, childUpdates, _, _) =
           buildUpdateChildren
             currfspath path NameMap.empty false scanInfo in
+        (* Set the unchanged flag on directory after scanning the children.
+           This makes updates scanning faster the next time if there are no
+           changes. *)
+        let inode =
+          match Fileinfo.stamp info with Fileinfo.InodeStamp i -> i | _ -> 0 in
+        let desc, _ =
+          Props.setDirChangeFlag info.Fileinfo.desc scanInfo.dirStamp inode in
         (None,
-         Updates (Dir (info.Fileinfo.desc, childUpdates, PropsUpdated, false),
+         Updates (Dir (desc, childUpdates, PropsUpdated, false),
                   oldInfoOf archive))
   with
     Util.Transient(s) -> None, Error(s)


### PR DESCRIPTION
Currently, after synchronizing a newly added directory, it is always treated as 'changed' during the next updates scanning, even if there are no changes. This is not an issue but presents a small optimization opportunity.

Synchronizing newly added directories as 'unchanged' (as they are just synchronized, they are unchanged in terms of the archive) will allow more efficient updates scanning the next time. This applies also to the roots.

It is only a minor optimization as the effects are seen only at the first scan after synchronizing a new directory and even then only if the directory is actually unchanged since previous synchronization. Even though the opportunities for this change to make a difference in real usage scenarios are very few, it does have a measurable impact. With my test cases, the time to scan updates was reduced by 20% and memory usage was reduced by a third. Since I have been running a lot of tests for some other code changes, this change took away quite a nuisance.

As far as I can tell, and as confirmed by my tests, this change does not break functional logic. That is, it will not miss updates. This same result would be achieved by running Unison twice, which is why I believe it to be correct.