### PR TITLE
Makefile: Self-tests must be run with text UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ text:
 	$(MAKE) -C src UISTYLE=text
 
 test:
-	./src/unison -selftest
+	./src/unison -ui text -selftest
 
 all: src
 


### PR DESCRIPTION
This has been causing trouble before.
Self-tests don't work with a GUI and this causes 'make test' to fail. Adding '-ui text' will force running the text UI even with a GUI binary.

Closes #350 