### PR TITLE
Store all working files in UNISON dir

### DIFF
--- a/src/files.ml
+++ b/src/files.ml
@@ -25,7 +25,7 @@ let debugverbose = Trace.debug "files+"
 
 (* ------------------------------------------------------------ *)
 
-let commitLogName = Util.fileInHomeDir "DANGER.README"
+let commitLogName = Util.fileInUnisonDir "DANGER.README"
 
 let writeCommitLog source target tempname =
   let sourcename = Fspath.toDebugString source in
@@ -49,7 +49,7 @@ let writeCommitLog source target tempname =
 let clearCommitLog pathTo =
   debug (fun() -> (Util.msg "Deleting commit log\n"));
 
-  let tmpPathDir = Fspath.canonize (Some Util.homeDirStr) in  (* tmpPathDir is a Fspath.t *)
+  let tmpPathDir = Fspath.canonize (Some Util.unisonDirStr) in  (* tmpPathDir is a Fspath.t *)
   (* Use pathTo in the temporary name (instead of DANGER.README) to reduce chance of reuse *)
   let tmpPath = Os.tempPath tmpPathDir pathTo in  (* tmpPath is a Path.local *)
   let dangerFspath = Fspath.canonize (Some (System.fspathToString commitLogName)) in

--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -113,11 +113,11 @@ let logging =
 
 let logfile =
   Prefs.createFspath "logfile"
-    (Util.fileInUnisonDir "unison.log")
+    (System.fspathFromString "unison.log")
     "!logfile name"
     "By default, logging messages will be appended to the file
      \\verb|unison.log| in your .unison directory.  Set this preference if
-     you prefer another file.  It can be a path relative to your HOME directory.
+     you prefer another file.  It can be a path relative to your .unison directory.
      Sending SIGUSR1 will close the logfile; the logfile will be re-opened (and
      created, if needed) automatically, to allow for log rotation."
 
@@ -143,7 +143,7 @@ let rec getLogch() =
   match !logch with
     None ->
       let prefstr = System.fspathToString (Prefs.read logfile) in
-      let file = Util.fileMaybeRelToHomeDir prefstr in
+      let file = Util.fileMaybeRelToUnisonDir prefstr in
       let ch =
         System.open_out_gen [Open_wronly; Open_creat; Open_append] 0o600 file in
       logch := Some (ch, file);

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -487,11 +487,6 @@ let homeDir () =
 
 let fileInHomeDir n = System.fspathConcat (homeDir ()) n
 
-let fileMaybeRelToHomeDir n =
-  if Filename.is_relative n
-  then fileInHomeDir n
-  else System.fspathFromString n
-
 (*****************************************************************************)
 (*                       .unison dir                                         *)
 (*****************************************************************************)
@@ -511,4 +506,11 @@ let unisonDir =
     else
       genericName
 
+let unisonDirStr = System.fspathToString unisonDir
+
 let fileInUnisonDir str = System.fspathConcat unisonDir str
+
+let fileMaybeRelToUnisonDir n =
+  if Filename.is_relative n
+  then fileInUnisonDir n
+  else System.fspathFromString n

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -83,9 +83,6 @@ val percentageOfTotal :
   int        (* percentage of total *)
 val monthname : int -> string
 val percent2string : float -> string
-val fileInHomeDir : string -> System.fspath
-val fileMaybeRelToHomeDir : string -> System.fspath
-val homeDirStr : string
 
 (* Just like the versions in the Unix module, but raising Transient
    instead of Unix_error *)
@@ -109,6 +106,8 @@ val unisonDir : System.fspath
 
 (* build a fspath representing an archive child path whose name is given     *)
 val fileInUnisonDir : string -> System.fspath
+val fileMaybeRelToUnisonDir : string -> System.fspath
+val unisonDirStr : string
 
 (* Printing and formatting functions *)
 

--- a/src/update.ml
+++ b/src/update.ml
@@ -519,7 +519,7 @@ let rec showArchive = function
 let dumpArchiveLocal (fspath,()) =
   let (name, root) = archiveName fspath MainArch in
   let archive = getArchive root in
-  let f = Util.fileInHomeDir "unison.dump" in
+  let f = Util.fileInUnisonDir "unison.dump" in
   debug (fun () -> Printf.eprintf "Dumping archive into `%s'\n"
                      (System.fspathToDebugString f));
   let ch = System.open_out_gen [Open_wronly; Open_creat; Open_trunc] 0o600 f in


### PR DESCRIPTION
This is a follow-up to #436 which moved the log file default location to UNISON dir. This PR moves all working files to UNISON dir.
Incidentally closes #463 even though the separate question of allowing relative paths is still open.