### PR TITLE
Properly skip empty output from ssh

### DIFF
--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -230,7 +230,7 @@ let rec termInput fdTerm fdInput =
       Lwt.return None
     else
       let query = Bytes.sub_string buf 0 len in
-      if query = "\r\n" then
+      if query = "\r\n" || query = "\n" || query = "\r" then
         readPrompt ()
       else
         Lwt.return (Some query)
@@ -252,7 +252,7 @@ let handlePasswordRequests fdTerm callback =
         Lwt.return ()
       else
         let query = Bytes.sub_string buf 0 len in
-        if query = "\r\n" then
+        if query = "\r\n" || query = "\n" || query = "\r" then
           loop ()
         else begin
           let response = callback query in

--- a/src/uimac/MyController.m
+++ b/src/uimac/MyController.m
@@ -478,8 +478,10 @@ CAMLprim value unisonInit1Complete(value v)
             return;
         }
     }
-    NSLog(@"Unrecognized message from ssh: %@",prompt);
+    NSLog(@"Unrecognized message from ssh: '%@'",prompt);
         ocamlCall("x@", "openConnectionCancel", preconn);
+    NSRunAlertPanel(@"Connection Error", @"Unrecognized message from ssh: '%@'", @"OK", nil, nil, prompt);
+    [self chooseProfiles];
 }
 
 // The password window will invoke this when Enter occurs, b/c we


### PR DESCRIPTION
Fixes #328
The first commit fixes the origin of unrecognized prompt from ssh. The second commit fixes the GUI hanging due to the unrecognized prompt.