### PR TITLE
Disable ANSI color output by default on Windows

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -106,7 +106,7 @@ let setColorPreference () =
     match Prefs.read colorMode with
     | `True    -> true
     | `False   -> false
-    | `Default -> colorOk
+    | `Default -> colorOk && Sys.os_type <> "Win32"
 
 let color t =
   if not !colorEnabled then "" else


### PR DESCRIPTION
It turns out that ANSI color support in Windows is... a complex matter.
Disable default color output on Windows.