### PR TITLE
Get correct ctime in Windows

### DIFF
--- a/src/fs.ml
+++ b/src/fs.ml
@@ -69,5 +69,6 @@ let fingerprint f = System.fingerprint (Fspath.toString f)
 
 let canSetTime f = System.canSetTime (Fspath.toString f)
 let hasInodeNumbers () = System.hasInodeNumbers ()
+let hasCorrectCTime = System.hasCorrectCTime
 
 let setUnicodeEncoding = System.setUnicodeEncoding

--- a/src/system/system_generic.ml
+++ b/src/system/system_generic.ml
@@ -93,6 +93,13 @@ let canSetTime f =
    have access to the lower 32 bits on 32bit systems... *)
 let hasInodeNumbers () = isNotWindows
 
+(* Cygwin can apparently provide correct ctime.
+ *
+ * With current OCaml Unix library, ctime is not correct on Win32.
+ * This can change in future, in which case [hasCorrectCTime] should
+ * be made dependent on OCaml version. *)
+let hasCorrectCTime = isNotWindows
+
 (****)
 
 type terminalStateFunctions =

--- a/src/system/system_intf.ml
+++ b/src/system/system_intf.ml
@@ -47,6 +47,13 @@ val fingerprint : fspath -> Digest.t
 val canSetTime : fspath -> bool
 val hasInodeNumbers : unit -> bool
 
+(* [hasCorrectCTime] is true when [stat] and [lstat] return the status change
+ * time. This is commonly broken on Windows, where creation time (completely
+ * unrelated to ctime; it is the birthtime) is returned instead. However, it
+ * is possible to get the correct status change time on Windows, which is why
+ * [hasCorrectCTime] can have a different value on different systems. *)
+val hasCorrectCTime : bool
+
 end
 
 module type Full = sig

--- a/src/system/system_win.ml
+++ b/src/system/system_win.ml
@@ -313,6 +313,10 @@ let canSetTime f = true
    number of "a". *)
 let hasInodeNumbers () = true
 
+external hasCorrectCTime_impl : unit -> bool = "win_has_correct_ctime"
+
+let hasCorrectCTime = hasCorrectCTime_impl ()
+
 (****)
 
 external getConsoleMode : unit -> int = "win_get_console_mode"

--- a/src/system/win/system_impl.ml
+++ b/src/system/win/system_impl.ml
@@ -60,4 +60,5 @@ module Fs = struct
 
   let canSetTime v = c1 W.canSetTime G.canSetTime v
   let hasInodeNumbers v = c1 W.hasInodeNumbers G.hasInodeNumbers v
+  let hasCorrectCTime = if !unicode then W.hasCorrectCTime else G.hasCorrectCTime
 end


### PR DESCRIPTION
Standard Win32 API functions do not provide the status change time (ctime) of files and directories. A common substitute is to provide creation time, which is actually btime (and not available in the traditional POSIX stat interface) and is not usable as ctime.

On some filesystems, it is possible to get the real ctime using Windows syscalls via the Native API. Using Native API is a bit tricky, though. Native API header files (for non-driver development?) are not available, so relevant type definitions and function prototypes must be included in your own code. Further, the functions are not (easily?) available for build-time linking and must be dynamically linked at runtime.
This approach also ensures compatibility with other compilers, like Mingw.

This patch borrows code from libuv to get the definitions and prototypes and do the runtime linking.

If the Native API function `NtQueryInformationFile` is available then this patch will use it, making correct ctime available in OCaml code, else it will fall back to Win32 API. The fallback is to using creation time, which is not a suitable alternative to ctime in any way. This is only done for compatibiltiy with the previous code.

For file times, the previous code using Win32 API discarded fractions of a second (not sure if this has been intentional). This patch does not change that and uses the same time conversion formulas as is.

Getting correct ctime is not particularly interesting by itself. I am soon adding Windows code to ACL synchronization PR and then the ctime will provide actual value. Nevertheless, this code is not directly related to ACL synchronization and could be of general value.

**About licensing**

This PR includes code borrowed from libuv (MIT license). The borrowed code is not in any way specific to libuv or modified for libuv use, and the same code is also present in for example Wine (LGPLv2.1+), ReactOS (GPLv2), Cygwin (LGPLv3+), and probably elsewhere.