### PR TITLE
Revert "Add new directories as 'unchanged'"

### DIFF
--- a/src/update.ml
+++ b/src/update.ml
@@ -1696,15 +1696,8 @@ and buildUpdateRec archive currfspath path scanInfo =
         let (newChildren, childUpdates, _, _) =
           buildUpdateChildren
             currfspath path NameMap.empty false scanInfo in
-        (* Set the unchanged flag on directory after scanning the children.
-           This makes updates scanning faster the next time if there are no
-           changes. *)
-        let inode =
-          match Fileinfo.stamp info with Fileinfo.InodeStamp i -> i | _ -> 0 in
-        let desc, _ =
-          Props.setDirChangeFlag info.Fileinfo.desc scanInfo.dirStamp inode in
         (None,
-         Updates (Dir (desc, childUpdates, PropsUpdated, false),
+         Updates (Dir (info.Fileinfo.desc, childUpdates, PropsUpdated, false),
                   oldInfoOf archive))
   with
     Util.Transient(s) -> None, Error(s)


### PR DESCRIPTION
Revert change from #450 

The change did break functional logic after all. The thinking was flawed -- directories were marked 'unchanged' at the updates detection phase, but this missed that synchronization of directories is not always atomic; it can be partial.

This would normally never be the case for new directories within roots. But this can happen in the case where the new directory is simultaneously detected in both roots (or, in case of roots, both roots exist at initial sync). In that case, some of the children can be synced and some could be skipped, resulting in partial sync of the directory. If the directory was now (incorrectly) marked 'unchanged', the skipped children would no longer be detected as 'updates' on the next run, until there were other updates which trigger a new scan of the directory.

This reverts commit 6517b4f545bbb70267976e4921d50e08fd179c2b.