### PR TITLE
fsmonitor: Fix symlink follow semantics

### DIFF
--- a/src/fsmonitor/linux/watcher.ml
+++ b/src/fsmonitor/linux/watcher.ml
@@ -220,9 +220,13 @@ let release_watch file =
 let selected_events =
   Inotify.([S_Attrib; S_Modify; S_Delete_self; S_Move_self;
             S_Create; S_Delete; S_Modify; S_Moved_from; S_Moved_to])
+let selected_events_nofollow = Inotify.S_Dont_follow :: selected_events
 
-let add_watch path file =
+let add_watch path file follow =
   try
+    let selected_events =
+      if follow then selected_events
+      else selected_events_nofollow in
     let id = Lwt_inotify.add_watch st path selected_events in
     begin match get_watch file with
       Some id' when id = id' ->

--- a/src/fsmonitor/watchercommon.ml
+++ b/src/fsmonitor/watchercommon.ml
@@ -366,7 +366,7 @@ let signal_overflow () =
 (****)
 
 module type S = sig
-  val add_watch : string -> t -> unit
+  val add_watch : string -> t -> bool -> unit
   val release_watch : t -> unit
   val watch : unit -> unit
   val clear_event_memory : unit -> unit
@@ -508,7 +508,7 @@ let start_watching hash fspath path =
   start_file.gen <- !current_gen;
   let fspath = concat fspath path in
 (*Format.eprintf ">>> %s@." fspath;*)
-  if is_root start_file then add_watch fspath start_file;
+  if is_root start_file then add_watch fspath start_file false;
   print_ack () >>= fun () ->
   let rec add_directories () =
     read_line () >>= fun l ->
@@ -522,7 +522,7 @@ let start_watching hash fspath path =
         clear_file_changes file;
         file.gen <- !current_gen;
 (*Format.eprintf "%s@." fullpath;*)
-        add_watch fullpath file;
+        add_watch fullpath file false;
         print_ack () >>= fun () ->
         add_directories ()
     | "LINK" ->
@@ -532,7 +532,7 @@ let start_watching hash fspath path =
         clear_file_changes file;
         file.gen <- !current_gen;
 (*Format.eprintf "%s@." fullpath;*)
-        add_watch fullpath file;
+        add_watch fullpath file true;
         print_ack () >>= fun () ->
         add_directories ()
     | "DONE" ->

--- a/src/fsmonitor/watchercommon.mli
+++ b/src/fsmonitor/watchercommon.mli
@@ -24,7 +24,7 @@ module F (M : sig type watch end) : sig
   val signal_overflow : unit -> unit
 
   module type S = sig
-    val add_watch : string -> t -> unit
+    val add_watch : string -> t -> bool -> unit
     val release_watch : t -> unit
     val watch : unit -> unit
     val clear_event_memory : unit -> unit

--- a/src/fsmonitor/windows/watcher.ml
+++ b/src/fsmonitor/windows/watcher.ml
@@ -178,7 +178,7 @@ let watch_root_directory path dir =
                    (Watchercommon.format_exc e); Lwt.return ()));
   h
 
-let add_watch path file =
+let add_watch path file _ =
   if get_watch file = None then begin
     let watch_info =
       { handle = None;


### PR DESCRIPTION
Symlinks must not be followed by default. Symlink following (= monitoring symlink target) is requested explicitly per link. This patch corrects the follow semantics (correctly implement the protocol defined in https://github.com/bcpierce00/unison/blob/master/src/fswatch.ml).