### PR TITLE
GHA: Add OCaml 4.12.0, replace 4.11.1 -> 4.11.2

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -15,20 +15,23 @@ jobs:
       fail-fast: false
       matrix:
         job:
-        - { os: macos-10.15   , ocaml-version: 4.11.1 }
+        - { os: macos-10.15   , ocaml-version: 4.12.0 }
+        - { os: macos-10.15   , ocaml-version: 4.11.2 }
         - { os: macos-10.15   , ocaml-version: 4.10.1 }
         - { os: macos-10.15   , ocaml-version: 4.09.1 }
         - { os: macos-10.15   , ocaml-version: 4.08.1 }
         - { os: macos-10.15   , ocaml-version: 4.07.1 }
         - { os: macos-10.15   , ocaml-version: 4.05.0 }
-        - { os: ubuntu-latest  , ocaml-version: 4.11.1 }
+        - { os: ubuntu-latest  , ocaml-version: 4.12.0 }
+        - { os: ubuntu-latest  , ocaml-version: 4.11.2 }
         - { os: ubuntu-latest  , ocaml-version: 4.10.1 }
         - { os: ubuntu-latest  , ocaml-version: 4.10.0+musl+static+flambda }
         - { os: ubuntu-latest  , ocaml-version: 4.09.1 }
         - { os: ubuntu-latest  , ocaml-version: 4.08.1 }
         - { os: ubuntu-latest  , ocaml-version: 4.07.1 }
         - { os: ubuntu-latest  , ocaml-version: 4.05.0 }
-        - { os: windows-latest , ocaml-version: 4.11.1 }
+        - { os: windows-latest , ocaml-version: 4.12.0 }
+        - { os: windows-latest , ocaml-version: 4.11.2 }
         - { os: windows-latest , ocaml-version: 4.10.1 }
         - { os: windows-latest , ocaml-version: 4.10.1+mingw32 }
         - { os: windows-latest , ocaml-version: 4.09.1 }


### PR DESCRIPTION
Build on 4.12.0 will succeed once either #480 or #481 is merged.