### PR TITLE
Add a proper opam file and add support for alternative libc

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -286,12 +286,8 @@ endif
 ########################################################################
 ### Filesystem monitoring
 
-OCAMLSWITCH_IS_MUSL := $(shell opam switch show 2> /dev/null | grep -iF '+musl')
-
 ifeq ($(OSARCH),Linux)
-ifeq ($(OCAMLSWITCH_IS_MUSL),)
 -include fsmonitor/linux/Makefile src/fsmonitor/linux/Makefile
-endif
 endif
 
 ifeq ($(OSARCH),win32gnuc)

--- a/src/fsmonitor/linux/inotify_stubs.c
+++ b/src/fsmonitor/linux/inotify_stubs.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <sys/inotify.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -28,18 +29,6 @@
 #include <caml/callback.h>
 
 #include <features.h>
-
-#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 4
-#define GLIBC_SUPPORT_INOTIFY 1
-#else
-#define GLIBC_SUPPORT_INOTIFY 0
-#endif
-
-#if GLIBC_SUPPORT_INOTIFY
-#include <sys/inotify.h>
-#else
-#include "inotify_compat.h"
-#endif
 
 static int inotify_flag_table[] = {
         IN_ACCESS, IN_ATTRIB, IN_CLOSE_WRITE, IN_CLOSE_NOWRITE,

--- a/unison.opam
+++ b/unison.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "juergen@hoetzel.info"
+authors: [
+  "Jürgen Hötzel <juergen@hoetzel.info>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+dev-repo: "git://github.com/bcpierce00/unison.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.03" & < "4.12"}
+  "dune" {>= "1.3"}
+  "lablgtk" {>= "2.18.6"}
+]
+available: os-family != "alpine" # uses glibc-only macros
+synopsis: "File-synchronization tool for Unix and Windows"
+description: """
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""

--- a/unison.opam
+++ b/unison.opam
@@ -13,7 +13,6 @@ depends: [
   "dune" {>= "1.3"}
   "lablgtk" {>= "2.18.6"}
 ]
-available: os-family != "alpine" # uses glibc-only macros
 synopsis: "File-synchronization tool for Unix and Windows"
 description: """
 Unison is a file-synchronization tool for Unix and Windows. It allows


### PR DESCRIPTION
Adding a proper opam file allows to use `opam pin` on this repository and well as fix https://github.com/ocaml/opam/issues/4584
`glibc` 2.4 was released in 2006, the `inotify_compat.h` is not present in the repository and alpine/musl has this include file.