### PR TITLE
fsmonitor: Fix clear changes at recursive deletes

### DIFF
--- a/src/fsmonitor/watchercommon.ml
+++ b/src/fsmonitor/watchercommon.ml
@@ -486,6 +486,7 @@ let rec remove_file file =
   StringMap.iter (fun _ f -> remove_file f) file.subdirs;
   Hashtbl.remove file_by_id file.id;
   release_watch file;
+  clear_file_changes file;
   match file.parent with
     Root _         -> ()
   | Parent (nm, p) -> p.subdirs <- StringMap.remove nm p.subdirs


### PR DESCRIPTION
Fix a corner case where changes in a sub-directory are not cleared correctly if said directory or a parent is deleted. Fsmonitor will enter a loop reporting the same changes over and over, since they are never cleared.

In practice, the issue does not manifest itself often (if ever) because deletes are reported as "immediate changes", thus never processed recursively. The fix is still required because the code does not require nor enforce deletes to be processed as "immediate changes".