### PR TITLE
fsmonitor: Report changes on the root itself

### DIFF
--- a/src/fsmonitor/watchercommon.ml
+++ b/src/fsmonitor/watchercommon.ml
@@ -393,11 +393,7 @@ let gather_changes hash time =
     (Hashtbl.fold
        (fun (hash', _, path) r l ->
           if hash' <> hash then l else
-          (* If this path is not watched (presumably, it does not exist),
-             we report that it should be scanned again. On the other hand,
-             this is not reported as a change by the WAIT function, so that
-             Unison does not loop checking this path. *)
-          if r.changed && r.watch = None then path :: l else
+          if r.changed then gather_rec path r (path :: l) else
           gather_rec path r l)
        roots [])
 


### PR DESCRIPTION
Report changes on the root directory itself, in addition to reporting changes within the root directory.

Without this patch, changes on root are reported only if the watch has been released before reporting changes. I don't quite get the explanation in the now-removed code comment. The previous code includes a condition `if r.changed` so it is reported only if there were changes detected -- and this makes the comment bogus. Also having the `&& r.watch = None` condition, changes on a root that is still being watched, and its children, are effectively just ignored. The patch removes the `&& r.watch = None` condition and also makes sure any changes on children are reported.

Other semantics have not been changed (mentioning it just in case, re the comment `On the other hand, this is not reported as a change by the WAIT function, so that Unison does not loop checking this path.`).

This issue is not likely often noticed in practice because it only manifests itself under certain narrow conditions.