### PR TITLE
GHA: Package fsmonitor on Windows

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -153,10 +153,9 @@ jobs:
       run: |
         opam exec -- make src OSTYPE=$OSTYPE UISTYLE=text STATIC=${{ steps.vars.outputs.STATIC }}
         # stage
-        # * notes: darwin/macos doesn't build `unison-fsmonitor` ; windows gtk2 build hangs at "looking for changes" when `unison-fsmonitor.exe` is present
+        # * notes: darwin/macos doesn't build `unison-fsmonitor`
         for file in ${PROJECT_EXES} ; do
           if [ -f "src/${file}${{ steps.vars.outputs.EXE_suffix }}" ]; then
-            case '${{ matrix.job.os }}' in windows-*) if [ "${file}" = "unison-fsmonitor" ]; then continue; fi ;; esac
             cp "src/${file}${{ steps.vars.outputs.EXE_suffix }}" '${{ steps.vars.outputs.PKG_DIR }}/bin'
             echo "'src/${file}${{ steps.vars.outputs.EXE_suffix }}' copied to '${{ steps.vars.outputs.PKG_DIR }}/bin'"
           fi


### PR DESCRIPTION
`unison-fsmonitor` is currently not packaged on Windows (see #380) because it causes a hang. Exact comment from workflow file:
```
windows gtk2 build hangs at "looking for changes" when `unison-fsmonitor.exe` is present
```

Can anyone actually reproduce this hang? I propose to package `unison-fsmonitor` on Windows unless the hang is confirmed.