### PR TITLE
GHA: Build on Ubuntu 18.04

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -22,14 +22,14 @@ jobs:
         - { os: macos-10.15   , ocaml-version: 4.08.1 }
         - { os: macos-10.15   , ocaml-version: 4.07.1 }
         - { os: macos-10.15   , ocaml-version: 4.05.0 }
-        - { os: ubuntu-latest  , ocaml-version: 4.12.0 }
-        - { os: ubuntu-latest  , ocaml-version: 4.11.2 }
-        - { os: ubuntu-latest  , ocaml-version: 4.10.1 }
-        - { os: ubuntu-latest  , ocaml-version: 4.10.0+musl+static+flambda }
-        - { os: ubuntu-latest  , ocaml-version: 4.09.1 }
-        - { os: ubuntu-latest  , ocaml-version: 4.08.1 }
-        - { os: ubuntu-latest  , ocaml-version: 4.07.1 }
-        - { os: ubuntu-latest  , ocaml-version: 4.05.0 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.12.0 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.11.2 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.10.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.10.0+musl+static+flambda }
+        - { os: ubuntu-18.04  , ocaml-version: 4.09.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.08.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.07.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.05.0 }
         - { os: windows-latest , ocaml-version: 4.12.0 }
         - { os: windows-latest , ocaml-version: 4.11.2 }
         - { os: windows-latest , ocaml-version: 4.10.1 }


### PR DESCRIPTION
GHA switched ubuntu-latest build environment to Ubuntu 20.04 which has a newer glibc. Building against this newer glibc stops binaries from working on some still supported distributions.

@gdt I propose a new rc is released with this patch.

Closes #491 