### PR TITLE
fsmonitor: Remove unused include

### DIFF
--- a/src/fsmonitor/linux/inotify_stubs.c
+++ b/src/fsmonitor/linux/inotify_stubs.c
@@ -28,8 +28,6 @@
 #include <caml/signals.h>
 #include <caml/callback.h>
 
-#include <features.h>
-
 static int inotify_flag_table[] = {
         IN_ACCESS, IN_ATTRIB, IN_CLOSE_WRITE, IN_CLOSE_NOWRITE,
         IN_CREATE, IN_DELETE, IN_DELETE_SELF, IN_MODIFY,


### PR DESCRIPTION
Including <features.h> is no longer needed after commit 6e7a1a97d9b433dbe6a23990bfb105fbeaa49b51.