### PR TITLE
Re-establish silently dropped connections

### DIFF
--- a/src/remote.mli
+++ b/src/remote.mli
@@ -52,6 +52,10 @@ val canonizeRoot :
   string -> Clroot.clroot -> (string -> string -> string) option ->
   Common.root Lwt.t
 
+(* Test if connection to the remote server (if any) corresponding
+   to the root is established. Always returns true for local roots *)
+val isRootConnected : Common.root -> bool
+
 (* Statistics *)
 val emittedBytes : float ref
 val receivedBytes : float ref

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -662,10 +662,7 @@ let initPrefs ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
   Lwt_unix.run (Globals.installRoots termInteract);
 
   (* If both roots are local, disable the xferhint table to save time *)
-  begin match Globals.roots() with
-    ((Local,_),(Local,_)) -> Prefs.set Xferhint.xferbycopying false
-  | _ -> ()
-  end;
+  if numRemote = 0 then Prefs.set Xferhint.xferbycopying false;
 
   (* If no paths were specified, then synchronize the whole replicas *)
   if Prefs.read Globals.paths = [] then Prefs.set Globals.paths [Path.empty];

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -652,6 +652,12 @@ let initPrefs ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
 
   Recon.checkThatPreferredRootIsValid();
 
+  (* If both roots are local, disable the xferhint table to save time *)
+  if numRemote = 0 then Prefs.set Xferhint.xferbycopying false;
+
+  (* If no paths were specified, then synchronize the whole replicas *)
+  if Prefs.read Globals.paths = [] then Prefs.set Globals.paths [Path.empty];
+
   (* The following step contacts the server, so warn the user it could take
      some time *)
   if not (Prefs.read contactquietly || Prefs.read Trace.terse) then
@@ -660,12 +666,6 @@ let initPrefs ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
   (* Canonize the names of the roots, sort them (with local roots first),
      and install them in Globals. *)
   Lwt_unix.run (Globals.installRoots termInteract);
-
-  (* If both roots are local, disable the xferhint table to save time *)
-  if numRemote = 0 then Prefs.set Xferhint.xferbycopying false;
-
-  (* If no paths were specified, then synchronize the whole replicas *)
-  if Prefs.read Globals.paths = [] then Prefs.set Globals.paths [Path.empty];
 
   (* Expand any "wildcard" paths [with final component *] *)
   Globals.expandWildcardPaths();

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -711,6 +711,13 @@ let initPrefs ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
 
   firstTime := false
 
+let refreshConnection ~displayWaitMessage ~termInteract =
+  assert (Safelist.length (Globals.rootsList ()) > 1);
+  let numConn = ref 0 in
+  Lwt_unix.run (Globals.allRootsIter
+    (fun r -> if Remote.isRootConnected r then incr numConn; Lwt.return ()));
+  if !numConn < 2 then initRoots displayWaitMessage termInteract
+
 (**********************************************************************
                        Common startup sequence
  **********************************************************************)

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -105,6 +105,15 @@ val initPrefs :
   termInteract:(string -> string -> string) option ->
   unit
 
+(* Make sure remote connections (if any) corresponding to active roots
+   are still established and re-establish them if necessary.
+   [refreshConnection] is like [initPrefs] but without reloading the profile
+   and re-initializing the prefs. *)
+val refreshConnection :
+  displayWaitMessage:(unit -> unit) ->
+  termInteract:(string -> string -> string) option ->
+  unit
+
 val validateAndFixupPrefs : unit -> unit Lwt.t
 
 (* Exit codes *)

--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -3854,6 +3854,7 @@ lst_store#set ~row ~column:c_path path;
     in
     clearMainWindow ();
     if not (Prefs.profileUnchanged ()) then loadProfile n true
+    else Uicommon.refreshConnection displayWaitMessage termInteract
   in
 
   let detectCmd () =

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1060,6 +1060,10 @@ let synchronizeOnce ?wantWatcher ?skipRecentFiles pathsOpt =
     let c = "-\\|/".[truncate (mod_float (4. *. Unix.gettimeofday ()) 4.)] in
     Util.set_infos (Format.sprintf "%c %s" c path)
   in
+  Uicommon.refreshConnection
+    (fun () -> if not (Prefs.read silent)
+               then Util.msg "%s\n" (Uicommon.contactingServerMsg()))
+    None;
   Trace.status "Looking for changes";
   if not (Prefs.read Trace.terse) && (Prefs.read Trace.debugmods = []) then
     Uutil.setUpdateStatusPrinter (Some showStatus);


### PR DESCRIPTION
### Motivation

Unison relies on the remote connection being opened as part of the profile initialization and then staying open for as long as Unison runs, which in repeat mode can be an extended period of time. If the connection breaks for whatever reason then it is treated as a fatal error. Connection may have been silently dropped (for any number external reasons) between two synchronizations. This means that the next rescan, whether by `repeat` preference or manually in the GUI, will fail with fatal error.

### Description

This patch catches the lost connection exception and the connection is marked as closed. This allows to cleanly re-open the connection later.

Add function to check connection status, which as a side-effect triggers throwing a lost connection exception if connection had been silently broken, thereby detecting the closed state.

Due to Lwt threads, it is difficult to track the code. The thread spawned in `initConnection` is the long-running connection thread that handles all client-side communication. This is where the lost connection exception will be caught and processed, without the `checkConnection` function even being aware about it. `hostFspath` and `isRootConnected` functions must check the list of open connections twice in order to detect the close processed by another thread. The function to process the lost connection exception and mark the connection as closed is provided at the time of building the connection.

Lost connection exception is cleanly handled only while explicitly checking connection status. If a connection is dropped during active syncing then the exception will be reraised and is treated as fatal, just as before.

Add a function for UI to refresh connections by checking their status and re-establishing them as necessary. This way the UI can rely on remote connection being open at beginning of every scan even if it was temporarily broken between synchronizations. Just installing the roots again will also re-establish broken connections, so even UIs that don't explicitly refresh connections will benefit, as long as they reload the profile or re-install the roots. This includes `uimac` but it has not been tested.

Closes #333