### PR TITLE
Implement RPC version handshake

### DIFF
--- a/src/compat404.ml
+++ b/src/compat404.ml
@@ -1,0 +1,16 @@
+(* Functions added in OCaml 4.04 *)
+
+module String = struct
+  include String
+
+  let split_on_char sep s =
+    let r = ref [] in
+    let j = ref (length s) in
+    for i = length s - 1 downto 0 do
+      if unsafe_get s i = sep then begin
+        r := sub s (i + 1) (!j - i - 1) :: !r;
+        j := i
+      end
+    done;
+    sub s 0 !j :: !r
+end

--- a/src/configure.ml
+++ b/src/configure.ml
@@ -7,6 +7,7 @@ let compat4 =
   [
     compat4pred 2, "Compat402", "compat402.cmo";
     compat4pred 3, "Compat403", "compat403.cmo";
+    compat4pred 4, "Compat404", "compat404.cmo";
     compat4pred 8, "Compat408", "compat408.cmo" ]
 
 let objects =

--- a/src/copy.ml
+++ b/src/copy.ml
@@ -408,10 +408,10 @@ let processTransferInstruction conn (file_id, ti) =
        ignore (Remote.MsgIdMap.find file_id !decompressor ti))
 
 let marshalTransferInstruction =
-  (fun (file_id, (data, pos, len)) rem ->
+  (fun _ (file_id, (data, pos, len)) rem ->
      (Remote.encodeInt file_id :: (data, pos, len) :: rem,
       len + Remote.intSize)),
-  (fun buf pos ->
+  (fun _ buf pos ->
      let len = Bytearray.length buf - pos - Remote.intSize in
      (Remote.decodeInt buf pos, (buf, pos + Remote.intSize, len)))
 

--- a/src/props.ml
+++ b/src/props.ml
@@ -665,6 +665,19 @@ end
 (*                           Properties                                      *)
 (* ------------------------------------------------------------------------- *)
 
+(* IMPORTANT!
+   This is the 2.51-compatible version of type [Props.t]. It must always remain
+   exactly the same as the type [Props.t] in version 2.51.5. This means that if
+   any of the types it is composed of changes then for each changed type also a
+   2.51-compatible version must be created. *)
+type t251 =
+  { perm : Perm.t;
+    uid : Uid.t;
+    gid : Gid.t;
+    time : Time.t;
+    typeCreator : TypeCreator.t;
+    length : Uutil.Filesize.t }
+
 type t =
   { perm : Perm.t;
     uid : Uid.t;
@@ -672,6 +685,22 @@ type t =
     time : Time.t;
     typeCreator : TypeCreator.t;
     length : Uutil.Filesize.t }
+
+let to_compat251 (p : t) : t251 =
+  { perm = p.perm;
+    uid = p.uid;
+    gid = p.gid;
+    time = p.time;
+    typeCreator = p.typeCreator;
+    length = p.length }
+
+let of_compat251 (p : t251) : t =
+  { perm = p.perm;
+    uid = p.uid;
+    gid = p.gid;
+    time = p.time;
+    typeCreator = p.typeCreator;
+    length = p.length }
 
 let template perm =
   { perm = perm; uid = Uid.dummy; gid = Gid.dummy;
@@ -681,6 +710,18 @@ let template perm =
 let dummy = template Perm.dummy
 
 let hash p h =
+  Perm.hash p.perm
+    (Uid.hash p.uid
+       (Gid.hash p.gid
+          (Time.hash p.time
+             (TypeCreator.hash p.typeCreator h))))
+
+(* IMPORTANT!
+   This is the 2.51-compatible version of [hash]. It must always produce exactly
+   the same result as the [hash] in version 2.51.5.
+   If code changes elsewhere make this function produce a different result then
+   it must be updated accordingly to again return the 2.51-compatible result. *)
+let hash251 (p : t251) h =
   Perm.hash p.perm
     (Uid.hash p.uid
        (Gid.hash p.gid

--- a/src/props.mli
+++ b/src/props.mli
@@ -3,9 +3,13 @@
 
 (* File properties: time, permission, length, etc. *)
 
+type t251
 type t
+val to_compat251 : t -> t251
+val of_compat251 : t251 -> t
 val dummy : t
 val hash : t -> int -> int
+val hash251 : t251 -> int -> int
 val similar : t -> t -> bool
 val override : t -> t -> t
 val strip : t -> t

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -453,7 +453,10 @@ type 'a unmarshalFunction = connection -> Bytearray.t -> 'a
 type 'a marshalingFunctions = 'a marshalFunction * 'a unmarshalFunction
 
 type 'a convV0Fun =
-  V0 : ('a -> 'compat) * ('compat -> 'a) -> 'a convV0Fun [@unboxed]
+  V0 : ('a -> 'compat) * ('compat -> 'a) -> 'a convV0Fun (* [@unboxed] *)
+(* FIX: `unboxed` commented out to restore compatibility with OCaml < 4.02
+   Remove this hack after next release when this compatibility is no longer
+   required. *)
 
 external id : 'a -> 'a = "%identity"
 let convV0_id = V0 (id, id)
@@ -1147,9 +1150,8 @@ let parseVersion side s =
   if s = "" then
     error "invalid format"
   else
-    match int_of_string s with
-    | ver -> Some ver
-    | exception Failure _ -> error "parse error"
+    try Some (int_of_string s) with
+    | Failure _ -> error "parse error"
 
 let parseServerVersions inp =
   let supported l = function
@@ -1841,7 +1843,10 @@ let checkClientVersion conn () =
              ^ String.escaped (fromClient
              ^ Bytes.to_string (peekWithoutBlocking conn.inputBuffer)) ^ "\"")
   | Data buf ->
-      match parseVersion "client" buf with
+      (* FIX: This monstrosity needs to be changed to `match ... with exception ...`
+         after the next release when compatibility with OCaml < 4.02 is no longer
+         required. *)
+      match (try parseVersion "client" buf with Util.Transient e -> ignore (error e); None) with
       | Some clientVer ->
           if verIsSupported clientVer then begin
             setConnectionVersion conn clientVer;
@@ -1852,7 +1857,6 @@ let checkClientVersion conn () =
                    ^ string_of_int clientVer ^ "\". "
                    ^ "Supported RPC versions: " ^ rpcSupportedVersionStr)
       | None -> Lwt.return ()
-      | exception Util.Transient e -> error e
 
 (****)
 

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -450,7 +450,7 @@ type 'a unmarshalFunction = connection -> Bytearray.t -> 'a
 type 'a marshalingFunctions = 'a marshalFunction * 'a unmarshalFunction
 
 type 'a convV0Fun =
-  V0 : ('a -> 'compat) * ('compat -> 'a) -> 'a convV0Fun
+  V0 : ('a -> 'compat) * ('compat -> 'a) -> 'a convV0Fun [@unboxed]
 
 external id : 'a -> 'a = "%identity"
 let convV0_id = V0 (id, id)

--- a/src/remote.mli
+++ b/src/remote.mli
@@ -87,6 +87,7 @@ module MsgIdMap : Map.S with type key = msgId
 val newMsgId : unit -> msgId
 
 type connection
+val connectionVersion : connection -> int
 val connectionToRoot : Common.root -> connection
 
 val registerServerCmd :
@@ -106,8 +107,8 @@ val streamingActivated : bool Prefs.t
 
 val registerStreamCmd :
   string ->
-  ('a ->
+  (connection -> 'a ->
    (Bytearray.t * int * int) list -> (Bytearray.t * int * int) list * int) *
-  (Bytearray.t -> int -> 'a) ->
+  (connection -> Bytearray.t -> int -> 'a) ->
   (connection -> 'a -> unit) ->
   connection -> (('a -> unit Lwt.t) -> 'b Lwt.t) -> 'b Lwt.t

--- a/src/remote.mli
+++ b/src/remote.mli
@@ -5,6 +5,29 @@ module Thread : sig
   val unwindProtect : (unit -> 'a Lwt.t) -> (exn -> unit Lwt.t) -> 'a Lwt.t
 end
 
+(* A pair of functions enabling conversion from type 'a to a 2.51-compatible
+   type and the other way around.
+   The conversion functions are needed because the 2.51-compatible types must
+   be frozen in time and never changed in future. Type 'a can and will change
+   in time as enhancements are added and old code is removed.
+   When a type is changed, breaking compatibility with 2.51, then respective
+   conversion functions must also be added. *)
+type 'a convV0Fun
+val makeConvV0FunArg :
+    ('a -> 'compat)
+ -> ('compat -> 'a)
+ -> 'a convV0Fun * 'b convV0Fun
+val makeConvV0FunRet :
+    ('b -> 'compat)
+ -> ('compat -> 'b)
+ -> 'a convV0Fun * 'b convV0Fun
+val makeConvV0Funs :
+    ('a -> 'compat)
+ -> ('compat -> 'a)
+ -> ('b -> 'compat)
+ -> ('compat -> 'b)
+ -> 'a convV0Fun * 'b convV0Fun
+
 (* Register a server function.  The result is a function that takes a host
    name as argument and either executes locally or else communicates with a
    remote server, as appropriate.  (Calling registerServerCmd also has the
@@ -13,6 +36,8 @@ end
    requested by a remote client.) *)
 val registerHostCmd :
     string              (* command name *)
+ -> ?convV0: 'a convV0Fun * 'b convV0Fun
+                        (* 2.51-compatibility functions for args and result *)
  -> ('a -> 'b Lwt.t)    (* local command *)
  -> (   string          (* -> host *)
      -> 'a              (*    arguments *)
@@ -27,6 +52,9 @@ val registerHostCmd :
    <funcName>OnRoot and <funcName>Local *)
 val registerRootCmd :
     string                         (* command name *)
+ -> ?convV0: (Fspath.t * 'a) convV0Fun * 'b convV0Fun
+                                   (* 2.51-compatibility functions for args
+                                      and result *)
  -> ((Fspath.t * 'a) -> 'b Lwt.t)  (* local command *)
  -> (   Common.root                (* -> root *)
      -> 'a                         (*    additional arguments *)
@@ -91,12 +119,17 @@ val connectionVersion : connection -> int
 val connectionToRoot : Common.root -> connection
 
 val registerServerCmd :
-  string -> (connection -> 'a -> 'b Lwt.t) -> connection -> 'a -> 'b Lwt.t
+    string
+ -> ?convV0: 'a convV0Fun * 'b convV0Fun
+ -> (connection -> 'a -> 'b Lwt.t) -> connection -> 'a -> 'b Lwt.t
 val intSize : int
 val encodeInt : int -> Bytearray.t * int * int
 val decodeInt : Bytearray.t -> int -> int
 val registerRootCmdWithConnection :
     string                          (* command name *)
+ -> ?convV0: 'a convV0Fun * 'b convV0Fun
+                                    (* 2.51-compatibility functions for args
+                                       and result *)
  -> (connection -> 'a -> 'b Lwt.t)  (* local command *)
  ->    Common.root                  (* root on which the command is executed *)
     -> Common.root                  (* other root *)

--- a/src/remote.mli
+++ b/src/remote.mli
@@ -91,19 +91,6 @@ val connectionToRoot : Common.root -> connection
 
 val registerServerCmd :
   string -> (connection -> 'a -> 'b Lwt.t) -> connection -> 'a -> 'b Lwt.t
-val registerSpecialServerCmd :
-  string ->
-  ('a ->
-   (Bytearray.t * int * int) list -> (Bytearray.t * int * int) list * int) *
-  (Bytearray.t -> int -> 'a) ->
-  ('b ->
-   (Bytearray.t * int * int) list -> (Bytearray.t * int * int) list * int) *
-  (Bytearray.t -> int -> 'b) ->
-  (connection -> 'a -> 'b Lwt.t) -> connection -> 'a -> 'b Lwt.t
-val defaultMarshalingFunctions :
-  ('a ->
-   (Bytearray.t * int * int) list -> (Bytearray.t * int * int) list * int) *
-  (Bytearray.t -> int -> 'b)
 val intSize : int
 val encodeInt : int -> Bytearray.t * int * int
 val decodeInt : Bytearray.t -> int -> int


### PR DESCRIPTION
As mentioned in the mail sent to unison-hackers list. This patch is intended to introduce a compatibility measure, ~~but while doing so, it is itself a **breaking change**~~. _Edit_: Compatibility with 2.51 is possible to keep.

### Background and motivation

With current implementation, when client opens the connection to a server, it checks compatibility by comparing a Unison version string sent by server. This is limiting when it comes to making backwards-compatible changes.

This patch implements a version handshake so that client and server can agree on a common RPC protocol version out of potentially several supported versions.

This is a low-level part of a fix to #407. A separate API-level mechanism is planned for a complete fix to #407.

### Description

RPC version is defined as an integer. Versions do not have to be consecutive (or even positive, for that matter), only the value matters. Larger version values are always considered to be more recent than smaller version values. This patch sets the starting version at `1` but it could be any integer.

A release could support several RPC versions (which do not have to be consecutive; could support versions 1 and 3 but not 2, for example). When client establishes a connection to the server, a version is selected which both client and server support, even if it is not the latest version. This allows a client to connect to both older servers (assuming the client supports an older RPC version) and newer servers (assuming the newer server supports an older RPC version).

The version handshake process is described in the code. The handshake process itself is a very simple text-based interaction.

### What is it not?

This patch does nothing about incompatibilities caused by different OCaml versions.