### PR TITLE
Reformat .depend for maintainability

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -1,389 +1,1519 @@
-abort.cmi : uutil.cmi
-bytearray.cmi :
-case.cmi : ubase/prefs.cmi
-checksum.cmi :
-clroot.cmi :
-common.cmi : uutil.cmi props.cmi path.cmi osx.cmi os.cmi name.cmi fspath.cmi \
-    fileinfo.cmi
-copy.cmi : uutil.cmi props.cmi path.cmi osx.cmi os.cmi lwt/lwt.cmi \
-    fspath.cmi fileinfo.cmi common.cmi
-external.cmi : lwt/lwt.cmi
-fileinfo.cmi : system.cmi props.cmi ubase/prefs.cmi path.cmi osx.cmi \
-    fspath.cmi
-files.cmi : uutil.cmi system.cmi props.cmi path.cmi lwt/lwt_util.cmi \
-    lwt/lwt.cmi common.cmi
-fileutil.cmi :
-fingerprint.cmi : uutil.cmi path.cmi fspath.cmi
-fpcache.cmi : system.cmi props.cmi path.cmi osx.cmi os.cmi fspath.cmi \
-    fileinfo.cmi
-fs.cmi : system/system_intf.cmo fspath.cmi
-fspath.cmi : system.cmi path.cmi name.cmi
-fswatch.cmi : ubase/prefs.cmi path.cmi lwt/lwt.cmi fspath.cmi
-fswatchold.cmi : path.cmi lwt/lwt.cmi fspath.cmi
-globals.cmi : ubase/prefs.cmi pred.cmi path.cmi lwt/lwt.cmi common.cmi
-lock.cmi : system.cmi
-name.cmi :
-os.cmi : uutil.cmi system.cmi props.cmi path.cmi name.cmi fspath.cmi \
-    fileinfo.cmi
-osx.cmi : uutil.cmi ubase/prefs.cmi path.cmi fspath.cmi fingerprint.cmi
-path.cmi : pred.cmi name.cmi
-pred.cmi :
-props.cmi : uutil.cmi ubase/prefs.cmi path.cmi osx.cmi fspath.cmi
-recon.cmi : props.cmi path.cmi common.cmi
-remote.cmi : ubase/prefs.cmi lwt/lwt.cmi fspath.cmi common.cmi clroot.cmi \
+abort.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    ubase/prefs.cmi \
+    abort.cmi
+abort.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    ubase/prefs.cmx \
+    abort.cmi
+abort.cmi : \
+    uutil.cmi
+bytearray.cmo : \
     bytearray.cmi
-sortri.cmi : common.cmi
-stasher.cmi : update.cmi ubase/prefs.cmi path.cmi os.cmi fspath.cmi
-strings.cmi :
-system.cmi : system/system_intf.cmo
-terminal.cmi : lwt/lwt_unix.cmi
-test.cmi :
-transfer.cmi : uutil.cmi lwt/lwt.cmi bytearray.cmi
-transport.cmi : uutil.cmi lwt/lwt.cmi common.cmi
-tree.cmi :
-ui.cmi :
-uicommon.cmi : uutil.cmi ubase/prefs.cmi path.cmi lwt/lwt.cmi common.cmi
-uigtk2.cmi : uicommon.cmi
-uitext.cmi : uicommon.cmi
-unicode.cmi :
-update.cmi : uutil.cmi tree.cmi props.cmi path.cmi osx.cmi os.cmi name.cmi \
-    ubase/myMap.cmi lwt/lwt.cmi fspath.cmi fileinfo.cmi common.cmi
-uutil.cmi :
-xferhint.cmi : ubase/prefs.cmi path.cmi os.cmi fspath.cmi
-abort.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi ubase/prefs.cmi \
-    abort.cmi
-abort.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx ubase/prefs.cmx \
-    abort.cmi
-bytearray.cmo : bytearray.cmi
-bytearray.cmx : bytearray.cmi
-case.cmo : uutil.cmi ubase/util.cmi unicode.cmi ubase/prefs.cmi case.cmi
-case.cmx : uutil.cmx ubase/util.cmx unicode.cmx ubase/prefs.cmx case.cmi
-checksum.cmo : checksum.cmi
-checksum.cmx : checksum.cmi
-clroot.cmo : ubase/util.cmi ubase/rx.cmi ubase/prefs.cmi clroot.cmi
-clroot.cmx : ubase/util.cmx ubase/rx.cmx ubase/prefs.cmx clroot.cmi
-common.cmo : uutil.cmi ubase/util.cmi ubase/safelist.cmi props.cmi path.cmi \
-    osx.cmi os.cmi name.cmi fspath.cmi fileinfo.cmi common.cmi
-common.cmx : uutil.cmx ubase/util.cmx ubase/safelist.cmx props.cmx path.cmx \
-    osx.cmx os.cmx name.cmx fspath.cmx fileinfo.cmx common.cmi
-copy.cmo : xferhint.cmi uutil.cmi ubase/util.cmi update.cmi transfer.cmi \
-    ubase/trace.cmi ubase/safelist.cmi remote.cmi props.cmi ubase/prefs.cmi \
-    path.cmi osx.cmi os.cmi lwt/lwt_util.cmi lwt/lwt.cmi globals.cmi \
-    fspath.cmi fs.cmi fpcache.cmi fingerprint.cmi fileinfo.cmi external.cmi \
-    common.cmi clroot.cmi bytearray.cmi abort.cmi copy.cmi
-copy.cmx : xferhint.cmx uutil.cmx ubase/util.cmx update.cmx transfer.cmx \
-    ubase/trace.cmx ubase/safelist.cmx remote.cmx props.cmx ubase/prefs.cmx \
-    path.cmx osx.cmx os.cmx lwt/lwt_util.cmx lwt/lwt.cmx globals.cmx \
-    fspath.cmx fs.cmx fpcache.cmx fingerprint.cmx fileinfo.cmx external.cmx \
-    common.cmx clroot.cmx bytearray.cmx abort.cmx copy.cmi
-external.cmo : ubase/util.cmi system.cmi ubase/safelist.cmi lwt/lwt_util.cmi \
-    lwt/lwt_unix.cmi lwt/lwt.cmi external.cmi
-external.cmx : ubase/util.cmx system.cmx ubase/safelist.cmx lwt/lwt_util.cmx \
-    lwt/lwt_unix.cmx lwt/lwt.cmx external.cmi
-fileinfo.cmo : ubase/util.cmi system.cmi props.cmi ubase/prefs.cmi path.cmi \
-    osx.cmi fswatch.cmi fspath.cmi fs.cmi fileinfo.cmi
-fileinfo.cmx : ubase/util.cmx system.cmx props.cmx ubase/prefs.cmx path.cmx \
-    osx.cmx fswatch.cmx fspath.cmx fs.cmx fileinfo.cmi
-files.cmo : xferhint.cmi uutil.cmi ubase/util.cmi update.cmi ubase/trace.cmi \
-    system.cmi stasher.cmi ubase/safelist.cmi ubase/rx.cmi remote.cmi \
-    props.cmi ubase/prefs.cmi path.cmi osx.cmi os.cmi name.cmi \
-    lwt/lwt_util.cmi lwt/lwt_unix.cmi lwt/lwt.cmi globals.cmi fspath.cmi \
-    fs.cmi fingerprint.cmi fileinfo.cmi external.cmi copy.cmi common.cmi \
-    abort.cmi files.cmi
-files.cmx : xferhint.cmx uutil.cmx ubase/util.cmx update.cmx ubase/trace.cmx \
-    system.cmx stasher.cmx ubase/safelist.cmx ubase/rx.cmx remote.cmx \
-    props.cmx ubase/prefs.cmx path.cmx osx.cmx os.cmx name.cmx \
-    lwt/lwt_util.cmx lwt/lwt_unix.cmx lwt/lwt.cmx globals.cmx fspath.cmx \
-    fs.cmx fingerprint.cmx fileinfo.cmx external.cmx copy.cmx common.cmx \
-    abort.cmx files.cmi
-fileutil.cmo : fileutil.cmi
-fileutil.cmx : fileutil.cmi
-fingerprint.cmo : uutil.cmi ubase/util.cmi path.cmi fspath.cmi fs.cmi \
+bytearray.cmx : \
+    bytearray.cmi
+bytearray.cmi :
+case.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    unicode.cmi \
+    ubase/prefs.cmi \
+    case.cmi
+case.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    unicode.cmx \
+    ubase/prefs.cmx \
+    case.cmi
+case.cmi : \
+    ubase/prefs.cmi
+checksum.cmo : \
+    checksum.cmi
+checksum.cmx : \
+    checksum.cmi
+checksum.cmi :
+clroot.cmo : \
+    ubase/util.cmi \
+    ubase/rx.cmi \
+    ubase/prefs.cmi \
+    clroot.cmi
+clroot.cmx : \
+    ubase/util.cmx \
+    ubase/rx.cmx \
+    ubase/prefs.cmx \
+    clroot.cmi
+clroot.cmi :
+common.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/safelist.cmi \
+    props.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    name.cmi \
+    fspath.cmi \
+    fileinfo.cmi \
+    common.cmi
+common.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/safelist.cmx \
+    props.cmx \
+    path.cmx \
+    osx.cmx \
+    os.cmx \
+    name.cmx \
+    fspath.cmx \
+    fileinfo.cmx \
+    common.cmi
+common.cmi : \
+    uutil.cmi \
+    props.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    name.cmi \
+    fspath.cmi \
+    fileinfo.cmi
+copy.cmo : \
+    xferhint.cmi \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    transfer.cmi \
+    ubase/trace.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fspath.cmi \
+    fs.cmi \
+    fpcache.cmi \
+    fingerprint.cmi \
+    fileinfo.cmi \
+    external.cmi \
+    common.cmi \
+    clroot.cmi \
+    bytearray.cmi \
+    abort.cmi \
+    copy.cmi
+copy.cmx : \
+    xferhint.cmx \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    transfer.cmx \
+    ubase/trace.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    osx.cmx \
+    os.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fspath.cmx \
+    fs.cmx \
+    fpcache.cmx \
+    fingerprint.cmx \
+    fileinfo.cmx \
+    external.cmx \
+    common.cmx \
+    clroot.cmx \
+    bytearray.cmx \
+    abort.cmx \
+    copy.cmi
+copy.cmi : \
+    uutil.cmi \
+    props.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    lwt/lwt.cmi \
+    fspath.cmi \
+    fileinfo.cmi \
+    common.cmi
+external.cmo : \
+    ubase/util.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    external.cmi
+external.cmx : \
+    ubase/util.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    external.cmi
+external.cmi : \
+    lwt/lwt.cmi
+fileinfo.cmo : \
+    ubase/util.cmi \
+    system.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    fswatch.cmi \
+    fspath.cmi \
+    fs.cmi \
+    fileinfo.cmi
+fileinfo.cmx : \
+    ubase/util.cmx \
+    system.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    osx.cmx \
+    fswatch.cmx \
+    fspath.cmx \
+    fs.cmx \
+    fileinfo.cmi
+fileinfo.cmi : \
+    system.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    fspath.cmi
+files.cmo : \
+    xferhint.cmi \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    stasher.cmi \
+    ubase/safelist.cmi \
+    ubase/rx.cmi \
+    remote.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    name.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fspath.cmi \
+    fs.cmi \
+    fingerprint.cmi \
+    fileinfo.cmi \
+    external.cmi \
+    copy.cmi \
+    common.cmi \
+    abort.cmi \
+    files.cmi
+files.cmx : \
+    xferhint.cmx \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    stasher.cmx \
+    ubase/safelist.cmx \
+    ubase/rx.cmx \
+    remote.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    osx.cmx \
+    os.cmx \
+    name.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fspath.cmx \
+    fs.cmx \
+    fingerprint.cmx \
+    fileinfo.cmx \
+    external.cmx \
+    copy.cmx \
+    common.cmx \
+    abort.cmx \
+    files.cmi
+files.cmi : \
+    uutil.cmi \
+    system.cmi \
+    props.cmi \
+    path.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt.cmi \
+    common.cmi
+fileutil.cmo : \
+    fileutil.cmi
+fileutil.cmx : \
+    fileutil.cmi
+fileutil.cmi :
+fingerprint.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    path.cmi \
+    fspath.cmi \
+    fs.cmi \
     fingerprint.cmi
-fingerprint.cmx : uutil.cmx ubase/util.cmx path.cmx fspath.cmx fs.cmx \
+fingerprint.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    path.cmx \
+    fspath.cmx \
+    fs.cmx \
     fingerprint.cmi
-fpcache.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi system.cmi \
-    ubase/safelist.cmi props.cmi ubase/prefs.cmi path.cmi osx.cmi os.cmi \
-    fspath.cmi fileinfo.cmi fpcache.cmi
-fpcache.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx system.cmx \
-    ubase/safelist.cmx props.cmx ubase/prefs.cmx path.cmx osx.cmx os.cmx \
-    fspath.cmx fileinfo.cmx fpcache.cmi
-fs.cmo : fspath.cmi fs.cmi
-fs.cmx : fspath.cmx fs.cmi
-fspath.cmo : uutil.cmi ubase/util.cmi system.cmi ubase/rx.cmi path.cmi \
-    name.cmi fileutil.cmi fspath.cmi
-fspath.cmx : uutil.cmx ubase/util.cmx system.cmx ubase/rx.cmx path.cmx \
-    name.cmx fileutil.cmx fspath.cmi
-fswatch.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi system.cmi \
-    ubase/prefs.cmi path.cmi lwt/lwt_unix.cmi lwt/lwt.cmi fspath.cmi \
+fingerprint.cmi : \
+    uutil.cmi \
+    path.cmi \
+    fspath.cmi
+fpcache.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    fspath.cmi \
+    fileinfo.cmi \
+    fpcache.cmi
+fpcache.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    osx.cmx \
+    os.cmx \
+    fspath.cmx \
+    fileinfo.cmx \
+    fpcache.cmi
+fpcache.cmi : \
+    system.cmi \
+    props.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    fspath.cmi \
+    fileinfo.cmi
+fs.cmo : \
+    fspath.cmi \
+    fs.cmi
+fs.cmx : \
+    fspath.cmx \
+    fs.cmi
+fs.cmi : \
+    system/system_intf.cmo \
+    fspath.cmi
+fsmonitor/linux/inotify.cmo : \
+    fsmonitor/linux/inotify.cmi
+fsmonitor/linux/inotify.cmx : \
+    fsmonitor/linux/inotify.cmi
+fsmonitor/linux/inotify.cmi :
+fsmonitor/linux/lwt_inotify.cmo : \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    fsmonitor/linux/inotify.cmi \
+    fsmonitor/linux/lwt_inotify.cmi
+fsmonitor/linux/lwt_inotify.cmx : \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    fsmonitor/linux/inotify.cmx \
+    fsmonitor/linux/lwt_inotify.cmi
+fsmonitor/linux/lwt_inotify.cmi : \
+    lwt/lwt.cmi \
+    fsmonitor/linux/inotify.cmi
+fsmonitor/linux/watcher.cmo : \
+    fsmonitor/watchercommon.cmi \
+    lwt/lwt_unix.cmi \
+    fsmonitor/linux/lwt_inotify.cmi \
+    lwt/lwt.cmi \
+    fsmonitor/linux/inotify.cmi
+fsmonitor/linux/watcher.cmx : \
+    fsmonitor/watchercommon.cmx \
+    lwt/lwt_unix.cmx \
+    fsmonitor/linux/lwt_inotify.cmx \
+    lwt/lwt.cmx \
+    fsmonitor/linux/inotify.cmx
+fsmonitor/watchercommon.cmo : \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    fsmonitor/watchercommon.cmi
+fsmonitor/watchercommon.cmx : \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    fsmonitor/watchercommon.cmi
+fsmonitor/watchercommon.cmi :
+fsmonitor/windows/shortnames.cmo : \
+    fsmonitor/windows/shortnames.cmi
+fsmonitor/windows/shortnames.cmx : \
+    fsmonitor/windows/shortnames.cmi
+fsmonitor/windows/shortnames.cmi :
+fsmonitor/windows/watcher.cmo : \
+    fsmonitor/watchercommon.cmi \
+    fsmonitor/windows/shortnames.cmi \
+    lwt/lwt.cmi
+fsmonitor/windows/watcher.cmx : \
+    fsmonitor/watchercommon.cmx \
+    fsmonitor/windows/shortnames.cmx \
+    lwt/lwt.cmx
+fspath.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    system.cmi \
+    ubase/rx.cmi \
+    path.cmi \
+    name.cmi \
+    fileutil.cmi \
+    fspath.cmi
+fspath.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    system.cmx \
+    ubase/rx.cmx \
+    path.cmx \
+    name.cmx \
+    fileutil.cmx \
+    fspath.cmi
+fspath.cmi : \
+    system.cmi \
+    path.cmi \
+    name.cmi
+fswatch.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    fspath.cmi \
     fswatch.cmi
-fswatch.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx system.cmx \
-    ubase/prefs.cmx path.cmx lwt/lwt_unix.cmx lwt/lwt.cmx fspath.cmx \
+fswatch.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    fspath.cmx \
     fswatch.cmi
-fswatchold.cmo : uutil.cmi ubase/util.cmi system.cmi ubase/safelist.cmi \
-    ubase/prefs.cmi pred.cmi path.cmi os.cmi lwt/lwt_unix.cmi lwt/lwt.cmi \
-    globals.cmi fswatch.cmi fspath.cmi fswatchold.cmi
-fswatchold.cmx : uutil.cmx ubase/util.cmx system.cmx ubase/safelist.cmx \
-    ubase/prefs.cmx pred.cmx path.cmx os.cmx lwt/lwt_unix.cmx lwt/lwt.cmx \
-    globals.cmx fswatch.cmx fspath.cmx fswatchold.cmi
-globals.cmo : ubase/util.cmi ubase/trace.cmi ubase/safelist.cmi remote.cmi \
-    ubase/prefs.cmi pred.cmi path.cmi os.cmi name.cmi lwt/lwt_util.cmi \
-    lwt/lwt_unix.cmi lwt/lwt.cmi common.cmi clroot.cmi globals.cmi
-globals.cmx : ubase/util.cmx ubase/trace.cmx ubase/safelist.cmx remote.cmx \
-    ubase/prefs.cmx pred.cmx path.cmx os.cmx name.cmx lwt/lwt_util.cmx \
-    lwt/lwt_unix.cmx lwt/lwt.cmx common.cmx clroot.cmx globals.cmi
-linkgtk.cmo : main.cmo
-linkgtk.cmx : main.cmx
-linkgtk2.cmo : uigtk2.cmi main.cmo
-linkgtk2.cmx : uigtk2.cmx main.cmx
-linktext.cmo : uitext.cmi main.cmo
-linktext.cmx : uitext.cmx main.cmx
-lock.cmo : ubase/util.cmi system.cmi lock.cmi
-lock.cmx : ubase/util.cmx system.cmx lock.cmi
-main.cmo : uutil.cmi ubase/util.cmi uitext.cmi uicommon.cmi strings.cmi \
-    ubase/safelist.cmi remote.cmi ubase/prefs.cmi os.cmi
-main.cmx : uutil.cmx ubase/util.cmx uitext.cmx uicommon.cmx strings.cmx \
-    ubase/safelist.cmx remote.cmx ubase/prefs.cmx os.cmx
-mkProjectInfo.cmo :
-mkProjectInfo.cmx :
-name.cmo : ubase/util.cmi ubase/rx.cmi case.cmi name.cmi
-name.cmx : ubase/util.cmx ubase/rx.cmx case.cmx name.cmi
-os.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi system.cmi \
-    ubase/safelist.cmi props.cmi ubase/prefs.cmi path.cmi osx.cmi name.cmi \
-    fspath.cmi fs.cmi fingerprint.cmi fileinfo.cmi os.cmi
-os.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx system.cmx \
-    ubase/safelist.cmx props.cmx ubase/prefs.cmx path.cmx osx.cmx name.cmx \
-    fspath.cmx fs.cmx fingerprint.cmx fileinfo.cmx os.cmi
-osx.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi system.cmi \
-    ubase/safelist.cmi ubase/prefs.cmi path.cmi name.cmi fspath.cmi fs.cmi \
-    fingerprint.cmi osx.cmi
-osx.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx system.cmx \
-    ubase/safelist.cmx ubase/prefs.cmx path.cmx name.cmx fspath.cmx fs.cmx \
-    fingerprint.cmx osx.cmi
-path.cmo : ubase/util.cmi ubase/safelist.cmi ubase/rx.cmi pred.cmi name.cmi \
-    fileutil.cmi case.cmi path.cmi
-path.cmx : ubase/util.cmx ubase/safelist.cmx ubase/rx.cmx pred.cmx name.cmx \
-    fileutil.cmx case.cmx path.cmi
+fswatch.cmi : \
+    ubase/prefs.cmi \
+    path.cmi \
+    lwt/lwt.cmi \
+    fspath.cmi
+fswatchold.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fswatch.cmi \
+    fspath.cmi \
+    fswatchold.cmi
+fswatchold.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    ubase/prefs.cmx \
+    pred.cmx \
+    path.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fswatch.cmx \
+    fspath.cmx \
+    fswatchold.cmi
+fswatchold.cmi : \
+    path.cmi \
+    lwt/lwt.cmi \
+    fspath.cmi
+globals.cmo : \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    os.cmi \
+    name.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    common.cmi \
+    clroot.cmi \
+    globals.cmi
+globals.cmx : \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    ubase/prefs.cmx \
+    pred.cmx \
+    path.cmx \
+    os.cmx \
+    name.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    common.cmx \
+    clroot.cmx \
+    globals.cmi
+globals.cmi : \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    lwt/lwt.cmi \
+    common.cmi
+linkgtk.cmo : \
+    main.cmo
+linkgtk.cmx : \
+    main.cmx
+linkgtk2.cmo : \
+    uigtk2.cmi \
+    main.cmo
+linkgtk2.cmx : \
+    uigtk2.cmx \
+    main.cmx
+linktext.cmo : \
+    uitext.cmi \
+    main.cmo
+linktext.cmx : \
+    uitext.cmx \
+    main.cmx
+lock.cmo : \
+    ubase/util.cmi \
+    system.cmi \
+    lock.cmi
+lock.cmx : \
+    ubase/util.cmx \
+    system.cmx \
+    lock.cmi
+lock.cmi : \
+    system.cmi
+lwt/example/editor.cmo : \
+    lwt/lwt_unix.cmi
+lwt/example/editor.cmx : \
+    lwt/lwt_unix.cmx
+lwt/example/relay.cmo : \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi
+lwt/example/relay.cmx : \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx
+lwt/generic/lwt_unix_impl.cmo : \
+    lwt/pqueue.cmi \
+    lwt/lwt.cmi
+lwt/generic/lwt_unix_impl.cmx : \
+    lwt/pqueue.cmx \
+    lwt/lwt.cmx
+lwt/lwt.cmo : \
+    lwt/lwt.cmi
+lwt/lwt.cmx : \
+    lwt/lwt.cmi
+lwt/lwt.cmi :
+lwt/lwt_unix.cmo : \
+    lwt/lwt_unix.cmi
+lwt/lwt_unix.cmx : \
+    lwt/lwt_unix.cmi
+lwt/lwt_unix.cmi : \
+    lwt/lwt.cmi
+lwt/lwt_util.cmo : \
+    lwt/lwt.cmi \
+    lwt/lwt_util.cmi
+lwt/lwt_util.cmx : \
+    lwt/lwt.cmx \
+    lwt/lwt_util.cmi
+lwt/lwt_util.cmi : \
+    lwt/lwt.cmi
+lwt/pqueue.cmo : \
+    lwt/pqueue.cmi
+lwt/pqueue.cmx : \
+    lwt/pqueue.cmi
+lwt/pqueue.cmi :
+lwt/win/lwt_unix_impl.cmo : \
+    lwt/pqueue.cmi \
+    lwt/lwt.cmi
+lwt/win/lwt_unix_impl.cmx : \
+    lwt/pqueue.cmx \
+    lwt/lwt.cmx
+lwt/win/lwt_win.cmo : \
+    lwt/win/lwt_win.cmi
+lwt/win/lwt_win.cmx : \
+    lwt/win/lwt_win.cmi
+lwt/win/lwt_win.cmi : \
+    lwt/lwt.cmi
+main.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    uitext.cmi \
+    uicommon.cmi \
+    strings.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    ubase/prefs.cmi \
+    os.cmi
+main.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    uitext.cmx \
+    uicommon.cmx \
+    strings.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    ubase/prefs.cmx \
+    os.cmx
+name.cmo : \
+    ubase/util.cmi \
+    ubase/rx.cmi \
+    case.cmi \
+    name.cmi
+name.cmx : \
+    ubase/util.cmx \
+    ubase/rx.cmx \
+    case.cmx \
+    name.cmi
+name.cmi :
+os.cmo : \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    name.cmi \
+    fspath.cmi \
+    fs.cmi \
+    fingerprint.cmi \
+    fileinfo.cmi \
+    os.cmi
+os.cmx : \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    osx.cmx \
+    name.cmx \
+    fspath.cmx \
+    fs.cmx \
+    fingerprint.cmx \
+    fileinfo.cmx \
+    os.cmi
+os.cmi : \
+    uutil.cmi \
+    props.cmi \
+    path.cmi \
+    name.cmi \
+    fspath.cmi \
+    fileinfo.cmi
+osx.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    name.cmi \
+    fspath.cmi \
+    fs.cmi \
+    fingerprint.cmi \
+    osx.cmi
+osx.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    name.cmx \
+    fspath.cmx \
+    fs.cmx \
+    fingerprint.cmx \
+    osx.cmi
+osx.cmi : \
+    uutil.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    fspath.cmi \
+    fingerprint.cmi
+path.cmo : \
+    ubase/util.cmi \
+    ubase/safelist.cmi \
+    ubase/rx.cmi \
+    pred.cmi \
+    name.cmi \
+    fileutil.cmi \
+    case.cmi \
+    path.cmi
+path.cmx : \
+    ubase/util.cmx \
+    ubase/safelist.cmx \
+    ubase/rx.cmx \
+    pred.cmx \
+    name.cmx \
+    fileutil.cmx \
+    case.cmx \
+    path.cmi
+path.cmi : \
+    pred.cmi \
+    name.cmi
 pixmaps.cmo :
 pixmaps.cmx :
-pred.cmo : ubase/util.cmi ubase/safelist.cmi ubase/rx.cmi ubase/prefs.cmi \
-    case.cmi pred.cmi
-pred.cmx : ubase/util.cmx ubase/safelist.cmx ubase/rx.cmx ubase/prefs.cmx \
-    case.cmx pred.cmi
-props.cmo : uutil.cmi ubase/util.cmi ubase/prefs.cmi path.cmi osx.cmi \
-    lwt/lwt_unix.cmi fspath.cmi fs.cmi external.cmi props.cmi
-props.cmx : uutil.cmx ubase/util.cmx ubase/prefs.cmx path.cmx osx.cmx \
-    lwt/lwt_unix.cmx fspath.cmx fs.cmx external.cmx props.cmi
-recon.cmo : uutil.cmi ubase/util.cmi update.cmi tree.cmi ubase/trace.cmi \
-    sortri.cmi ubase/safelist.cmi props.cmi ubase/prefs.cmi pred.cmi path.cmi \
-    name.cmi globals.cmi fileinfo.cmi common.cmi recon.cmi
-recon.cmx : uutil.cmx ubase/util.cmx update.cmx tree.cmx ubase/trace.cmx \
-    sortri.cmx ubase/safelist.cmx props.cmx ubase/prefs.cmx pred.cmx path.cmx \
-    name.cmx globals.cmx fileinfo.cmx common.cmx recon.cmi
-remote.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi terminal.cmi \
-    system.cmi ubase/safelist.cmi ubase/prefs.cmi os.cmi lwt/lwt_util.cmi \
-    lwt/lwt_unix.cmi lwt/lwt.cmi fspath.cmi fs.cmi common.cmi clroot.cmi \
-    case.cmi bytearray.cmi remote.cmi
-remote.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx terminal.cmx \
-    system.cmx ubase/safelist.cmx ubase/prefs.cmx os.cmx lwt/lwt_util.cmx \
-    lwt/lwt_unix.cmx lwt/lwt.cmx fspath.cmx fs.cmx common.cmx clroot.cmx \
-    case.cmx bytearray.cmx remote.cmi
-sortri.cmo : ubase/util.cmi ubase/safelist.cmi ubase/prefs.cmi pred.cmi \
-    path.cmi common.cmi sortri.cmi
-sortri.cmx : ubase/util.cmx ubase/safelist.cmx ubase/prefs.cmx pred.cmx \
-    path.cmx common.cmx sortri.cmi
-stasher.cmo : xferhint.cmi ubase/util.cmi update.cmi system.cmi \
-    ubase/safelist.cmi remote.cmi props.cmi ubase/prefs.cmi pred.cmi path.cmi \
-    osx.cmi os.cmi lwt/lwt_unix.cmi lwt/lwt.cmi globals.cmi fspath.cmi \
-    fingerprint.cmi fileutil.cmi fileinfo.cmi copy.cmi common.cmi stasher.cmi
-stasher.cmx : xferhint.cmx ubase/util.cmx update.cmx system.cmx \
-    ubase/safelist.cmx remote.cmx props.cmx ubase/prefs.cmx pred.cmx path.cmx \
-    osx.cmx os.cmx lwt/lwt_unix.cmx lwt/lwt.cmx globals.cmx fspath.cmx \
-    fingerprint.cmx fileutil.cmx fileinfo.cmx copy.cmx common.cmx stasher.cmi
-strings.cmo : strings.cmi
-strings.cmx : strings.cmi
-system.cmo : system.cmi
-system.cmx : system.cmi
-terminal.cmo : system.cmi ubase/rx.cmi lwt/lwt_unix.cmi lwt/lwt.cmi \
-    terminal.cmi
-terminal.cmx : system.cmx ubase/rx.cmx lwt/lwt_unix.cmx lwt/lwt.cmx \
-    terminal.cmi
-test.cmo : uutil.cmi ubase/util.cmi update.cmi uicommon.cmi transport.cmi \
-    ubase/trace.cmi stasher.cmi ubase/safelist.cmi remote.cmi recon.cmi \
-    ubase/prefs.cmi path.cmi os.cmi lwt/lwt_util.cmi lwt/lwt_unix.cmi \
-    lwt/lwt.cmi globals.cmi fspath.cmi fs.cmi fingerprint.cmi common.cmi \
-    test.cmi
-test.cmx : uutil.cmx ubase/util.cmx update.cmx uicommon.cmx transport.cmx \
-    ubase/trace.cmx stasher.cmx ubase/safelist.cmx remote.cmx recon.cmx \
-    ubase/prefs.cmx path.cmx os.cmx lwt/lwt_util.cmx lwt/lwt_unix.cmx \
-    lwt/lwt.cmx globals.cmx fspath.cmx fs.cmx fingerprint.cmx common.cmx \
-    test.cmi
-transfer.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi ubase/safelist.cmi \
-    lwt/lwt.cmi checksum.cmi bytearray.cmi transfer.cmi
-transfer.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx ubase/safelist.cmx \
-    lwt/lwt.cmx checksum.cmx bytearray.cmx transfer.cmi
-transport.cmo : uutil.cmi ubase/util.cmi ubase/trace.cmi remote.cmi \
-    props.cmi ubase/prefs.cmi path.cmi osx.cmi lwt/lwt_util.cmi lwt/lwt.cmi \
-    globals.cmi files.cmi common.cmi abort.cmi transport.cmi
-transport.cmx : uutil.cmx ubase/util.cmx ubase/trace.cmx remote.cmx \
-    props.cmx ubase/prefs.cmx path.cmx osx.cmx lwt/lwt_util.cmx lwt/lwt.cmx \
-    globals.cmx files.cmx common.cmx abort.cmx transport.cmi
-tree.cmo : ubase/safelist.cmi tree.cmi
-tree.cmx : ubase/safelist.cmx tree.cmi
-uicommon.cmo : xferhint.cmi uutil.cmi ubase/util.cmi update.cmi \
-    ubase/trace.cmi system.cmi stasher.cmi ubase/safelist.cmi remote.cmi \
-    recon.cmi props.cmi ubase/prefs.cmi path.cmi osx.cmi os.cmi name.cmi \
-    lwt/lwt_unix.cmi lwt/lwt.cmi globals.cmi fspath.cmi files.cmi \
-    fileinfo.cmi common.cmi clroot.cmi case.cmi uicommon.cmi
-uicommon.cmx : xferhint.cmx uutil.cmx ubase/util.cmx update.cmx \
-    ubase/trace.cmx system.cmx stasher.cmx ubase/safelist.cmx remote.cmx \
-    recon.cmx props.cmx ubase/prefs.cmx path.cmx osx.cmx os.cmx name.cmx \
-    lwt/lwt_unix.cmx lwt/lwt.cmx globals.cmx fspath.cmx files.cmx \
-    fileinfo.cmx common.cmx clroot.cmx case.cmx uicommon.cmi
-uigtk2.cmo : uutil.cmi ubase/util.cmi update.cmi unicode.cmi uitext.cmi \
-    uicommon.cmi transport.cmi ubase/trace.cmi system.cmi strings.cmi \
-    sortri.cmi ubase/safelist.cmi remote.cmi recon.cmi ubase/prefs.cmi \
-    pixmaps.cmo path.cmi os.cmi lwt/lwt_util.cmi lwt/lwt_unix.cmi lwt/lwt.cmi \
-    globals.cmi files.cmi common.cmi clroot.cmi case.cmi uigtk2.cmi
-uigtk2.cmx : uutil.cmx ubase/util.cmx update.cmx unicode.cmx uitext.cmx \
-    uicommon.cmx transport.cmx ubase/trace.cmx system.cmx strings.cmx \
-    sortri.cmx ubase/safelist.cmx remote.cmx recon.cmx ubase/prefs.cmx \
-    pixmaps.cmx path.cmx os.cmx lwt/lwt_util.cmx lwt/lwt_unix.cmx lwt/lwt.cmx \
-    globals.cmx files.cmx common.cmx clroot.cmx case.cmx uigtk2.cmi
-uimacbridge.cmo : xferhint.cmi uutil.cmi ubase/util.cmi update.cmi \
-    uicommon.cmi transport.cmi ubase/trace.cmi terminal.cmi system.cmi \
-    stasher.cmi ubase/safelist.cmi remote.cmi recon.cmi ubase/prefs.cmi \
-    path.cmi os.cmi main.cmo lwt/lwt_util.cmi lwt/lwt_unix.cmi lwt/lwt.cmi \
-    globals.cmi fspath.cmi files.cmi common.cmi clroot.cmi
-uimacbridge.cmx : xferhint.cmx uutil.cmx ubase/util.cmx update.cmx \
-    uicommon.cmx transport.cmx ubase/trace.cmx terminal.cmx system.cmx \
-    stasher.cmx ubase/safelist.cmx remote.cmx recon.cmx ubase/prefs.cmx \
-    path.cmx os.cmx main.cmx lwt/lwt_util.cmx lwt/lwt_unix.cmx lwt/lwt.cmx \
-    globals.cmx fspath.cmx files.cmx common.cmx clroot.cmx
-uimacbridgenew.cmo : xferhint.cmi uutil.cmi ubase/util.cmi update.cmi \
-    unicode.cmi uicommon.cmi transport.cmi ubase/trace.cmi terminal.cmi \
-    system.cmi stasher.cmi ubase/safelist.cmi remote.cmi recon.cmi \
-    ubase/prefs.cmi path.cmi os.cmi main.cmo lwt/lwt_util.cmi \
-    lwt/lwt_unix.cmi lwt/lwt.cmi globals.cmi fspath.cmi files.cmi common.cmi \
-    clroot.cmi
-uimacbridgenew.cmx : xferhint.cmx uutil.cmx ubase/util.cmx update.cmx \
-    unicode.cmx uicommon.cmx transport.cmx ubase/trace.cmx terminal.cmx \
-    system.cmx stasher.cmx ubase/safelist.cmx remote.cmx recon.cmx \
-    ubase/prefs.cmx path.cmx os.cmx main.cmx lwt/lwt_util.cmx \
-    lwt/lwt_unix.cmx lwt/lwt.cmx globals.cmx fspath.cmx files.cmx common.cmx \
-    clroot.cmx
-uitext.cmo : uutil.cmi ubase/util.cmi update.cmi uicommon.cmi transport.cmi \
-    ubase/trace.cmi system.cmi ubase/safelist.cmi remote.cmi recon.cmi \
-    ubase/prefs.cmi path.cmi lwt/lwt_util.cmi lwt/lwt_unix.cmi lwt/lwt.cmi \
-    globals.cmi fswatchold.cmi common.cmi uitext.cmi
-uitext.cmx : uutil.cmx ubase/util.cmx update.cmx uicommon.cmx transport.cmx \
-    ubase/trace.cmx system.cmx ubase/safelist.cmx remote.cmx recon.cmx \
-    ubase/prefs.cmx path.cmx lwt/lwt_util.cmx lwt/lwt_unix.cmx lwt/lwt.cmx \
-    globals.cmx fswatchold.cmx common.cmx uitext.cmi
-unicode.cmo : unicode_tables.cmo unicode.cmi
-unicode.cmx : unicode_tables.cmx unicode.cmi
-unicode_tables.cmo :
-unicode_tables.cmx :
-update.cmo : xferhint.cmi uutil.cmi ubase/util.cmi tree.cmi ubase/trace.cmi \
-    system.cmi ubase/safelist.cmi remote.cmi props.cmi ubase/proplist.cmi \
-    ubase/prefs.cmi pred.cmi path.cmi osx.cmi os.cmi name.cmi ubase/myMap.cmi \
-    lwt/lwt_unix.cmi lwt/lwt.cmi lock.cmi globals.cmi fswatchold.cmi \
-    fswatch.cmi fspath.cmi fpcache.cmi fingerprint.cmi fileinfo.cmi \
-    common.cmi case.cmi update.cmi
-update.cmx : xferhint.cmx uutil.cmx ubase/util.cmx tree.cmx ubase/trace.cmx \
-    system.cmx ubase/safelist.cmx remote.cmx props.cmx ubase/proplist.cmx \
-    ubase/prefs.cmx pred.cmx path.cmx osx.cmx os.cmx name.cmx ubase/myMap.cmx \
-    lwt/lwt_unix.cmx lwt/lwt.cmx lock.cmx globals.cmx fswatchold.cmx \
-    fswatch.cmx fspath.cmx fpcache.cmx fingerprint.cmx fileinfo.cmx \
-    common.cmx case.cmx update.cmi
-uutil.cmo : ubase/util.cmi ubase/trace.cmi uutil.cmi
-uutil.cmx : ubase/util.cmx ubase/trace.cmx uutil.cmi
-xferhint.cmo : ubase/util.cmi ubase/trace.cmi ubase/prefs.cmi path.cmi \
-    os.cmi fspath.cmi xferhint.cmi
-xferhint.cmx : ubase/util.cmx ubase/trace.cmx ubase/prefs.cmx path.cmx \
-    os.cmx fspath.cmx xferhint.cmi
-fsmonitor/watchercommon.cmo : lwt/lwt_unix.cmi lwt/lwt.cmi \
-    fsmonitor/watchercommon.cmi
-fsmonitor/watchercommon.cmx : lwt/lwt_unix.cmx lwt/lwt.cmx \
-    fsmonitor/watchercommon.cmi
-lwt/lwt.cmo : lwt/lwt.cmi
-lwt/lwt.cmx : lwt/lwt.cmi
-lwt/lwt_unix.cmo : lwt/lwt_unix.cmi
-lwt/lwt_unix.cmx : lwt/lwt_unix.cmi
-lwt/lwt_util.cmo : lwt/lwt.cmi lwt/lwt_util.cmi
-lwt/lwt_util.cmx : lwt/lwt.cmx lwt/lwt_util.cmi
-lwt/pqueue.cmo : lwt/pqueue.cmi
-lwt/pqueue.cmx : lwt/pqueue.cmi
+pred.cmo : \
+    ubase/util.cmi \
+    ubase/safelist.cmi \
+    ubase/rx.cmi \
+    ubase/prefs.cmi \
+    case.cmi \
+    pred.cmi
+pred.cmx : \
+    ubase/util.cmx \
+    ubase/safelist.cmx \
+    ubase/rx.cmx \
+    ubase/prefs.cmx \
+    case.cmx \
+    pred.cmi
+pred.cmi :
+props.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    lwt/lwt_unix.cmi \
+    fspath.cmi \
+    fs.cmi \
+    external.cmi \
+    props.cmi
+props.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    osx.cmx \
+    lwt/lwt_unix.cmx \
+    fspath.cmx \
+    fs.cmx \
+    external.cmx \
+    props.cmi
+props.cmi : \
+    uutil.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    fspath.cmi
+recon.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    tree.cmi \
+    ubase/trace.cmi \
+    sortri.cmi \
+    ubase/safelist.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    name.cmi \
+    globals.cmi \
+    fileinfo.cmi \
+    common.cmi \
+    recon.cmi
+recon.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    tree.cmx \
+    ubase/trace.cmx \
+    sortri.cmx \
+    ubase/safelist.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    pred.cmx \
+    path.cmx \
+    name.cmx \
+    globals.cmx \
+    fileinfo.cmx \
+    common.cmx \
+    recon.cmi
+recon.cmi : \
+    props.cmi \
+    path.cmi \
+    common.cmi
+remote.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    terminal.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    ubase/prefs.cmi \
+    os.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    fspath.cmi \
+    fs.cmi \
+    common.cmi \
+    clroot.cmi \
+    case.cmi \
+    bytearray.cmi \
+    remote.cmi
+remote.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    terminal.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    ubase/prefs.cmx \
+    os.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    fspath.cmx \
+    fs.cmx \
+    common.cmx \
+    clroot.cmx \
+    case.cmx \
+    bytearray.cmx \
+    remote.cmi
+remote.cmi : \
+    ubase/prefs.cmi \
+    lwt/lwt.cmi \
+    fspath.cmi \
+    common.cmi \
+    clroot.cmi \
+    bytearray.cmi
+sortri.cmo : \
+    ubase/util.cmi \
+    ubase/safelist.cmi \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    common.cmi \
+    sortri.cmi
+sortri.cmx : \
+    ubase/util.cmx \
+    ubase/safelist.cmx \
+    ubase/prefs.cmx \
+    pred.cmx \
+    path.cmx \
+    common.cmx \
+    sortri.cmi
+sortri.cmi : \
+    common.cmi
+stasher.cmo : \
+    xferhint.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fspath.cmi \
+    fingerprint.cmi \
+    fileutil.cmi \
+    fileinfo.cmi \
+    copy.cmi \
+    common.cmi \
+    stasher.cmi
+stasher.cmx : \
+    xferhint.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    pred.cmx \
+    path.cmx \
+    osx.cmx \
+    os.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fspath.cmx \
+    fingerprint.cmx \
+    fileutil.cmx \
+    fileinfo.cmx \
+    copy.cmx \
+    common.cmx \
+    stasher.cmi
+stasher.cmi : \
+    update.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    os.cmi \
+    fspath.cmi
+strings.cmo : \
+    strings.cmi
+strings.cmx : \
+    strings.cmi
+strings.cmi :
+system.cmo : \
+    system.cmi
+system.cmx : \
+    system.cmi
+system.cmi : \
+    system/system_intf.cmo
+system/generic/system_impl.cmo : \
+    system/system_generic.cmo
+system/generic/system_impl.cmx : \
+    system/system_generic.cmx
 system/system_generic.cmo :
 system/system_generic.cmx :
 system/system_intf.cmo :
 system/system_intf.cmx :
-system/system_win.cmo : unicode.cmi system/system_generic.cmo ubase/rx.cmi
-system/system_win.cmx : unicode.cmx system/system_generic.cmx ubase/rx.cmx
-ubase/myMap.cmo : ubase/myMap.cmi
-ubase/myMap.cmx : ubase/myMap.cmi
-ubase/prefs.cmo : ubase/util.cmi ubase/uarg.cmi system.cmi \
-    ubase/safelist.cmi ubase/prefs.cmi
-ubase/prefs.cmx : ubase/util.cmx ubase/uarg.cmx system.cmx \
-    ubase/safelist.cmx ubase/prefs.cmi
-ubase/proplist.cmo : ubase/util.cmi ubase/proplist.cmi
-ubase/proplist.cmx : ubase/util.cmx ubase/proplist.cmi
-ubase/rx.cmo : ubase/rx.cmi
-ubase/rx.cmx : ubase/rx.cmi
-ubase/safelist.cmo : ubase/safelist.cmi
-ubase/safelist.cmx : ubase/safelist.cmi
-ubase/trace.cmo : ubase/util.cmi system.cmi ubase/safelist.cmi \
-    ubase/prefs.cmi ubase/trace.cmi
-ubase/trace.cmx : ubase/util.cmx system.cmx ubase/safelist.cmx \
-    ubase/prefs.cmx ubase/trace.cmi
-ubase/uarg.cmo : ubase/util.cmi system.cmi ubase/safelist.cmi ubase/uarg.cmi
-ubase/uarg.cmx : ubase/util.cmx system.cmx ubase/safelist.cmx ubase/uarg.cmi
-ubase/util.cmo : system.cmi ubase/safelist.cmi ubase/util.cmi
-ubase/util.cmx : system.cmx ubase/safelist.cmx ubase/util.cmi
-fsmonitor/watchercommon.cmi :
-lwt/lwt.cmi :
-lwt/lwt_unix.cmi : lwt/lwt.cmi
-lwt/lwt_util.cmi : lwt/lwt.cmi
-lwt/pqueue.cmi :
+system/system_win.cmo : \
+    unicode.cmi \
+    system/system_generic.cmo \
+    ubase/rx.cmi
+system/system_win.cmx : \
+    unicode.cmx \
+    system/system_generic.cmx \
+    ubase/rx.cmx
+system/win/system_impl.cmo : \
+    system/system_win.cmo \
+    system/system_generic.cmo
+system/win/system_impl.cmx : \
+    system/system_win.cmx \
+    system/system_generic.cmx
+terminal.cmo : \
+    system.cmi \
+    ubase/rx.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    terminal.cmi
+terminal.cmx : \
+    system.cmx \
+    ubase/rx.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    terminal.cmi
+terminal.cmi : \
+    lwt/lwt_unix.cmi
+test.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    uicommon.cmi \
+    transport.cmi \
+    ubase/trace.cmi \
+    stasher.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    recon.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    os.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fspath.cmi \
+    fs.cmi \
+    fingerprint.cmi \
+    common.cmi \
+    test.cmi
+test.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    uicommon.cmx \
+    transport.cmx \
+    ubase/trace.cmx \
+    stasher.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    recon.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    os.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fspath.cmx \
+    fs.cmx \
+    fingerprint.cmx \
+    common.cmx \
+    test.cmi
+test.cmi :
+transfer.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    ubase/safelist.cmi \
+    lwt/lwt.cmi \
+    checksum.cmi \
+    bytearray.cmi \
+    transfer.cmi
+transfer.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    ubase/safelist.cmx \
+    lwt/lwt.cmx \
+    checksum.cmx \
+    bytearray.cmx \
+    transfer.cmi
+transfer.cmi : \
+    uutil.cmi \
+    lwt/lwt.cmi \
+    bytearray.cmi
+transport.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    remote.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    osx.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    files.cmi \
+    common.cmi \
+    abort.cmi \
+    transport.cmi
+transport.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    remote.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    osx.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    files.cmx \
+    common.cmx \
+    abort.cmx \
+    transport.cmi
+transport.cmi : \
+    uutil.cmi \
+    lwt/lwt.cmi \
+    common.cmi
+tree.cmo : \
+    ubase/safelist.cmi \
+    tree.cmi
+tree.cmx : \
+    ubase/safelist.cmx \
+    tree.cmi
+tree.cmi :
+ubase/myMap.cmo : \
+    ubase/myMap.cmi
+ubase/myMap.cmx : \
+    ubase/myMap.cmi
 ubase/myMap.cmi :
-ubase/prefs.cmi : ubase/util.cmi system.cmi
+ubase/prefs.cmo : \
+    ubase/util.cmi \
+    ubase/uarg.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    ubase/prefs.cmi
+ubase/prefs.cmx : \
+    ubase/util.cmx \
+    ubase/uarg.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    ubase/prefs.cmi
+ubase/prefs.cmi : \
+    ubase/util.cmi \
+    system.cmi
+ubase/projectInfo.cmo :
+ubase/projectInfo.cmx :
+ubase/proplist.cmo : \
+    ubase/util.cmi \
+    ubase/proplist.cmi
+ubase/proplist.cmx : \
+    ubase/util.cmx \
+    ubase/proplist.cmi
 ubase/proplist.cmi :
+ubase/rx.cmo : \
+    ubase/rx.cmi
+ubase/rx.cmx : \
+    ubase/rx.cmi
 ubase/rx.cmi :
+ubase/safelist.cmo : \
+    ubase/safelist.cmi
+ubase/safelist.cmx : \
+    ubase/safelist.cmi
 ubase/safelist.cmi :
-ubase/trace.cmi : ubase/prefs.cmi
+ubase/trace.cmo : \
+    ubase/util.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    ubase/prefs.cmi \
+    ubase/trace.cmi
+ubase/trace.cmx : \
+    ubase/util.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    ubase/prefs.cmx \
+    ubase/trace.cmi
+ubase/trace.cmi : \
+    ubase/prefs.cmi
+ubase/uarg.cmo : \
+    ubase/util.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    ubase/uarg.cmi
+ubase/uarg.cmx : \
+    ubase/util.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    ubase/uarg.cmi
 ubase/uarg.cmi :
-ubase/util.cmi : system.cmi
-fsmonitor/linux/inotify.cmo : fsmonitor/linux/inotify.cmi
-fsmonitor/linux/inotify.cmx : fsmonitor/linux/inotify.cmi
-fsmonitor/linux/lwt_inotify.cmo : lwt/lwt_unix.cmi lwt/lwt.cmi \
-    fsmonitor/linux/inotify.cmi fsmonitor/linux/lwt_inotify.cmi
-fsmonitor/linux/lwt_inotify.cmx : lwt/lwt_unix.cmx lwt/lwt.cmx \
-    fsmonitor/linux/inotify.cmx fsmonitor/linux/lwt_inotify.cmi
-fsmonitor/linux/watcher.cmo : fsmonitor/watchercommon.cmi lwt/lwt_unix.cmi \
-    fsmonitor/linux/lwt_inotify.cmi lwt/lwt.cmi fsmonitor/linux/inotify.cmi
-fsmonitor/linux/watcher.cmx : fsmonitor/watchercommon.cmx lwt/lwt_unix.cmx \
-    fsmonitor/linux/lwt_inotify.cmx lwt/lwt.cmx fsmonitor/linux/inotify.cmx
-fsmonitor/windows/shortnames.cmo : fsmonitor/windows/shortnames.cmi
-fsmonitor/windows/shortnames.cmx : fsmonitor/windows/shortnames.cmi
-fsmonitor/windows/watcher.cmo : fsmonitor/watchercommon.cmi \
-    fsmonitor/windows/shortnames.cmi lwt/lwt.cmi
-fsmonitor/windows/watcher.cmx : fsmonitor/watchercommon.cmx \
-    fsmonitor/windows/shortnames.cmx lwt/lwt.cmx
-lwt/example/editor.cmo : lwt/lwt_unix.cmi
-lwt/example/editor.cmx : lwt/lwt_unix.cmx
-lwt/example/relay.cmo : lwt/lwt_unix.cmi lwt/lwt.cmi
-lwt/example/relay.cmx : lwt/lwt_unix.cmx lwt/lwt.cmx
-lwt/generic/lwt_unix_impl.cmo : lwt/pqueue.cmi lwt/lwt.cmi
-lwt/generic/lwt_unix_impl.cmx : lwt/pqueue.cmx lwt/lwt.cmx
-lwt/win/lwt_unix_impl.cmo : lwt/pqueue.cmi lwt/lwt.cmi
-lwt/win/lwt_unix_impl.cmx : lwt/pqueue.cmx lwt/lwt.cmx
-lwt/win/lwt_win.cmo : lwt/win/lwt_win.cmi
-lwt/win/lwt_win.cmx : lwt/win/lwt_win.cmi
-system/generic/system_impl.cmo : system/system_generic.cmo
-system/generic/system_impl.cmx : system/system_generic.cmx
-system/win/system_impl.cmo : system/system_win.cmo system/system_generic.cmo
-system/win/system_impl.cmx : system/system_win.cmx system/system_generic.cmx
-fsmonitor/linux/inotify.cmi :
-fsmonitor/linux/lwt_inotify.cmi : lwt/lwt.cmi fsmonitor/linux/inotify.cmi
-fsmonitor/windows/shortnames.cmi :
-lwt/win/lwt_win.cmi : lwt/lwt.cmi
+ubase/util.cmo : \
+    system.cmi \
+    ubase/safelist.cmi \
+    ubase/projectInfo.cmo \
+    ubase/util.cmi
+ubase/util.cmx : \
+    system.cmx \
+    ubase/safelist.cmx \
+    ubase/projectInfo.cmx \
+    ubase/util.cmi
+ubase/util.cmi : \
+    system.cmi
+ui.cmi :
+uicommon.cmo : \
+    xferhint.cmi \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    stasher.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    recon.cmi \
+    props.cmi \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    name.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fspath.cmi \
+    files.cmi \
+    fileinfo.cmi \
+    common.cmi \
+    clroot.cmi \
+    case.cmi \
+    uicommon.cmi
+uicommon.cmx : \
+    xferhint.cmx \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    stasher.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    recon.cmx \
+    props.cmx \
+    ubase/prefs.cmx \
+    pred.cmx \
+    path.cmx \
+    osx.cmx \
+    os.cmx \
+    name.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fspath.cmx \
+    files.cmx \
+    fileinfo.cmx \
+    common.cmx \
+    clroot.cmx \
+    case.cmx \
+    uicommon.cmi
+uicommon.cmi : \
+    uutil.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    lwt/lwt.cmi \
+    common.cmi
+uigtk2.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    unicode.cmi \
+    uitext.cmi \
+    uicommon.cmi \
+    transport.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    strings.cmi \
+    sortri.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    recon.cmi \
+    ubase/prefs.cmi \
+    pixmaps.cmo \
+    path.cmi \
+    os.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    common.cmi \
+    clroot.cmi \
+    case.cmi \
+    uigtk2.cmi
+uigtk2.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    unicode.cmx \
+    uitext.cmx \
+    uicommon.cmx \
+    transport.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    strings.cmx \
+    sortri.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    recon.cmx \
+    ubase/prefs.cmx \
+    pixmaps.cmx \
+    path.cmx \
+    os.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    common.cmx \
+    clroot.cmx \
+    case.cmx \
+    uigtk2.cmi
+uigtk2.cmi : \
+    uicommon.cmi
+uimacbridge.cmo : \
+    xferhint.cmi \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    uicommon.cmi \
+    transport.cmi \
+    ubase/trace.cmi \
+    terminal.cmi \
+    system.cmi \
+    stasher.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    recon.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    os.cmi \
+    main.cmo \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fspath.cmi \
+    files.cmi \
+    common.cmi \
+    clroot.cmi
+uimacbridge.cmx : \
+    xferhint.cmx \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    uicommon.cmx \
+    transport.cmx \
+    ubase/trace.cmx \
+    terminal.cmx \
+    system.cmx \
+    stasher.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    recon.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    os.cmx \
+    main.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fspath.cmx \
+    files.cmx \
+    common.cmx \
+    clroot.cmx
+uimacbridgenew.cmo : \
+    xferhint.cmi \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    unicode.cmi \
+    uicommon.cmi \
+    transport.cmi \
+    ubase/trace.cmi \
+    terminal.cmi \
+    system.cmi \
+    stasher.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    recon.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    os.cmi \
+    main.cmo \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fspath.cmi \
+    files.cmi \
+    common.cmi \
+    clroot.cmi
+uimacbridgenew.cmx : \
+    xferhint.cmx \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    unicode.cmx \
+    uicommon.cmx \
+    transport.cmx \
+    ubase/trace.cmx \
+    terminal.cmx \
+    system.cmx \
+    stasher.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    recon.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    os.cmx \
+    main.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fspath.cmx \
+    files.cmx \
+    common.cmx \
+    clroot.cmx
+uitext.cmo : \
+    uutil.cmi \
+    ubase/util.cmi \
+    update.cmi \
+    uicommon.cmi \
+    transport.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    sortri.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    recon.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    lwt/lwt_util.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    globals.cmi \
+    fswatchold.cmi \
+    common.cmi \
+    uitext.cmi
+uitext.cmx : \
+    uutil.cmx \
+    ubase/util.cmx \
+    update.cmx \
+    uicommon.cmx \
+    transport.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    sortri.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    recon.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    lwt/lwt_util.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    globals.cmx \
+    fswatchold.cmx \
+    common.cmx \
+    uitext.cmi
+uitext.cmi : \
+    uicommon.cmi
+unicode.cmo : \
+    unicode_tables.cmo \
+    unicode.cmi
+unicode.cmx : \
+    unicode_tables.cmx \
+    unicode.cmi
+unicode.cmi :
+unicode_tables.cmo :
+unicode_tables.cmx :
+update.cmo : \
+    xferhint.cmi \
+    uutil.cmi \
+    ubase/util.cmi \
+    tree.cmi \
+    ubase/trace.cmi \
+    system.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    props.cmi \
+    ubase/proplist.cmi \
+    ubase/prefs.cmi \
+    pred.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    name.cmi \
+    ubase/myMap.cmi \
+    lwt/lwt_unix.cmi \
+    lwt/lwt.cmi \
+    lock.cmi \
+    globals.cmi \
+    fswatchold.cmi \
+    fswatch.cmi \
+    fspath.cmi \
+    fpcache.cmi \
+    fingerprint.cmi \
+    fileinfo.cmi \
+    common.cmi \
+    case.cmi \
+    update.cmi
+update.cmx : \
+    xferhint.cmx \
+    uutil.cmx \
+    ubase/util.cmx \
+    tree.cmx \
+    ubase/trace.cmx \
+    system.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    props.cmx \
+    ubase/proplist.cmx \
+    ubase/prefs.cmx \
+    pred.cmx \
+    path.cmx \
+    osx.cmx \
+    os.cmx \
+    name.cmx \
+    ubase/myMap.cmx \
+    lwt/lwt_unix.cmx \
+    lwt/lwt.cmx \
+    lock.cmx \
+    globals.cmx \
+    fswatchold.cmx \
+    fswatch.cmx \
+    fspath.cmx \
+    fpcache.cmx \
+    fingerprint.cmx \
+    fileinfo.cmx \
+    common.cmx \
+    case.cmx \
+    update.cmi
+update.cmi : \
+    uutil.cmi \
+    tree.cmi \
+    props.cmi \
+    path.cmi \
+    osx.cmi \
+    os.cmi \
+    name.cmi \
+    ubase/myMap.cmi \
+    lwt/lwt.cmi \
+    fspath.cmi \
+    fileinfo.cmi \
+    common.cmi
+uutil.cmo : \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    ubase/projectInfo.cmo \
+    uutil.cmi
+uutil.cmx : \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    ubase/projectInfo.cmx \
+    uutil.cmi
+uutil.cmi :
+xferhint.cmo : \
+    ubase/util.cmi \
+    ubase/trace.cmi \
+    ubase/prefs.cmi \
+    path.cmi \
+    os.cmi \
+    fspath.cmi \
+    xferhint.cmi
+xferhint.cmx : \
+    ubase/util.cmx \
+    ubase/trace.cmx \
+    ubase/prefs.cmx \
+    path.cmx \
+    os.cmx \
+    fspath.cmx \
+    xferhint.cmi
+xferhint.cmi : \
+    ubase/prefs.cmi \
+    path.cmi \
+    os.cmi \
+    fspath.cmi


### PR DESCRIPTION
One per line makes it easier to generate diffs.

Let's just get this out of the way. This is how `.depend` is generated now and it makes sense when it comes to maintainability. Any patch that includes a re-generated `.depend` would include this enormous diff anyway. Better do it separately to make reviewing code patches easier.