### PR TITLE
RFC: Features - backwards-compatible extensibility

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -1526,11 +1526,13 @@ uutil.cmo : \
     ubase/util.cmi \
     ubase/trace.cmi \
     ubase/projectInfo.cmo \
+    features.cmi \
     uutil.cmi
 uutil.cmx : \
     ubase/util.cmx \
     ubase/trace.cmx \
     ubase/projectInfo.cmx \
+    features.cmx \
     uutil.cmi
 uutil.cmi :
 xferhint.cmo : \

--- a/src/.depend
+++ b/src/.depend
@@ -164,6 +164,13 @@ external.cmx : \
     external.cmi
 external.cmi : \
     lwt/lwt.cmi
+features.cmo : \
+    ubase/util.cmi \
+    features.cmi
+features.cmx : \
+    ubase/util.cmx \
+    features.cmi
+features.cmi :
 fileinfo.cmo : \
     ubase/util.cmi \
     system.cmi \
@@ -474,6 +481,7 @@ globals.cmo : \
     pred.cmi \
     path.cmi \
     os.cmi \
+    negotiate.cmi \
     name.cmi \
     lwt/lwt_util.cmi \
     lwt/lwt_unix.cmi \
@@ -490,6 +498,7 @@ globals.cmx : \
     pred.cmx \
     path.cmx \
     os.cmx \
+    negotiate.cmx \
     name.cmx \
     lwt/lwt_util.cmx \
     lwt/lwt_unix.cmx \
@@ -612,6 +621,25 @@ name.cmx : \
     case.cmx \
     name.cmi
 name.cmi :
+negotiate.cmo : \
+    ubase/util.cmi \
+    ubase/safelist.cmi \
+    remote.cmi \
+    lwt/lwt.cmi \
+    features.cmi \
+    common.cmi \
+    negotiate.cmi
+negotiate.cmx : \
+    ubase/util.cmx \
+    ubase/safelist.cmx \
+    remote.cmx \
+    lwt/lwt.cmx \
+    features.cmx \
+    common.cmx \
+    negotiate.cmi
+negotiate.cmi : \
+    lwt/lwt.cmi \
+    common.cmi
 os.cmo : \
     ubase/util.cmi \
     ubase/trace.cmi \
@@ -1161,6 +1189,7 @@ uicommon.cmo : \
     fspath.cmi \
     files.cmi \
     fileinfo.cmi \
+    features.cmi \
     common.cmi \
     clroot.cmi \
     case.cmi \
@@ -1190,6 +1219,7 @@ uicommon.cmx : \
     fspath.cmx \
     files.cmx \
     fileinfo.cmx \
+    features.cmx \
     common.cmx \
     clroot.cmx \
     case.cmx \

--- a/src/FEATURES.md
+++ b/src/FEATURES.md
@@ -166,8 +166,9 @@ to read and write archive files in this scenario:
   more forgiving variant of the point above, or actually reading and
   unmarshaling the archive according to the features used to write it --
   even if not all the same features are included in the currently negotiated
-  feature set. The latter requires types and code be tailored for this, the
-  same as with the next point below.
+  feature set. The latter is the currently chosen approach. It does require
+  types and code be tailored for this, the same as with the next point below,
+  but to a lesser degree.
 
 - The archive file on-disk format includes information about the types and
   structure of the written data (you can think like a DB with a relatively

--- a/src/FEATURES.md
+++ b/src/FEATURES.md
@@ -1,0 +1,171 @@
+# Introduction and motivation
+
+"Features" is a set of feature names supported by a specific version of
+Unison implementation. Over time, each incompatible change -- whether
+mandatory or an optional add-on -- is assigned a unique feature name.
+
+Features allow a client to connect to and properly work with a server of
+different version, older or newer. When setting up the connection, both
+server and client negotiate a commonly supported set of features.
+
+Using features instead of a version makes the implementation agnostic of any
+versioning schemes, forks and third party implementations. It also allows
+for more flexible code changes over time, without the code being polluted by
+adding more and more conditionals for various version combinations, such as
+"if version < X then", "if version >= Y and version < Z then", and so on.
+
+# Negotiation
+
+Feature negotiation takes place immediately after the RPC connection has
+been fully set up. See `negotiate.ml`.
+
+1. Client sends its full feature set to the server.
+2. Server validates the intersection of its and client's feature sets.
+   - If error then server sends NOK to client. The client closes connection.
+3. If OK then server sends intersection of feature sets to the client.
+4. Client validates the intersection.
+   - If error then client closes connection.
+5. If OK then the negotiation is complete and both server and client will
+   use only features fully supported by both.
+
+## Feature registration
+
+A feature is added to the set by registering it. This can be done by any
+part of the code that "owns" a feature, similar to how user preferences are
+registered. See `features.mli` and `features.ml`.
+
+Registering a feature requires a unique feature name and an optional
+validation function.
+
+## Feature validation
+
+Each feature can provide a separate validation function. When validating
+the intersection of client's and server's feature sets, validation
+functions for each included feature are run in arbitrary sequence.
+
+A validation function will be able to see the entire intersection and can
+freely decide whether the intersection is ok or not. Examples of possible
+validation scenarios:
+
+- A mandatory feature is not in the intersection
+  - This typically means that counterparty is too old, but could also mean
+    that the counterparty is too new and the feature has been removed.
+- User preference enabled for a feature not in intersection
+  (the preferences have not been sent to the server yet, so this
+  validation is not carried out by the server)
+- A feature depends on another feature not in intersection
+
+Some features in the intersection can conflict with each other. This can
+happen for example when two different implementations of a function are
+both supported but must not be used simultaneously. All such conflicts
+are benign in nature and will not cause feature intersection validation
+to fail. (Since the intersection is a subset of the entire feature set
+then failing a conflict would mean that the set of features is conflicting
+to begin with.)
+
+# Development
+
+Every incompatible code change must result in a change to the set of
+features:
+
+- New code that is mandatory to use (effectively breaks compatibility
+  with older versions despite feature negotiation) ->
+  - Register a new feature with a validation function that rejects any
+    feature intersection that does not include this feature
+- New code that is optional to use ->
+  - Register a new feature
+- New code that replaces existing code ->
+  - Register a new feature and remove one or more features
+- Remove existing code ->
+  - Remove one or more features
+- Code is not removed but it can be deprecated ->
+  - Add or change a validation function to output a deprecation warning
+
+## Code evolution, conflicting features
+
+With features, new code does not have to replace existing code even if
+they seemingly conflict. Both an existing feature and a new feature can
+co-exist. The code must be guarded by checking which features are enabled
+at runtime for each remote connection.
+
+For example:
+
+- Existing code implementes feature hash-1.
+- New code implements a new hashing algorithm and adds feature hash-2.
+- Even though two different hashing algorithms must not be used at the
+  same time, both implementations can co-exist as in the following
+  pseudocode example.
+
+```
+function hash
+  if (feature hash-2 enabled) then
+    new algorithm
+  else if (feature hash-1 enabled) then
+    previous algorithm
+  end
+```
+
+- If both server and client support hash-2 then the new implementation
+  will always be used, even if both server and client also support hash-1
+  at the same time.
+- If either server or client does not support hash-2 then the feature
+  intersection will only contain hash-1 and the previous implementation
+  will be used.
+
+Now let's imagine that in addition to hashing algorithm changing with
+the new feature, also the result type changes. This is trickier to implement
+but clearly not impossible.
+
+There are multiple ways of handling parallel implementation of conflicting
+types. These are not the topic of this document, but a few possibilities
+are provided for inspiration:
+
+- Abstract types and type variables
+- Variant types (aka sum types)
+- Extensible variant types
+- First class modules
+- GADTs
+- Classes/objects
+
+### Archive file
+
+Most changes will ultimately result in type changes. This will directly
+impact data encoded in wire format and stored in archive file format.
+
+Data on the wire is transient. As both client and server have agreed on
+a common feature set, they know how to marshal and unmarshal data on the
+wire without any issues.
+
+Data in the archive file is persistent and could have been written while
+a different set of features was agreed upon. There are a couple of ways
+to read and write archive files in this scenario:
+
+- Not even attempt to read an incompatible archive file. The exact used
+  feature set is written into the archive file. As long as both client and
+  server keep negotiating the same feature set, they can read existing
+  archive files. When the negotiated feature set changes (due to upgrades),
+  the previous archive files can be ignored (requires a complete rescan).
+  This may be acceptable, as such upgrades are assumed to be quite rare.
+
+- A subset of the used feature set is written into the archive file. Only
+  features that change the data structures written in the archive file are
+  stored in the file. The reading can work in two ways. Either as a slightly
+  more forgiving variant of the point above, or actually reading and
+  unmarshaling the archive according to the features used to write it --
+  even if not all the same features are included in the currently negotiated
+  feature set. The latter requires types and code be tailored for this, the
+  same as with the next point below.
+
+- The archive file on-disk format includes information about the types and
+  structure of the written data (you can think like a DB with a relatively
+  dynamic but still typed schema). The data can be read back selectively,
+  and even converted as necessary (for example, can read a stored int32 into
+  in-memory int64).
+  The selective reading can mean two things. First, the archive was written
+  with a feature that is no longer enabled. The data that was only relevant
+  to that feature is just skipped. Second, the archive was written without
+  a feature that is now enabled. For the newly-enabled feature there is no
+  data in the archive but this does not break reading the file, as long as
+  the new feature can deal with default or "empty" values for its data
+  structures.
+

--- a/src/FEATURES.md
+++ b/src/FEATURES.md
@@ -81,6 +81,19 @@ features:
 - Code is not removed but it can be deprecated ->
   - Add or change a validation function to output a deprecation warning
 
+## User preferences
+
+User preferences are sent from client to server after establishing a
+connection. The server must know all preferences received from the client,
+otherwise the connection fails.
+
+When new preferences are created with a new feature, it is possible (and in
+most cases required) to add a guard function that determines if the
+preference is sent to the server or not. Typically, this guard function
+will take the form `fun () -> Features.enabled somefeature`, meaning that
+the preference is sent to server if and only if 'somefeature' is known by
+the server.
+
 ## Code evolution, conflicting features
 
 With features, new code does not have to replace existing code even if

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -210,12 +210,12 @@ OCAMLOBJS += \
           lwt/pqueue.cmo lwt/lwt.cmo lwt/lwt_util.cmo \
           lwt/$(SYSTEM)/lwt_unix_impl.cmo lwt/lwt_unix.cmo \
           \
-          uutil.cmo case.cmo pred.cmo \
+          features.cmo uutil.cmo case.cmo pred.cmo \
           fileutil.cmo name.cmo path.cmo fspath.cmo fs.cmo fingerprint.cmo \
           abort.cmo osx.cmo external.cmo fswatch.cmo \
           props.cmo fileinfo.cmo os.cmo lock.cmo clroot.cmo common.cmo \
-          tree.cmo checksum.cmo terminal.cmo \
-          transfer.cmo xferhint.cmo remote.cmo globals.cmo fswatchold.cmo \
+          tree.cmo checksum.cmo terminal.cmo transfer.cmo xferhint.cmo \
+          remote.cmo negotiate.cmo globals.cmo fswatchold.cmo \
           fpcache.cmo update.cmo copy.cmo stasher.cmo \
 	  files.cmo sortri.cmo recon.cmo transport.cmo \
           strings.cmo uicommon.cmo uitext.cmo test.cmo

--- a/src/features.ml
+++ b/src/features.ml
@@ -1,0 +1,76 @@
+(* Unison file synchronizer: src/features.ml *)
+(* Copyright 2021, Tõivo Leedjärv
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+type id = string
+
+type t = { mutable enabled : bool;
+           validator : (id list -> bool -> string option) option }
+
+let allFeatures = Hashtbl.create 8
+let allNames = ref []
+
+let all () = !allNames
+
+let mem = List.mem
+
+let empty = []
+
+let inter a b = List.filter (fun name -> mem name a) b
+
+let setEnabled features =
+  Hashtbl.iter (fun name t -> t.enabled <- mem name features) allFeatures
+
+let resetEnabled () = setEnabled empty
+
+(***************)
+
+let validate features =
+  let aux name t =
+    let failed = match t.validator with
+      | Some fn -> fn features (mem name features)
+      | None -> None
+    in
+    match failed with
+    | None -> ()
+    | Some e ->
+        raise (Util.Fatal
+          ("Client and server are incompatible. Setting up feature \""
+           ^ name ^ "\" failed with error\n\"" ^ e ^ "\".\n\n"
+           ^ "It may be possible to rectify this by changing the user "
+           ^ "preferences.\nUltimately, it may require upgrading either "
+           ^ "the server or the client."))
+  in
+  Hashtbl.iter aux allFeatures
+
+let validateEnabled () =
+  let enabled name t accu = if t.enabled then name :: accu else accu in
+  validate (Hashtbl.fold enabled allFeatures [])
+
+(***************)
+
+let enabled feature = feature.enabled
+
+let dummy = { enabled = false; validator = None }
+
+let register name validatefn =
+  if Hashtbl.mem allFeatures name then
+    raise (Util.Fatal ("Feature " ^ name ^ " registered twice"));
+  let v = { enabled = false; validator = validatefn } in
+  Hashtbl.add allFeatures name v;
+  allNames := name :: !allNames;
+  v
+

--- a/src/features.ml
+++ b/src/features.ml
@@ -38,6 +38,10 @@ let changingArchiveFormat () =
 
 let inter a b = List.filter (fun name -> mem name a) b
 
+let getEnabled () =
+  let enabled name t accu = if t.enabled then name :: accu else accu in
+  Hashtbl.fold enabled allFeatures []
+
 let setEnabled features =
   Hashtbl.iter (fun name t -> t.enabled <- mem name features) allFeatures
 
@@ -63,9 +67,7 @@ let validate features =
   in
   Hashtbl.iter aux allFeatures
 
-let validateEnabled () =
-  let enabled name t accu = if t.enabled then name :: accu else accu in
-  validate (Hashtbl.fold enabled allFeatures [])
+let validateEnabled () = validate (getEnabled ())
 
 (***************)
 

--- a/src/features.ml
+++ b/src/features.ml
@@ -18,6 +18,7 @@
 type id = string
 
 type t = { mutable enabled : bool;
+           arcFormatChange : bool;
            validator : (id list -> bool -> string option) option }
 
 let allFeatures = Hashtbl.create 8
@@ -28,6 +29,12 @@ let all () = !allNames
 let mem = List.mem
 
 let empty = []
+
+let changingArchiveFormat () =
+  let enabledArch name t accu =
+    if t.enabled && t.arcFormatChange then name :: accu else accu
+  in
+  Hashtbl.fold enabledArch allFeatures []
 
 let inter a b = List.filter (fun name -> mem name a) b
 
@@ -64,12 +71,12 @@ let validateEnabled () =
 
 let enabled feature = feature.enabled
 
-let dummy = { enabled = false; validator = None }
+let dummy = { enabled = false; arcFormatChange = false; validator = None }
 
-let register name validatefn =
+let register name ?(arcFormatChange = false) validatefn =
   if Hashtbl.mem allFeatures name then
     raise (Util.Fatal ("Feature " ^ name ^ " registered twice"));
-  let v = { enabled = false; validator = validatefn } in
+  let v = { enabled = false; arcFormatChange; validator = validatefn } in
   Hashtbl.add allFeatures name v;
   allNames := name :: !allNames;
   v

--- a/src/features.mli
+++ b/src/features.mli
@@ -27,7 +27,7 @@ val enabled : t -> bool
 
     Feature negotiation must have been completed to get the correct result. *)
 
-val register : string ->
+val register : string -> ?arcFormatChange:bool ->
         (id list -> bool -> string option) option -> t
 (** [register n f] registers a supported feature with a unique identifier [n].
 
@@ -37,6 +37,11 @@ val register : string ->
     indicating whether the tested feature is included in the negotiated set.
     [f] must return [Some msg] if the negotiation result must be rejected with
     the error message [msg], otherwise it must return [None].
+
+    [archFormatChange] is an optional argument which indicates whether the
+    feature, if enabled, changes the archive format that is stored on disk.
+    In other words, it indicates if the archive stored while this feature was
+    enabled requires the existence of this feature to be read back in.
 
     @return feature value that can be tested by {!Features.enabled} function.
     @raise {!Util.Fatal} if [n] is not unique. *)
@@ -50,6 +55,10 @@ val all : unit -> id list
 
 val empty : id list
 (** Empty set of features. *)
+
+val changingArchiveFormat : unit -> id list
+(** Set of all currently enabled features that impact the on-disk archive
+    format. The same features must exist in order to read in the archive. *)
 
 val mem : id -> id list -> bool
 (** [mem n s] tests whether feature with id [n] belongs to feature set [s]. *)

--- a/src/features.mli
+++ b/src/features.mli
@@ -72,6 +72,9 @@ val validate : id list -> unit
 
     @raise {!Util.Fatal} at first failed validation. *)
 
+val getEnabled : unit -> id list
+(** Set of enabled features. *)
+
 val resetEnabled : unit -> unit
 (** Make the set of enabled features empty. Can be used to reset the results
     of previous feature negotiation. *)

--- a/src/features.mli
+++ b/src/features.mli
@@ -1,0 +1,75 @@
+(* Unison file synchronizer: src/features.mli *)
+(* Copyright 2021, Tõivo Leedjärv
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+type t
+(** The type of a feature. *)
+
+type id = string
+(** The type of feature's identifier. Features are identified by their name. *)
+
+val enabled : t -> bool
+(** Test whether a feature is currently enabled (included in the current
+    set of enabled features).
+
+    Feature negotiation must have been completed to get the correct result. *)
+
+val register : string ->
+        (id list -> bool -> string option) option -> t
+(** [register n f] registers a supported feature with a unique identifier [n].
+
+    [f] is an optional validation function that will be called during feature
+    negotiation. [f] will receive as the first argument the feature set to be
+    enabled as a result of negotiation and as the second argument a boolean
+    indicating whether the tested feature is included in the negotiated set.
+    [f] must return [Some msg] if the negotiation result must be rejected with
+    the error message [msg], otherwise it must return [None].
+
+    @return feature value that can be tested by {!Features.enabled} function.
+    @raise {!Util.Fatal} if [n] is not unique. *)
+
+val dummy : t
+(** A feature value that will never be included in feature negotiation or
+    the set of enabled features. *)
+
+val all : unit -> id list
+(** Set of all supported features registered by {!Features.register}. *)
+
+val empty : id list
+(** Empty set of features. *)
+
+val mem : id -> id list -> bool
+(** [mem n s] tests whether feature with id [n] belongs to feature set [s]. *)
+
+val inter : id list -> id list -> id list
+(** Feature set intersection. *)
+
+val validate : id list -> unit
+(** [validate s] calls validation functions associated with each registered
+    feature in arbitrary order, with only features in [s] considered enabled.
+
+    @raise {!Util.Fatal} at first failed validation. *)
+
+val resetEnabled : unit -> unit
+(** Make the set of enabled features empty. Can be used to reset the results
+    of previous feature negotiation. *)
+
+val setEnabled : id list -> unit
+(** [setEnabled s] makes [s] the set of enabled features. *)
+
+val validateEnabled : unit -> unit
+(** Same as {!Features.validate} with the set of currently enabled features. *)
+

--- a/src/globals.ml
+++ b/src/globals.ml
@@ -67,7 +67,8 @@ let installRoots termInteract =
        return (r' :: l))))
     roots (return []) >>= (fun roots' ->
   theroots := roots';
-  return ())
+  Negotiate.features (Common.sortRoots roots') >>=
+  return)
 
 (* Alternate interface, should replace old interface eventually *)
 let installRoots2 () =
@@ -75,7 +76,7 @@ let installRoots2 () =
   let roots = rawRoots () in
   theroots :=
     Safelist.map Remote.canonize ((Safelist.map Clroot.parseRoot) roots);
-  theroots := !theroots
+  Lwt.ignore_result (Negotiate.features (Common.sortRoots !theroots) >>= return)
 
 let roots () =
   match !theroots with

--- a/src/negotiate.ml
+++ b/src/negotiate.ml
@@ -1,0 +1,82 @@
+(* Unison file synchronizer: src/negotiate.ml *)
+(* Copyright 2021, Tõivo Leedjärv
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+let (>>=) = Lwt.bind
+
+let debug = Util.debug "features"
+
+let debugFeatures name features =
+  debug (fun () ->
+    Util.msg "%s:\n" name;
+    Safelist.iter (fun n -> Util.msg "  - %s\n" n) features)
+
+let getCommonFeaturesLocal (root, features) =
+  Features.resetEnabled ();
+  let supportedFeatures = Features.all () in
+  debugFeatures "Supported features" supportedFeatures;
+  debugFeatures "Received features for feature negotiation" features;
+  let common = Features.inter features supportedFeatures in
+  debugFeatures "Selected common features" common;
+  try
+    let () = Features.validate common in
+    let () = Features.setEnabled common in
+    Lwt.return common
+  with
+  | e -> Lwt.fail e
+
+let negotiateFeaturesRpcName = "negotiateFeatures"
+let getCommonFeaturesRemote =
+  Remote.registerRootCmd negotiateFeaturesRpcName getCommonFeaturesLocal
+
+let getCommonFeaturesOnRoot features = function
+  | (Common.Local, _) -> Lwt.return features
+  | root -> getCommonFeaturesRemote root features
+
+let commonFeatures root fts =
+  getCommonFeaturesOnRoot fts root >>= fun common ->
+  let rn = "Common features for root " ^ Common.root2string root in
+  debugFeatures rn common;
+  try
+    let () = Features.validate common in
+    Lwt.return common
+  with
+  | e -> Lwt.fail e
+
+let allRootsSupportFeatures roots =
+  let aux k r =
+    let supp = Remote.commandAvailable r negotiateFeaturesRpcName in
+    k >>= fun k' ->
+    supp >>= fun supp' ->
+    Lwt.return (k' && supp')
+  in
+  Safelist.fold_left aux (Lwt.return true) roots
+
+let features roots =
+  Features.resetEnabled ();
+  let supportedFeatures = Features.all () in
+  debugFeatures "Supported features" supportedFeatures;
+  allRootsSupportFeatures roots >>= (fun supported ->
+  if not supported then begin
+    debug (fun () -> Util.msg "The server does not support \"features\".\n");
+    Lwt.return (Features.empty)
+  end else
+    Safelist.fold_left (fun fts r -> fts >>= commonFeatures r)
+      (Lwt.return supportedFeatures) roots
+  ) >>= fun common ->
+  debugFeatures "Enabled features" common;
+  Lwt.return (Features.setEnabled common)
+

--- a/src/negotiate.mli
+++ b/src/negotiate.mli
@@ -1,0 +1,19 @@
+(* Unison file synchronizer: src/negotiate.mli *)
+(* Copyright 2021, Tõivo Leedjärv
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+val features : Common.root list -> unit Lwt.t
+

--- a/src/ubase/prefs.mli
+++ b/src/ubase/prefs.mli
@@ -16,6 +16,7 @@ val readDefault : 'a t -> 'a
 val createBool :
         string              (* preference name *)
      -> ?local:bool             (* whether it is local to the client *)
+     -> ?send:(unit->bool)  (* whether preference should be sent to server *)
      -> bool                (* initial value *)
      -> string              (* documentation string *)
      -> string              (* full (tex) documentation string *)
@@ -24,6 +25,7 @@ val createBool :
 val createInt :
         string              (* preference name *)
      -> ?local:bool             (* whether it is local to the client *)
+     -> ?send:(unit->bool)  (* whether preference should be sent to server *)
      -> int                 (* initial value *)
      -> string              (* documentation string *)
      -> string              (* full (tex) documentation string *)
@@ -32,6 +34,7 @@ val createInt :
 val createString :
         string              (* preference name *)
      -> ?local:bool             (* whether it is local to the client *)
+     -> ?send:(unit->bool)  (* whether preference should be sent to server *)
      -> string              (* initial value *)
      -> string              (* documentation string *)
      -> string              (* full (tex) documentation string *)
@@ -40,6 +43,7 @@ val createString :
 val createFspath :
         string              (* preference name *)
      -> ?local:bool             (* whether it is local to the client *)
+     -> ?send:(unit->bool)  (* whether preference should be sent to server *)
      -> System.fspath       (* initial value *)
      -> string              (* documentation string *)
      -> string              (* full (tex) documentation string *)
@@ -48,6 +52,7 @@ val createFspath :
 val createStringList :
         string              (* preference name *)
      -> ?local:bool             (* whether it is local to the client *)
+     -> ?send:(unit->bool)  (* whether preference should be sent to server *)
      -> string              (* documentation string *)
      -> string              (* full (tex) documentation string *)
      -> string list t       (*   -> new preference value *)
@@ -55,6 +60,7 @@ val createStringList :
 val createBoolWithDefault :
         string              (* preference name *)
      -> ?local:bool             (* whether it is local to the client *)
+     -> ?send:(unit->bool)  (* whether preference should be sent to server *)
      -> string              (* documentation string *)
      -> string              (* full (tex) documentation string *)
      -> [`True|`False|`Default] t
@@ -67,6 +73,7 @@ exception IllegalValue of string
 val create :
         string                  (* preference name *)
      -> ?local:bool             (* whether it is local to the client *)
+     -> ?send:(unit->bool)      (* whether the pref should be sent to server *)
      -> 'a                      (* initial value *)
      -> string                  (* documentation string *)
      -> string                  (* full (tex) documentation string *)

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -475,6 +475,7 @@ let validateAndFixupPrefs () =
   Prefs.set Globals.someHostIsRunningWindows someHostIsRunningWindows;
   Prefs.set Globals.allHostsAreRunningWindows allHostsAreRunningWindows;
   if repeatWatcher () then Prefs.set Fswatch.useWatcher true;
+  Features.validateEnabled ();
   return ())
 
 (* ---- *)

--- a/src/uutil.ml
+++ b/src/uutil.ml
@@ -32,11 +32,17 @@ let myNameAndVersion = myName ^ " " ^ myVersion
 (*                             HASHING                                       *)
 (*****************************************************************************)
 
+let featHashOCaml4Murmur3 = Features.register "hash-ocaml4-murmur3" None
+
 let hash2 x y = (17 * x + 257 * y) land 0x3FFFFFFF
 
 external hash_param : int -> int -> 'a -> int = "unsn_hash_univ_param" [@@noalloc]
 
-let hash x = hash_param 10 100 x
+let hash x =
+  if Features.enabled featHashOCaml4Murmur3 then
+    Hashtbl.hash x
+  else (* The algorithm used before any features were defined *)
+    hash_param 10 100 x (* FIX: This algorithm should be removed eventually *)
 
 (*****************************************************************************)
 (*                             File sizes                                    *)


### PR DESCRIPTION
This is the second part of the proposal sent to unison-hackers mailing list (the first part is #507).

### Background and motivation

This is intended as the application-level fix to #407. As a mechanism it works independently, but to reach the full flexibility in extensibility, the code making use of this mechanism will benefit greatly from a fix to #375.

The PR is intended for review and discussion but it is actually a fully working change and is itself backwards-compatible. It could be merged immediately without any impact on the 2.51 version.

### Description

See `FEATURES.md` included in the PR.

### What is it not?

This patch does nothing about incompatibilities caused by different OCaml versions.

### Example

Adding a new hash function serves as a proof of concept and example (this is a non-breaking version of #480). Although fully working, it is more of a toy example when it comes to demonstrating the capabilities of the features mechanism. Unlike many other changes, it is extremely simple to implement in a compatible manner, for two reasons. For one, the types don't change. Also, while the calculated hash is stored and loaded, it is actually never compared to a re-calculated value. This means that the only critical moment is the comparing of hash values calculated on client and server at runtime. The features are negotiated for every new connection, so both client and server are guaranteed to use the same hash function at runtime.
