### PR TITLE
fsmonitor: Clear event memory at reset

### DIFF
--- a/src/fsmonitor/watchercommon.ml
+++ b/src/fsmonitor/watchercommon.ml
@@ -556,6 +556,7 @@ let reset hash =
        end)
     roots;
   List.iter (fun key -> Hashtbl.remove roots key) !l;
+  clear_event_memory ();
   clear_change_table hash
 
 (****)


### PR DESCRIPTION
Fix a corner case where some changes could unintentionally be ignored due to the "event memory" feature. This issue will manifest itself on platforms where platform-specific implementation of event memory does not distinguish between watcher "sessions" (this may be so only on Windows).

The event memory is currently cleared only when the previously queued changes are reported to Unison. In some cases the changes are not reported though, instead the entire watcher is reset and restarted by Unison's request. The event memory is not cleared. Depending on its platform-specific implementation, it could miss new legitimate change events because the event memory thinks that these events are already queued for reporting.

The fix is to clear event memory at watcher reset. This is a universal fix and requires no platform-specific changes.