### PR TITLE
fsmonitor: Fix overflow reporting on Windows

### DIFF
--- a/src/fsmonitor/windows/watcher.ml
+++ b/src/fsmonitor/windows/watcher.ml
@@ -163,7 +163,7 @@ let watch_root_directory path dir =
          end else
            !time_ref := time)
       l;
-    if l = [] then begin
+    if l = [] && get_watch dir <> None then begin
       if !Watchercommon.debug then Format.eprintf "OVERFLOW@.";
       signal_overflow ()
     end;


### PR DESCRIPTION
The overflow condition can arise in two cases. First, an actual overflow in Windows kernel. Second, a false positive when the watched dir handle is closed (intentionally, to stop the watch). This false positive case will cause an infinite loop. Closing a watch causes an overflow to be reported, which in turn causes Unison to reset the watchers, which in turn causes another false overflow to be reported and so on.

This patch fixes overflow reporting so that it is only triggered on the first, the only correct, condition.

Without the patch, the following can happen:
1. A RESET is received...
2. ... this causes dir handles to be closed.
3. In reaction to dir handle closing, `readdirectorychanges` will return len 0 (empty event list) which normally signals an overflow.
4. Since `readdirectorychanges` returns normally (just with an empty result), the event processing function is invoked...
5. ... which detects the empty list and signals an OVERFLOW...
6. ... and loops to invoke `readdirectorychanges` again...
7. ... which immediately raises an exception (invalid dir handle, since it is already closed).
8. Catching the exception causes the watch to finally close (thus only now completing the request from step 1).
9. Together with a RESET, a new START was received...
10. ... this causes a new dir handle to be opened and a new `readdirectorychanges` loop to be started.
11. Meanwhile, the previously reported overflow has been received by Unison...
12. ... which in turn issues a new RESET + START (step 1, look familiar?) ...
13. ... and the entire thing repeats as from step 2, becoming an infinite loop.