### PR TITLE
fsmonitor: Properly stop the watch loop on Windows

### DIFF
--- a/src/fsmonitor/windows/watcher.ml
+++ b/src/fsmonitor/windows/watcher.ml
@@ -167,7 +167,8 @@ let watch_root_directory path dir =
       if !Watchercommon.debug then Format.eprintf "OVERFLOW@.";
       signal_overflow ()
     end;
-    loop ()
+    if get_watch dir <> None then loop ()
+    else Lwt.return ()
   in
   ignore (Lwt.catch loop
             (fun e ->


### PR DESCRIPTION
With current code the watching loop is stopped only when catching an exception. Intentional or not, this seems to be sufficient because continuing to watch a closed dir handle will (eventually) raise an exception and stop the loop.

Yet, in some cases this exception is not raised (it is not clear why this happens). This creates a corner case when the loop is not stopped (it will probably be stopped eventually...).

RESET and START are usually received in combination (close previous watch, then start a new), which means that a new dir handle is opened and a new watch loop started on the same path; and this can happen over and over again. In the end, there could be many watch loops running for the same path, all but one waiting for the exception to stop the loop.

This patch adds a clear exit condition for the loop. When the watch has been released then the loop stops cleanly at next iteration.