### PR TITLE
fsmonitor: Report dir modify events on Windows

### DIFF
--- a/src/fsmonitor/windows/watcher.ml
+++ b/src/fsmonitor/windows/watcher.ml
@@ -156,10 +156,7 @@ let watch_root_directory path dir =
                  | _ ->
                      long_name subdir nm
                in
-               if
-                 not (kind = `MODIF && StringMap.mem nm (get_subdirs subdir))
-               then
-                 signal_change event_time subdir (Some nm) kind
+               signal_change event_time subdir (Some nm) kind
          end else
            !time_ref := time)
       l;


### PR DESCRIPTION
Current code does not report modification events on subdirectories. Subdir creation, rename and deletion on the other hand are reported. It is most likely done this way to prevent reporting "spurious" modification events on the directory when in fact the list of files in the directory had changed (which get reported by separate events).

This filtering will lose changes on the dir entity itself (think attribute and ACL changes). The patch enables reporting modification events on directories to make sure that these changes are not lost.

It is unclear if this patch carries any performance penalty on Unison side (such as, having to scan the entire dir instead of just one file) but it is quite unlikely with less-than-huge directories.