### PR TITLE
fsmonitor: Specify IN_EXCL_UNLINK for inotify

### DIFF
--- a/src/fsmonitor/linux/inotify.ml
+++ b/src/fsmonitor/linux/inotify.ml
@@ -33,6 +33,7 @@ type select_event =
         | S_Mask_add
         | S_Oneshot
         | S_Onlydir
+        | S_Excl_unlink
         (* convenience *)
         | S_Move
         | S_Close

--- a/src/fsmonitor/linux/inotify.mli
+++ b/src/fsmonitor/linux/inotify.mli
@@ -32,6 +32,7 @@ type select_event =
 | S_Mask_add
 | S_Oneshot
 | S_Onlydir
+| S_Excl_unlink
 | S_Move
 | S_Close
 | S_All

--- a/src/fsmonitor/linux/inotify_stubs.c
+++ b/src/fsmonitor/linux/inotify_stubs.c
@@ -33,7 +33,7 @@ static int inotify_flag_table[] = {
         IN_CREATE, IN_DELETE, IN_DELETE_SELF, IN_MODIFY,
         IN_MOVE_SELF, IN_MOVED_FROM, IN_MOVED_TO, IN_OPEN,
         IN_DONT_FOLLOW, IN_MASK_ADD, IN_ONESHOT, IN_ONLYDIR,
-        IN_MOVE, IN_CLOSE, IN_ALL_EVENTS, 0
+        IN_EXCL_UNLINK, IN_MOVE, IN_CLOSE, IN_ALL_EVENTS, 0
 };
 
 static int inotify_return_table[] = {

--- a/src/fsmonitor/linux/watcher.ml
+++ b/src/fsmonitor/linux/watcher.ml
@@ -218,6 +218,7 @@ let release_watch file =
         Hashtbl.replace watcher_by_id id s
 
 let selected_events =
+  Inotify.S_Excl_unlink ::
   Inotify.([S_Attrib; S_Modify; S_Delete_self; S_Move_self;
             S_Create; S_Delete; S_Modify; S_Moved_from; S_Moved_to])
 let selected_events_nofollow = Inotify.S_Dont_follow :: selected_events


### PR DESCRIPTION
From `inotify(7)`:
```
Specifying IN_EXCL_UNLINK changes the default behavior, so that events
are not generated for children after they have been unlinked from the
watched directory.
```