### PR TITLE
fsmonitor: Don't break on EAGAIN from inotify

### DIFF
--- a/src/fsmonitor/linux/lwt_inotify.ml
+++ b/src/fsmonitor/linux/lwt_inotify.ml
@@ -42,7 +42,7 @@ let rec read st =
     Lwt.return (Queue.take st.q)
   with Queue.Empty ->
     Lwt_unix.wait_read st.lwt_fd >>= fun () ->
-    let l = Inotify.read st.fd in
+    let l = try Inotify.read st.fd with Unix.Unix_error (EAGAIN, _, _) -> [] in
     List.iter (fun ev -> Queue.push ev st.q) l;
     read st
 


### PR DESCRIPTION
Reading from inotify is done in a loop which waits for input and then reads it. Nevertheless, it is possible to get `EAGAIN` when reading. Errors reading from inotify are currently all fatal.

Catch `EAGAIN` to continue the loop as normal.