### PR TITLE
fsmonitor: Catch ENOENT during add_watch

### DIFF
--- a/src/fsmonitor/linux/watcher.ml
+++ b/src/fsmonitor/linux/watcher.ml
@@ -242,8 +242,7 @@ let add_watch path file follow =
     release_watch file;
     match no with
       2 (* ENOENT *) ->
-        Watchercommon.error
-          (Format.sprintf "file '%s' does not exist" path)
+        raise Watchercommon.Already_lost
     | 28 (* ENOSPC *) ->
         Watchercommon.error "cannot add a watcher: system limit reached"
     | 13 (* EACCES *) | 20 (* ENOTDIR *) | 40 (* ELOOP *) ->

--- a/src/fsmonitor/solaris/watcher.ml
+++ b/src/fsmonitor/solaris/watcher.ml
@@ -278,6 +278,8 @@ let rec add_watch path file follow =
         if is_directory path follow then add_watch_children path
           (fun nm -> associate true wh id follow (Filename.concat path nm) nm)
       with
+      | Unix.Unix_error (ENOENT, _, _) ->
+          raise Watchercommon.Already_lost
       | Unix.Unix_error (EACCES, _, _)
       | Unix.Unix_error (ENOTDIR, _, _)
       | Unix.Unix_error (ELOOP, _, _) ->

--- a/src/fsmonitor/watchercommon.mli
+++ b/src/fsmonitor/watchercommon.mli
@@ -4,6 +4,8 @@ val debug : bool ref
 val error : string -> 'a
 val format_exc : exn -> string
 
+exception Already_lost
+
 module StringMap : Map.S with type key = string
 
 module F (M : sig type watch end) : sig


### PR DESCRIPTION
While it is rare to occur, it is possible that a directory is deleted after Unison has started scanning it but before fsmonitor has started watching it. In this case the fsmonitor would fail with a fatal error.

This patch tries to be smart about this scenario and will fail only if `ENOENT` is received on a root path. `ENOENT` on any sub-path is reported as a normal change event. Unison will scan the path again and discover that the directory is gone.