### PR TITLE
fsmonitor: Remove temporary OCaml 3.11 compat code

### DIFF
--- a/src/fsmonitor/watchercommon.ml
+++ b/src/fsmonitor/watchercommon.ml
@@ -22,11 +22,6 @@ let _ =
     ignore(Sys.set_signal Sys.sigpipe Sys.Signal_ignore)
 
 module StringMap = Map.Make(String)
-(*FIX: temporary workaround, as there is no StringMap.filter function
-  in OCaml 3.11 *)
-let stringmap_filter f m =
-  StringMap.fold (fun k v m' -> if f k v then StringMap.add k v m' else m')
-    m StringMap.empty
 module StringSet = Set.Make(String)
 module IntSet =
   Set.Make
@@ -301,7 +296,7 @@ let clear_change_table hash =
 let rec clear_changes hash time =
   let rec clear_rec f =
     f.changed_children <-
-      stringmap_filter
+      StringMap.filter
         (fun nm (_, time_ref) ->
            if time -. !time_ref <= delay then true else begin
              remove_change f nm;
@@ -379,7 +374,7 @@ let gather_changes hash time =
   clear_event_memory ();
   let rec gather_rec path r l =
     let c =
-      stringmap_filter (fun _ (_, time_ref) -> time -. !time_ref > delay)
+      StringMap.filter (fun _ (_, time_ref) -> time -. !time_ref > delay)
         r.changed_children
     in
     let l = StringMap.fold (fun nm _ l -> concat path nm :: l) c l in


### PR DESCRIPTION
Minimum support is currently at OCaml 4.05