### PR TITLE
Allow syncing symlinks on Windows

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -2005,11 +2005,16 @@ to treat a link in this manner, add a line of the form
 to the profile, where \ARG{pathspec} is a path pattern as described in
 \sectionref{pathspec}{Path Specification}.
 
-Windows file systems do not support symbolic links; Unison will refuse
-to propagate an opaque symbolic link from Unix to Windows and flag the
-path as erroneous.  When a Unix replica is to be synchronized with a
-Windows system, all symbolic links should match either an
-\verb|ignore| pattern or a \verb|follow| pattern.
+Not all Windows versions and file systems support symbolic links; Unison will
+refuse to propagate an opaque symbolic link from Unix to Windows and flag the
+path as erroneous if the support or privileges are lacking on the Windows side.
+When a Unix replica is to be synchronized with such Windows system, all symbolic
+links should match either an \verb|ignore| pattern or a \verb|follow| pattern.
+
+You may need to acquire extra privileges to create symbolic links under
+Windows. By default, this is only allowed for administrators. Unison may not
+be able to automatically detect support for symbolic links under Windows. In
+that case, set the preference {\tt links} to {\tt true} explicitly.
 
 
 \SUBSECTION{Permissions}{perms}

--- a/src/.depend
+++ b/src/.depend
@@ -625,6 +625,7 @@ os.cmo : \
     fspath.cmi \
     fs.cmi \
     fingerprint.cmi \
+    fileutil.cmi \
     fileinfo.cmi \
     os.cmi
 os.cmx : \
@@ -640,6 +641,7 @@ os.cmx : \
     fspath.cmx \
     fs.cmx \
     fingerprint.cmx \
+    fileutil.cmx \
     fileinfo.cmx \
     os.cmi
 os.cmi : \

--- a/src/fileinfo.ml
+++ b/src/fileinfo.ml
@@ -26,8 +26,9 @@ let allowSymlinks =
       links will result in an error during update detection.  \
       Ordinarily, when the flag is set to {\\tt default}, symbolic \
       links are synchronized except when one of the hosts is running \
-      Windows.  In rare circumstances it may be useful to set the flag \
-      manually.")
+      Windows.  On a Windows client, Unison makes an attempt to detect \
+      if symbolic links are supported and allowed by user privileges.  \
+      You may have to get elevated privileges to create symbolic links.")
 
 let symlinksAllowed =
   Prefs.createBool "links-aux" true
@@ -36,7 +37,8 @@ let symlinksAllowed =
 let init b =
   Prefs.set symlinksAllowed
     (Prefs.read allowSymlinks = `True ||
-     (Prefs.read allowSymlinks = `Default && not b))
+      (Prefs.read allowSymlinks = `Default &&
+      (not b || System.hasSymlink ())))
 
 type typ = [ `ABSENT | `FILE | `DIRECTORY | `SYMLINK ]
 

--- a/src/fs.ml
+++ b/src/fs.ml
@@ -69,6 +69,7 @@ let fingerprint f = System.fingerprint (Fspath.toString f)
 
 let canSetTime f = System.canSetTime (Fspath.toString f)
 let hasInodeNumbers () = System.hasInodeNumbers ()
+let hasSymlink () = System.hasSymlink ()
 let hasCorrectCTime = System.hasCorrectCTime
 
 let setUnicodeEncoding = System.setUnicodeEncoding

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -1744,8 +1744,10 @@ let docs =
       \032         symbolic links. When the flag is set to false, symbolic links\n\
       \032         will result in an error during update detection. Ordinarily,\n\
       \032         when the flag is set to default, symbolic links are synchronized\n\
-      \032         except when one of the hosts is running Windows. In rare\n\
-      \032         circumstances it may be useful to set the flag manually.\n\
+      \032         except when one of the hosts is running Windows. On a Windows\n\
+      \032         client, Unison makes an attempt to detect if symbolic links are\n\
+      \032         supported and allowed by user privileges. You may have to get\n\
+      \032         elevated privileges to create symbolic links.\n\
       \n\
       \032  log\n\
       \032         When this flag is set, Unison will log all changes to the\n\
@@ -2678,11 +2680,18 @@ let docs =
       \032  to the profile, where pathspec is a path pattern as described in the\n\
       \032  section \"Path Specification\" .\n\
       \n\
-      \032  Windows file systems do not support symbolic links; Unison will refuse\n\
-      \032  to propagate an opaque symbolic link from Unix to Windows and flag the\n\
-      \032  path as erroneous. When a Unix replica is to be synchronized with a\n\
-      \032  Windows system, all symbolic links should match either an ignore\n\
-      \032  pattern or a follow pattern.\n\
+      \032  Not all Windows versions and file systems support symbolic links;\n\
+      \032  Unison will refuse to propagate an opaque symbolic link from Unix to\n\
+      \032  Windows and flag the path as erroneous if the support or privileges are\n\
+      \032  lacking on the Windows side. When a Unix replica is to be synchronized\n\
+      \032  with such Windows system, all symbolic links should match either an\n\
+      \032  ignore pattern or a follow pattern.\n\
+      \n\
+      \032  You may need to acquire extra privileges to create symbolic links under\n\
+      \032  Windows. By default, this is only allowed for administrators. Unison\n\
+      \032  may not be able to automatically detect support for symbolic links\n\
+      \032  under Windows. In that case, set the preference links to true\n\
+      \032  explicitly.\n\
       \n\
       Permissions\n\
       \n\

--- a/src/system/system_generic.ml
+++ b/src/system/system_generic.ml
@@ -93,6 +93,8 @@ let canSetTime f =
    have access to the lower 32 bits on 32bit systems... *)
 let hasInodeNumbers () = isNotWindows
 
+let hasSymlink = Unix.has_symlink
+
 (* Cygwin can apparently provide correct ctime.
  *
  * With current OCaml Unix library, ctime is not correct on Win32.

--- a/src/system/system_intf.ml
+++ b/src/system/system_intf.ml
@@ -46,6 +46,7 @@ val fingerprint : fspath -> Digest.t
 
 val canSetTime : fspath -> bool
 val hasInodeNumbers : unit -> bool
+val hasSymlink : unit -> bool
 
 (* [hasCorrectCTime] is true when [stat] and [lstat] return the status change
  * time. This is commonly broken on Windows, where creation time (completely

--- a/src/system/system_win.ml
+++ b/src/system/system_win.ml
@@ -103,7 +103,7 @@ type dir_entry = Dir_empty | Dir_read of string | Dir_toread
 type dir_handle = System_generic.dir_handle
                 = { readdir : unit -> string; closedir : unit -> unit }
 
-external stat_impl : string -> string -> Unix.LargeFile.stats = "win_stat"
+external stat_impl : string -> string -> bool -> Unix.LargeFile.stats = "win_stat"
 external rmdir_impl : string -> string -> unit = "win_rmdir"
 external mkdir_impl : string -> string -> unit = "win_mkdir"
 external unlink_impl : string -> string -> unit = "win_unlink"
@@ -120,8 +120,8 @@ external findfirst : string -> string * int = "win_findfirstw"
 external findnext : int -> string = "win_findnextw"
 external findclose : int -> unit = "win_findclosew"
 
-let stat f = stat_impl f (epath f)
-let lstat = stat
+let stat f = stat_impl f (epath f) false
+let lstat f = stat_impl f (epath f) true
 let rmdir f = rmdir_impl f (epath f)
 let mkdir f perms = mkdir_impl f (epath f)
 let unlink f = unlink_impl f (epath f)

--- a/src/system/system_win.ml
+++ b/src/system/system_win.ml
@@ -131,8 +131,8 @@ let chown _ _ _ = raise (Unix.Unix_error (Unix.ENOSYS, "chown", ""))
 let utimes f t1 t2 = utimes_impl f (epath f) t1 t2
 let link f1 f2 = link_impl f1 (epath f1) (epath f2)
 let openfile f flags perm = open_impl f (epath f) flags perm
-let readlink _ = raise (Unix.Unix_error (Unix.ENOSYS, "readlink", ""))
-let symlink _ _ = raise (Unix.Unix_error (Unix.ENOSYS, "symlink", ""))
+let readlink = Unix.readlink
+let symlink f t = Unix.symlink f t
 
 let chdir f =
   try
@@ -312,6 +312,8 @@ let canSetTime f = true
    renaming a file "b" over a file "a" does not change the inode
    number of "a". *)
 let hasInodeNumbers () = true
+
+let hasSymlink = Unix.has_symlink
 
 external hasCorrectCTime_impl : unit -> bool = "win_has_correct_ctime"
 

--- a/src/system/win/system_impl.ml
+++ b/src/system/win/system_impl.ml
@@ -60,5 +60,6 @@ module Fs = struct
 
   let canSetTime v = c1 W.canSetTime G.canSetTime v
   let hasInodeNumbers v = c1 W.hasInodeNumbers G.hasInodeNumbers v
+  let hasSymlink v = c1 W.hasSymlink G.hasSymlink v
   let hasCorrectCTime = if !unicode then W.hasCorrectCTime else G.hasCorrectCTime
 end


### PR DESCRIPTION
OCaml Unix library has supported Windows symlinks since 4.03. Given this support, it was very easy to enable syncing of POSIX symlinks on Windows.

I have done some very light testing Windows <-> Linux and Windows <-> Windows (with admin privileges).

The main limitation is the required privileges, as documented in https://github.com/bcpierce00/unison/issues/283#issuecomment-578642699 and https://github.com/bcpierce00/unison/issues/283#issuecomment-688431489.

Closes #283