### PR TITLE
fsmonitor: Restore Windows 8.3 names processing

### DIFF
--- a/src/lwt/lwt_unix_stubs.c
+++ b/src/lwt/lwt_unix_stubs.c
@@ -699,3 +699,15 @@ CAMLprim value win_open_directory (value path, value wpath) {
   }
   CAMLreturn(win_alloc_handle(h));
 }
+
+value copy_wstring(LPCWSTR s);
+
+CAMLprim value win_long_path_name(value path) {
+  CAMLparam1(path);
+  wchar_t lbuf[32768] = L"";
+  DWORD res;
+
+  res = GetLongPathNameW((LPCWSTR) String_val(path), lbuf, 32768);
+
+  CAMLreturn(res == 0 || res > 32767 ? path : copy_wstring(lbuf));
+}

--- a/src/lwt/win/lwt_unix_impl.ml
+++ b/src/lwt/win/lwt_unix_impl.ml
@@ -712,3 +712,24 @@ if !d then Format.eprintf "Reading started@.";
                         (parse_directory_changes buf)))
 
 let close_dir = Unix.close
+
+external long_name : string -> string = "win_long_path_name"
+
+let longpathname root path =
+  (* Parameter [path] can be relative. Result value must then also be relative.
+     Input parameter to [long_name] must always be absolute path. *)
+  let epath = System_impl.Fs.W.epath (Filename.concat root path)
+  and root = System_impl.Fs.W.epath (Filename.concat root "") in
+  let root = String.sub root 0 (String.length root - 2) in (* Remove trailing \000\000 *)
+  let start = String.length root
+  and ln = long_name epath in
+  let n =
+  try
+    (* The assumption is that [root] does not change in [long_name]. The
+       Windows fsmonitor operates under this assumption, so it is ok here.
+       To remove this assumption, we'd have to pass [root] separately through
+       [long_name]. *)
+    String.sub ln start (String.length ln - start)
+  with
+  | Invalid_argument _ -> ln
+  in System_impl.Fs.W.path8 n

--- a/src/lwt/win/lwt_win.mli
+++ b/src/lwt/win/lwt_win.mli
@@ -18,3 +18,5 @@ val readdirectorychanges :
 
 val open_directory : string -> directory_handle
 val close_dir : directory_handle -> unit
+
+val longpathname : string -> string -> string

--- a/src/system/system_win_stubs.c
+++ b/src/system/system_win_stubs.c
@@ -23,7 +23,7 @@ struct filedescr {
 };
 #define Handle_val(v) (((struct filedescr *) Data_custom_val(v))->fd.handle)
 
-static value copy_wstring(LPCWSTR s)
+value copy_wstring(LPCWSTR s)
 {
   int len;
   value res;


### PR DESCRIPTION
I was wrong with #526. That functionality most definitely is needed. MSDN has this little gem to offer:
```
If there is both a short and long name for the file, the function will
return one of these names, but it is unspecified which one.
```

Restore the 8.3 short names processing it is then.

I'm not going to revert the previous patch, though. I noticed that it relied on an assumption that the "watchercommon" side uses only long names. The lookups are in practice only done in direction short name -> long name. Keeping the same assumption (I don't know if it is 100% guaranteed but at least it's not a regression), I implemented a much simpler mechanism that restores 8.3 short names processing.