### PR TITLE
GHA: Add a dune build via opam

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -237,3 +237,27 @@ jobs:
         files: ${{ steps.macapp.outputs.APP_NAME }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  opam_dune_build:
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+        - { os: ubuntu-latest  , ocaml-compiler: 4.12.x }
+
+    runs-on: ${{ matrix.job.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Use OCaml ${{ matrix.job.ocaml-compiler }}
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: "${{ matrix.job.ocaml-compiler }}"
+
+    - run: opam install . --deps-only
+
+    - run: opam exec -- dune build && cp -L ./_build/install/default/bin/unison* ./src/
+
+#    - run: opam exec -- make test


### PR DESCRIPTION
To avoid future embarrasments like #538.

Some notes and caveats:
1. This GHA job is created specifically to test dune builds. Building with dune is actually not required by `opam` -- it is ok to instruct opam to build with `make`, and this may be just what we have to do if nobody steps up to maintain dunefiles.
2. Unison's dunefiles are a bit outdated and currently unmaintained. They need an active maintainer who knows dune.
3. Self-tests are currently not working with dune builds. (Current dunefile explicitly excludes self-tests. I tried changing the dunefile to include the `Test` module in the 'library' or in an 'executable' but that didn't cut it. No idea how to get this working with dune.)