### PR TITLE
Fix build regression with ::= in Makefile

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -103,7 +103,7 @@ buildexecutable::
 CAMLFLAGS+=-g
 
 INCLFLAGS=-I lwt -I ubase -I system
-DEP_INCLFLAGS::=$(INCLFLAGS)
+DEP_INCLFLAGS=-I lwt -I ubase -I system
 CAMLFLAGS+=$(INCLFLAGS)
 CAMLFLAGS+=-I system/$(SYSTEM) -I lwt/$(SYSTEM)
 


### PR DESCRIPTION
`::=` is not well supported by different `make` implementations (also appears to be a rather recent addition in POSIX?).

Fixes #541 