### PR TITLE
Cleanup: remove dead code

### DIFF
--- a/src/case.ml
+++ b/src/case.ml
@@ -79,52 +79,6 @@ let init b someHostRunningOsX =
 
 (****)
 
-(* Dots are ignored at the end of filenames under Windows. *)
-
-(* FIX: for the moment, simply disallow files ending with a dot.
-   This is more efficient, and this may well be good enough.
-   We should reconsider this is people start complaining...
-
-let hasTrailingDots s =
-  let rec iter s pos len wasDot =
-    if pos = len then wasDot else
-    let c = s.[pos] in
-    (wasDot && c = '/') || iter s (pos + 1) len (c = '.')
-  in
-  iter s 0 (String.length s) false
-
-let removeTrailingDots s =
-  let len = String.length s in
-  let s' = Bytes.create len in
-  let pos = ref (len - 1) in
-  let pos' = ref (len - 1) in
-  while !pos >= 0 do
-    while !pos >= 0 && s.[!pos] = '.' do decr pos done;
-    while !pos >= 0 && s.[!pos] <> '/' do
-      s'.[!pos'] <- s.[!pos]; decr pos; decr pos'
-    done;
-    while !pos >= 0 && s.[!pos] = '/' do
-      s'.[!pos'] <- s.[!pos]; decr pos; decr pos'
-    done
-  done;
-  String.sub s' (!pos' + 1) (len - !pos' - 1)
-
-let rmTrailDots s =
-  s
-(*FIX: disabled for now -- requires an archive version change
-  if
-    Prefs.read someHostIsRunningWindows &&
-    not (Prefs.read allHostsAreRunningWindows) &&
-    hasTrailingDots s
-  then
-    removeTrailingDots s
-  else
-    s
-*)
-*)
-
-(****)
-
 type mode = Sensitive | Insensitive | UnicodeSensitive | UnicodeInsensitive
 
 (*

--- a/src/update.ml
+++ b/src/update.ml
@@ -584,12 +584,6 @@ let makeCaseSensitiveOnRoot =
        makeCaseSensitive (thisRootsGlobalName fspath);
        Lwt.return ())
 
-(*FIX: remove when Unison version > 2.40 *)
-let canMakeCaseSensitive () =
-  Globals.allRootsMap (fun r -> Remote.commandAvailable r "makeCaseSensitive")
-    >>= fun l ->
-  Lwt.return (List.for_all (fun x -> x) l)
-
 (****)
 
 (* Get the archive case sensitivity mode from the archive magic. *)
@@ -612,12 +606,7 @@ let checkArchiveCaseSensitivity l =
   if curMode = archMode then
     Lwt.return ()
   else begin
-    begin if archMode = Case.caseSensitiveModeDesc then
-      canMakeCaseSensitive ()
-    else
-      Lwt.return false
-    end >>= fun convert ->
-    if convert then
+    if archMode = Case.caseSensitiveModeDesc then
       Globals.allRootsIter (fun r -> makeCaseSensitiveOnRoot r ())
     else begin
       (* We cannot compute the archive name locally as it


### PR DESCRIPTION
Code removed in first commit clearly serves no purpose any longer (and is explicitly marked so).
Code removed in second commit was already (correctly) commented out.