### PR TITLE
uigtk2: Fix a row index error in the display loop

### DIFF
--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -3101,7 +3101,7 @@ lst_store#set ~row ~column:c_path path;
       ignore (mainWindow#prepend
                 [ r1; ""; r2; ""; transcodeFilename path ]);
       displayArrow 0 i action;
-      displayStatusIcon i status
+      displayStatusIcon 0 status
     done;
     debug (fun()-> Util.msg "reset current to %s\n"
              (match savedCurrent with None->"None" | Some(i) -> string_of_int i));


### PR DESCRIPTION
This is a fix for performance degradation with large number of rows in GUI (think tens and hundreds of thousands).