### PR TITLE
Fix error handling for log file related errors

### DIFF
--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -244,6 +244,12 @@ let log s = displayMessage (Log, s)
 
 let log_color s = displayMessage (LogColor, s)
 
+let logonly s =
+  let temp = !sendLogMsgsToStderr in
+  sendLogMsgsToStderr := false;
+  displayMessage (Log, s);
+  sendLogMsgsToStderr := temp
+
 let logverbose s =
   let temp = !sendLogMsgsToStderr in
   sendLogMsgsToStderr := !sendLogMsgsToStderr && not (Prefs.read terse);

--- a/src/ubase/trace.mli
+++ b/src/ubase/trace.mli
@@ -93,6 +93,10 @@ val log : string -> unit
    ANSI color escapes intact *)
 val log_color : string -> unit
 
+(* Like 'log', but only send message to log file and not to stderr, even when
+   [sendLogMsgsToStderr] is set to true *)
+val logonly : string -> unit
+
 (* Like 'log', but only send message to log file if -terse preference is set *)
 val logverbose : string -> unit
 

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -670,6 +670,10 @@ let initPrefs ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
   (* Print the preference settings *)
   debug (fun() -> Prefs.dumpPrefsToStderr() );
 
+  Trace.logonly (Printf.sprintf "\n%s log started at %s\n\n"
+    (String.capitalize_ascii Uutil.myNameAndVersion)
+    (Util.time2string (Unix.gettimeofday ())));
+
   (* If no roots are given either on the command line or in the profile,
      ask the user *)
   if Globals.rawRoots() = [] then begin

--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -665,7 +665,9 @@ let file_dialog ~parent ~title ~callback ?filename () =
 (* ------ *)
 
 let fatalError message =
-  Trace.log (message ^ "\n");
+  let () =
+    try Trace.log (message ^ "\n")
+    with Util.Fatal _ -> () in (* Can't allow fatal errors in fatal error handler *)
   let title = "Fatal error" in
   let t =
     GWindow.dialog ~parent:(toplevelWindow ())

--- a/src/uimacbridgenew.ml
+++ b/src/uimacbridgenew.ml
@@ -81,7 +81,9 @@ Callback.register "callbackThreadCreate" callbackThreadCreate;;
 external displayFatalError : string -> unit = "fatalError";;
 
 let fatalError message =
-  Trace.log (message ^ "\n");
+  let () =
+    try Trace.log (message ^ "\n")
+    with Util.Fatal _ -> () in (* Can't allow fatal errors in fatal error handler *)
   displayFatalError message
 
 (* Defined in MyController.m; display the warning and ask whether to

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -817,12 +817,6 @@ let doTransport reconItemList =
     in
     t1, Format.sprintf "%s  %s ETA" (Util.percent2string v) remTime
   in
-  let logOnly s =
-    let temp = !Trace.sendLogMsgsToStderr in
-    Trace.sendLogMsgsToStderr := false;
-    Trace.log (s ^ "\n");
-    Trace.sendLogMsgsToStderr := temp
-  in
   let tlog = ref t0 in
   let showProgress i bytes dbg =
     let t1, s = calcProgress i bytes dbg in
@@ -831,7 +825,7 @@ let doTransport reconItemList =
     if (Prefs.read Trace.terse) || (Prefs.read Globals.batch) then
       if (t1 -. !tlog) >= 60. then
       begin
-        logOnly s;
+        Trace.logonly (s ^ "\n");
         tlog := t1
       end
   in

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1369,7 +1369,9 @@ let getProfile default =
 let handleException e =
   restoreTerminal();
   let msg = Uicommon.exn2string e in
-  Trace.log (msg ^ "\n");
+  let () =
+    try Trace.log (msg ^ "\n")
+    with Util.Fatal _ -> () in (* Can't allow fatal errors in fatal error handler *)
   if not !Trace.sendLogMsgsToStderr then alwaysDisplay ("\n" ^ msg ^ "\n")
 
 let rec start interface =


### PR DESCRIPTION
There was a report in the mailing list
```
THere is one change that didn't go down well: The default file location
has changed from ~ to ~/.unison.

Now, I had already
        logfile = .unison/unison.log
in my config files.

That crashed unison with the error message that there is no such
directory
        ~/.unison/.unison/unison.log

On the TUI this is easy to see, **but** the GUI does not realize the
breakage and hangs forever not reacting at all.
```

This PR has two fixes. First, if the dir tree to log file does not exist then it is (attempted to be) created. Second, if opening or writing to log file fails, don't freak out about it in TUI and GUI error handlers.