### PR TITLE
uitext: Change terminal input - no more byte as a unit

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -1366,6 +1366,7 @@ uitext.cmo : \
     uutil.cmi \
     ubase/util.cmi \
     update.cmi \
+    unicode.cmi \
     uicommon.cmi \
     transport.cmi \
     ubase/trace.cmi \
@@ -1387,6 +1388,7 @@ uitext.cmx : \
     uutil.cmx \
     ubase/util.cmx \
     update.cmx \
+    unicode.cmx \
     uicommon.cmx \
     transport.cmx \
     ubase/trace.cmx \


### PR DESCRIPTION
### Background

Unison TUI has two modes of input, the "dumb tty" line-buffered mode and the "raw" non-line buffered mode. In both of these modes, user input is always read one byte at a time. In line-buffered mode, the remaining bytes are just discarded.

I suspect that this has always worked like this. The repo history goes back to 2005 only and this code was already present then.

I don't know what was the rationale for this implementation. I am not aware of any technical reasons why it must be like this. Perhaps it was just a result of having single-(ASCII-)character commands.

### The change

Not knowing any technical reasons for why input must be read per byte like this, I have changed the code to read in _all_ available input and treat it as a single user command. "All available input" means the entire line in line-buffered mode and (currently) up to 9 bytes in the raw mode.

I think there are good reason to do this. It will treat multi-byte encodings like UTF-8 correctly. It will treat ANSI (or other) escape sequences correctly. And finally, it will consider the entire user input when matching it against valid commands -- no more is garbage input processed as one or more valid commands.

I think this also fixes #77

### Examples

There are two commits. The first commit is the actual change. The second commit is not inteded for merging. It is present here to illustrate the new possibilities that someone may want to implement. The second commit accepts some ANSI escape sequences as valid commands, for example F1 for help, left and right arrows for change propagation, up/down arrows and PgUp/PgDn for navigation, etc.

To illustrate the change, here are before and after screenshots.
![image](https://user-images.githubusercontent.com/69477666/123861755-d840a800-d927-11eb-8aef-b5f583158b81.png)

Notice how before this PR the UTF-8 encoding is broken. Unison has no non-ASCII commands but the user could still accidentally hit such a key. Also notice how escape sequences are broken so bad that random commands ar executed. Escape sequences don't have to be valid commands but if the user accidentally hits such a key, they're in for a surprise.

And just for fun, proper Unicode input handling means that this is now possible:
![image](https://user-images.githubusercontent.com/69477666/123862768-0d99c580-d929-11eb-9594-fafd332c59be.png)
Yep... that's right.

