### PR TITLE
List software authors in opam file

### DIFF
--- a/unison.opam
+++ b/unison.opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "juergen@hoetzel.info"
 authors: [
-  "Jürgen Hötzel <juergen@hoetzel.info>"
-  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Benjamin C. Pierce"
+  "Jérôme Vouillon"
 ]
 license: "GPL-3.0-or-later"
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"

--- a/unison.opam
+++ b/unison.opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "juergen@hoetzel.info"
 authors: [
+  "Trevor Jim"
   "Benjamin C. Pierce"
   "Jérôme Vouillon"
 ]


### PR DESCRIPTION
I think the current `opam` file is incorrect.
According to opam manual, the "authors" field lists the original authors of the software, not the packagers.

@bcpierce00 please check and adjust the list of the actual authors (and optionally add email addresses if you wish).