### PR TITLE
Improve capturing output from diff command

### DIFF
--- a/src/external.ml
+++ b/src/external.ml
@@ -60,16 +60,16 @@ let runExternalProgram cmd =
   if Util.osType = `Win32 && not Util.isCygwin then begin
     debug (fun()-> Util.msg "Executing external program windows-style\n");
     let c = System.open_process_in ("\"" ^ cmd ^ "\"") in
-    let log = readChannelTillEof c in
+    let log = Util.trimWhitespace (readChannelTillEof c) in
     let returnValue = System.close_process_in c in
-    let mergeResultLog =
-      cmd ^
-      (if log <> "" then "\n\n" ^ log else "") ^
+    let resultLog =
+      (*cmd ^
+      (if log <> "" then "\n\n" ^*) log (*else "")*) ^
       (if returnValue <> Unix.WEXITED 0 then
          "\n\n" ^ Util.process_status_to_string returnValue
        else
          "") in
-    Lwt.return (returnValue,mergeResultLog)
+    Lwt.return (returnValue, resultLog)
   end else
     let (out, ipt, err) as desc = System.open_process_full cmd in
     let out = Lwt_unix.intern_in_channel out in

--- a/src/files.ml
+++ b/src/files.ml
@@ -688,15 +688,10 @@ let rec diff root1 path1 ui1 root2 path2 ui2 showDiff id =
         Util.replacesubstrings (Prefs.read diffCmd)
           ["CURRENT1", Fspath.quotes fspath1;
            "CURRENT2", Fspath.quotes fspath2] in
-    let c = System.open_process_in
-      (if Util.osType = `Win32 && not Util.isCygwin then
-        (* BCP: Proposed by Karl M. to deal with the standard windows
-           command processor's weird treatment of spaces and quotes: *)
-        "\"" ^ cmd ^ "\""
-       else
-         cmd) in
-    showDiff cmd (External.readChannelTillEof c);
-    ignore (System.close_process_in c) in
+    let _, diffResult = Lwt_unix.run (External.runExternalProgram cmd) in
+    if diffResult <> "" then
+      showDiff cmd diffResult
+  in
   match root1,root2 with
     (Local,fspath1),(Local,fspath2) ->
       Util.convertUnixErrorsToTransient


### PR DESCRIPTION
There are two improvements. First, error output is captured and displayed to user (this was a problem only in GUI). The side effect is that exit code is always printed for `diff` which usually has exit code of 1 when differences are found. It is printed (by `External.runExternalProgram`) at the end of diff output as "`Exited with status 1`".

Second, it prevents displaying a blank window (that normally contains the diff result) when using a GUI-based diff command (such as `meld`). This was a problem only in GUI. ~~Looking at the code of `External.runExternalProgram`, the output on Windows will never be empty, so this GUI-fix doesn't apply on Windows (this is not a regression).~~ _Edit: replicated in Windows code a change from commit https://github.com/bcpierce00/unison/commit/1934ced844bcbe57f5e50f21e5958f035641b8b4#diff-aad8e4461e3e7462c255b8ee09f7cda4870966d6d3a3ac863d6f12270d494591 (from 2008!) where it was done only in POSIX code of the function._ Error output is not captured on Windows, otherwise works good enough.

Not tested on ~~Windows or~~ macOS.

Fixes #68 