### PR TITLE
Restore compatibility with older OCaml compilers

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -21,7 +21,9 @@ jobs:
         - { os: macos-10.15   , ocaml-version: 4.09.1 }
         - { os: macos-10.15   , ocaml-version: 4.08.1 }
         - { os: macos-10.15   , ocaml-version: 4.07.1 }
+        - { os: macos-10.15   , ocaml-version: 4.06.1 }
         - { os: macos-10.15   , ocaml-version: 4.05.0 }
+        - { os: macos-10.15   , ocaml-version: 4.04.2 }
         - { os: ubuntu-18.04  , ocaml-version: 4.12.0 }
         - { os: ubuntu-18.04  , ocaml-version: 4.11.2 }
         - { os: ubuntu-18.04  , ocaml-version: 4.10.2 }
@@ -29,7 +31,9 @@ jobs:
         - { os: ubuntu-18.04  , ocaml-version: 4.09.1 }
         - { os: ubuntu-18.04  , ocaml-version: 4.08.1 }
         - { os: ubuntu-18.04  , ocaml-version: 4.07.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.06.1 }
         - { os: ubuntu-18.04  , ocaml-version: 4.05.0 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.04.2 }
         - { os: windows-latest , ocaml-version: 4.12.0+mingw64c }
         - { os: windows-latest , ocaml-version: 4.11.2+mingw64c }
         - { os: windows-latest , ocaml-version: 4.10.2+mingw64c }
@@ -37,7 +41,10 @@ jobs:
         - { os: windows-latest , ocaml-version: 4.09.1+mingw64c }
         - { os: windows-latest , ocaml-version: 4.08.1+mingw64c }
         - { os: windows-latest , ocaml-version: 4.07.1+mingw64c }
+        - { os: windows-latest , ocaml-version: 4.06.1+mingw64c }
         - { os: windows-latest , ocaml-version: 4.05.0+mingw64c }
+        - { os: windows-latest , ocaml-version: 4.04.2+mingw64c }
+        - { os: windows-latest , ocaml-version: 4.04.2+mingw32c }
 
     runs-on: ${{ matrix.job.os }}
 

--- a/src/.depend
+++ b/src/.depend
@@ -80,6 +80,11 @@ common.cmi : \
     name.cmi \
     fspath.cmi \
     fileinfo.cmi
+compat.cmo : \
+    compat.cmi
+compat.cmx : \
+    compat.cmi
+compat.cmi :
 copy.cmo : \
     xferhint.cmi \
     uutil.cmi \

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -196,6 +196,7 @@ endif
 # File extensions will be substituted for the native code version
 
 OCAMLOBJS += \
+          compat.cmo \
           ubase/rx.cmo \
 	  \
           unicode_tables.cmo unicode.cmo bytearray.cmo \

--- a/src/compat.ml
+++ b/src/compat.ml
@@ -1,0 +1,102 @@
+module Bytes = struct
+
+include Bytes
+
+(* The following code is taken from OCaml sources.
+   Authors of the code snippet: Alain Frisch and Daniel Bünzli *)
+
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** {6 Binary encoding/decoding of integers} *)
+
+external get_uint8 : bytes -> int -> int = "%bytes_safe_get"
+external get_uint16_ne : bytes -> int -> int = "%caml_string_get16"
+external get_int32_ne : bytes -> int -> int32 = "%caml_string_get32"
+external get_int64_ne : bytes -> int -> int64 = "%caml_string_get64"
+external set_int8 : bytes -> int -> int -> unit = "%bytes_safe_set"
+external set_int16_ne : bytes -> int -> int -> unit = "%caml_string_set16"
+external set_int32_ne : bytes -> int -> int32 -> unit = "%caml_string_set32"
+external set_int64_ne : bytes -> int -> int64 -> unit = "%caml_string_set64"
+external swap16 : int -> int = "%bswap16"
+external swap32 : int32 -> int32 = "%bswap_int32"
+external swap64 : int64 -> int64 = "%bswap_int64"
+
+let get_int8 b i =
+  ((get_uint8 b i) lsl (Sys.int_size - 8)) asr (Sys.int_size - 8)
+
+let get_uint16_le b i =
+  if Sys.big_endian then swap16 (get_uint16_ne b i)
+  else get_uint16_ne b i
+
+let get_uint16_be b i =
+  if not Sys.big_endian then swap16 (get_uint16_ne b i)
+  else get_uint16_ne b i
+
+let get_int16_ne b i =
+  ((get_uint16_ne b i) lsl (Sys.int_size - 16)) asr (Sys.int_size - 16)
+
+let get_int16_le b i =
+  ((get_uint16_le b i) lsl (Sys.int_size - 16)) asr (Sys.int_size - 16)
+
+let get_int16_be b i =
+  ((get_uint16_be b i) lsl (Sys.int_size - 16)) asr (Sys.int_size - 16)
+
+let get_int32_le b i =
+  if Sys.big_endian then swap32 (get_int32_ne b i)
+  else get_int32_ne b i
+
+let get_int32_be b i =
+  if not Sys.big_endian then swap32 (get_int32_ne b i)
+  else get_int32_ne b i
+
+let get_int64_le b i =
+  if Sys.big_endian then swap64 (get_int64_ne b i)
+  else get_int64_ne b i
+
+let get_int64_be b i =
+  if not Sys.big_endian then swap64 (get_int64_ne b i)
+  else get_int64_ne b i
+
+let set_int16_le b i x =
+  if Sys.big_endian then set_int16_ne b i (swap16 x)
+  else set_int16_ne b i x
+
+let set_int16_be b i x =
+  if not Sys.big_endian then set_int16_ne b i (swap16 x)
+  else set_int16_ne b i x
+
+let set_int32_le b i x =
+  if Sys.big_endian then set_int32_ne b i (swap32 x)
+  else set_int32_ne b i x
+
+let set_int32_be b i x =
+  if not Sys.big_endian then set_int32_ne b i (swap32 x)
+  else set_int32_ne b i x
+
+let set_int64_le b i x =
+  if Sys.big_endian then set_int64_ne b i (swap64 x)
+  else set_int64_ne b i x
+
+let set_int64_be b i x =
+  if not Sys.big_endian then set_int64_ne b i (swap64 x)
+  else set_int64_ne b i x
+
+let set_uint8 = set_int8
+let set_uint16_ne = set_int16_ne
+let set_uint16_be = set_int16_be
+let set_uint16_le = set_int16_le
+
+end

--- a/src/compat.mli
+++ b/src/compat.mli
@@ -1,0 +1,214 @@
+module Bytes : sig
+
+include module type of Bytes
+
+(* The following code is taken from OCaml sources.
+   Authors of the code snippet: Alain Frisch and Daniel Bünzli *)
+
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** {1 Binary encoding/decoding of integers} *)
+
+(** The functions in this section binary encode and decode integers to
+    and from byte sequences.
+    All following functions raise [Invalid_argument] if the space
+    needed at index [i] to decode or encode the integer is not
+    available.
+    Little-endian (resp. big-endian) encoding means that least
+    (resp. most) significant bytes are stored first.  Big-endian is
+    also known as network byte order.  Native-endian encoding is
+    either little-endian or big-endian depending on {!Sys.big_endian}.
+    32-bit and 64-bit integers are represented by the [int32] and
+    [int64] types, which can be interpreted either as signed or
+    unsigned numbers.
+    8-bit and 16-bit integers are represented by the [int] type,
+    which has more bits than the binary encoding.  These extra bits
+    are handled as follows: {ul
+    {- Functions that decode signed (resp. unsigned) 8-bit or 16-bit
+    integers represented by [int] values sign-extend
+    (resp. zero-extend) their result.}
+    {- Functions that encode 8-bit or 16-bit integers represented by
+    [int] values truncate their input to their least significant
+    bytes.}}
+*)
+
+val get_uint8 : bytes -> int -> int
+(** [get_uint8 b i] is [b]'s unsigned 8-bit integer starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int8 : bytes -> int -> int
+(** [get_int8 b i] is [b]'s signed 8-bit integer starting at byte index [i].
+    @since 4.08
+*)
+
+val get_uint16_ne : bytes -> int -> int
+(** [get_uint16_ne b i] is [b]'s native-endian unsigned 16-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_uint16_be : bytes -> int -> int
+(** [get_uint16_be b i] is [b]'s big-endian unsigned 16-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_uint16_le : bytes -> int -> int
+(** [get_uint16_le b i] is [b]'s little-endian unsigned 16-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int16_ne : bytes -> int -> int
+(** [get_int16_ne b i] is [b]'s native-endian signed 16-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int16_be : bytes -> int -> int
+(** [get_int16_be b i] is [b]'s big-endian signed 16-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int16_le : bytes -> int -> int
+(** [get_int16_le b i] is [b]'s little-endian signed 16-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int32_ne : bytes -> int -> int32
+(** [get_int32_ne b i] is [b]'s native-endian 32-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int32_be : bytes -> int -> int32
+(** [get_int32_be b i] is [b]'s big-endian 32-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int32_le : bytes -> int -> int32
+(** [get_int32_le b i] is [b]'s little-endian 32-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int64_ne : bytes -> int -> int64
+(** [get_int64_ne b i] is [b]'s native-endian 64-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int64_be : bytes -> int -> int64
+(** [get_int64_be b i] is [b]'s big-endian 64-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val get_int64_le : bytes -> int -> int64
+(** [get_int64_le b i] is [b]'s little-endian 64-bit integer
+    starting at byte index [i].
+    @since 4.08
+*)
+
+val set_uint8 : bytes -> int -> int -> unit
+(** [set_uint8 b i v] sets [b]'s unsigned 8-bit integer starting at byte index
+    [i] to [v].
+    @since 4.08
+*)
+
+val set_int8 : bytes -> int -> int -> unit
+(** [set_int8 b i v] sets [b]'s signed 8-bit integer starting at byte index
+    [i] to [v].
+    @since 4.08
+*)
+
+val set_uint16_ne : bytes -> int -> int -> unit
+(** [set_uint16_ne b i v] sets [b]'s native-endian unsigned 16-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_uint16_be : bytes -> int -> int -> unit
+(** [set_uint16_be b i v] sets [b]'s big-endian unsigned 16-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_uint16_le : bytes -> int -> int -> unit
+(** [set_uint16_le b i v] sets [b]'s little-endian unsigned 16-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int16_ne : bytes -> int -> int -> unit
+(** [set_int16_ne b i v] sets [b]'s native-endian signed 16-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int16_be : bytes -> int -> int -> unit
+(** [set_int16_be b i v] sets [b]'s big-endian signed 16-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int16_le : bytes -> int -> int -> unit
+(** [set_int16_le b i v] sets [b]'s little-endian signed 16-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int32_ne : bytes -> int -> int32 -> unit
+(** [set_int32_ne b i v] sets [b]'s native-endian 32-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int32_be : bytes -> int -> int32 -> unit
+(** [set_int32_be b i v] sets [b]'s big-endian 32-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int32_le : bytes -> int -> int32 -> unit
+(** [set_int32_le b i v] sets [b]'s little-endian 32-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int64_ne : bytes -> int -> int64 -> unit
+(** [set_int64_ne b i v] sets [b]'s native-endian 64-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int64_be : bytes -> int -> int64 -> unit
+(** [set_int64_be b i v] sets [b]'s big-endian 64-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+val set_int64_le : bytes -> int -> int64 -> unit
+(** [set_int64_le b i v] sets [b]'s little-endian 64-bit integer
+    starting at byte index [i] to [v].
+    @since 4.08
+*)
+
+end

--- a/src/uigtk2.ml
+++ b/src/uigtk2.ml
@@ -93,9 +93,10 @@ let icon =
 *)
 let icon =
   let p = GdkPixbuf.create ~width:48 ~height:48 ~has_alpha:true () in
-  Gpointer.blit
-    ~src:(Gpointer.region_of_bytes (Bytes.of_string Pixmaps.icon_data))
-    ~dst:(GdkPixbuf.get_pixels p);
+  let pxs = GdkPixbuf.get_pixels p in
+  (* This little hack is here to support compiling with lablgtk versions both
+     < 2.18.6 and >= 2.18.6 *)
+  String.iteri (fun i c -> Gpointer.set_byte pxs ~pos:i (Char.code c)) Pixmaps.icon_data;
   p
 
 let leftPtrWatch =


### PR DESCRIPTION
Unison currently compiles with OCaml >= 4.05. I discovered that the reason for that is lablgtk. A little hack (first commit) bypasses that issue and gets the compiler support down to >= 4.03 (older than that and other compatibility issues start to surface).

The ongoing Umarshal work will raise the compiler requirement to >= 4.08. To my understanding, the reason is the new `Bytes.get_*/set_*` functions that were introduced in OCaml 4.08. I have another hack (second commit) which would bring the compiler requirement back down to >= 4.04. (Umarshal will remain unchanged, it will only have to add `open Compat`). cc @glondu if this makes sense to you.

### Why bother?

The next release (hopefully) is going to be the first release with no run-time dependency on OCaml version. It would be very positive if that release supported the widest range of OCaml compilers because this makes for the best possible upgrade possibility for users.

After that release (or few), these commits can and should be reverted. Then there is no longer any run-time dependency on OCaml versions and it makes sense to bump the build requirement to 4.08 or even newer.