### PR TITLE
fsmonitor: Remove immediate events

### DIFF
--- a/src/fsmonitor/linux/watcher.ml
+++ b/src/fsmonitor/linux/watcher.ml
@@ -116,30 +116,9 @@ let is_deletion ev =
      | Q_overflow    -> false
      | Unmount       -> true)
 
-let is_immediate ev =
-  Inotify.
-    (match ev with
-     | Access        -> false
-     | Attrib        -> false
-     | Close_write   -> false
-     | Close_nowrite -> false
-     | Create        -> false
-     | Delete        -> true
-     | Delete_self   -> true
-     | Modify        -> false
-     | Move_self     -> true
-     | Moved_from    -> true
-     | Moved_to      -> true
-     | Open          -> false
-     | Ignored       -> false
-     | Isdir         -> false
-     | Q_overflow    -> false
-     | Unmount       -> true)
-
 let event_is_change (_, evl, _, _) = List.exists is_change evl
 let event_is_creation (_, evl, _, _) = List.exists is_creation evl
 let event_is_deletion (_, evl, _, _) = List.exists is_deletion evl
-let event_is_immediate (_, evl, _, _) = List.exists is_immediate evl
 
 let st = Lwt_inotify.init ()
 
@@ -171,11 +150,10 @@ let rec watch_rec () =
     if kind <> `OTHER then begin
       try
         let files = Hashtbl.find watcher_by_id wd in
-        let event_time = if event_is_immediate ev then 0. else time in
         IntSet.iter
           (fun file ->
              signal_change
-               event_time (Hashtbl.find file_by_id file) nm_opt kind)
+               time (Hashtbl.find file_by_id file) nm_opt kind)
           files
       with Not_found ->
         ()

--- a/src/fsmonitor/linux/watcher.ml
+++ b/src/fsmonitor/linux/watcher.ml
@@ -158,7 +158,6 @@ let path_of_id id =
     Format.sprintf "????"
 
 let previous_event = ref None
-let time_ref = ref (ref 0.)
 
 let clear_event_memory () = previous_event := None
 
@@ -168,12 +167,11 @@ let rec watch_rec () =
   if !previous_event <> Some ev then begin
     previous_event := Some ev;
     if !Watchercommon.debug then print_event path_of_id ev;
-    time_ref := ref time;
     let kind = event_kind ev in
     if kind <> `OTHER then begin
       try
         let files = Hashtbl.find watcher_by_id wd in
-        let event_time = if event_is_immediate ev then ref 0. else !time_ref in
+        let event_time = if event_is_immediate ev then 0. else time in
         IntSet.iter
           (fun file ->
              signal_change
@@ -185,8 +183,7 @@ let rec watch_rec () =
       if !Watchercommon.debug then Format.eprintf "OVERFLOW@.";
       signal_overflow ()
     end
-  end else
-    !time_ref := time;
+  end;
   watch_rec ()
 
 let watch () =

--- a/src/fsmonitor/solaris/watcher.ml
+++ b/src/fsmonitor/solaris/watcher.ml
@@ -362,7 +362,7 @@ let process_ev time ((file, name), (port, eo, id, ev)) =
     print_event ev
   end;
   let () = cleanup_watch file name port eo id ev in
-  let event_time = if event_is_immediate ev then ref 0. else ref time
+  let event_time = if event_is_immediate ev then 0. else time
   and name = match name with
   | "" -> None
   | _ -> Some name

--- a/src/fsmonitor/solaris/watcher.ml
+++ b/src/fsmonitor/solaris/watcher.ml
@@ -150,24 +150,6 @@ let event_kind =
   in
   List.fold_left (fun k v -> if k = `OTHER then kind v else k) `OTHER
 
-let event_is_exceptional =
-  let is_ex = function
-  | FILE_ACCESS -> false
-  | FILE_MODIFIED -> false
-  | FILE_ATTRIB -> false
-  | FILE_DELETE -> true
-  | FILE_RENAME_TO -> true
-  | FILE_RENAME_FROM -> true
-  | FILE_TRUNC -> false
-  | FILE_NOFOLLOW -> false
-  | UNMOUNTED -> true
-  | MOUNTEDOVER -> true
-  in
-  List.fold_left (fun k v -> if not k then is_ex v else k) false
-
-(* FIXME: should be equal to [event_is_exceptional] here? *)
-let event_is_immediate ev = false
-
 (****)
 
 external port_create : unit -> port = "unsn_port_create"
@@ -362,12 +344,11 @@ let process_ev time ((file, name), (port, eo, id, ev)) =
     print_event ev
   end;
   let () = cleanup_watch file name port eo id ev in
-  let event_time = if event_is_immediate ev then 0. else time
-  and name = match name with
+  let name = match name with
   | "" -> None
   | _ -> Some name
   in
-  signal_change event_time file name (event_kind ev)
+  signal_change time file name (event_kind ev)
 
 (* Always process events on children first and on parents last because
  * the cleanup procedure clears out children together with the parent. *)

--- a/src/fsmonitor/watchercommon.mli
+++ b/src/fsmonitor/watchercommon.mli
@@ -22,7 +22,7 @@ module F (M : sig type watch end) : sig
   val dir_path : t -> string -> string
 
   val signal_change :
-    float ref -> t -> string option -> [> `CREAT | `DEL ] -> unit
+    float -> t -> string option -> [> `CREAT | `DEL ] -> unit
   val signal_overflow : unit -> unit
 
   module type S = sig

--- a/src/fsmonitor/windows/watcher.ml
+++ b/src/fsmonitor/windows/watcher.ml
@@ -106,7 +106,6 @@ let get_win_path root dir ((ev_path, act) as ev) =
         (ev_path, Lwt_win.FILE_ACTION_MODIFIED))
 
 let previous_event = ref None
-let time_ref = ref (ref 0.)
 
 let clear_event_memory () = previous_event := None
 
@@ -135,7 +134,6 @@ let watch_root_directory path dir =
     List.iter
       (fun ((ev_path, _) as ev) ->
          if !previous_event <> Some ev then begin
-           time_ref := ref time;
            previous_event := Some ev;
            if !Watchercommon.debug then print_event ev;
            let pathnm, ev = get_win_path path dir ev in
@@ -144,11 +142,10 @@ let watch_root_directory path dir =
                ()
            | Some (subdir, nm) ->
                let event_time =
-                 if event_is_immediate ev then ref 0. else !time_ref in
+                 if event_is_immediate ev then 0. else time in
                let kind = event_kind ev in
                signal_change event_time subdir nm kind
-         end else
-           !time_ref := time)
+         end)
       l;
     if l = [] && get_watch dir <> None then begin
       if !Watchercommon.debug then Format.eprintf "OVERFLOW@.";

--- a/src/fsmonitor/windows/watcher.ml
+++ b/src/fsmonitor/windows/watcher.ml
@@ -44,14 +44,6 @@ module Windows = struct
 let print_event (nm, act) =
   Format.eprintf "%s %d@." nm (Obj.magic act : int)
 
-let event_is_immediate (_, act) =
-  match act with
-    Lwt_win.FILE_ACTION_ADDED
-  | Lwt_win.FILE_ACTION_MODIFIED         -> false
-  | Lwt_win.FILE_ACTION_REMOVED
-  | Lwt_win.FILE_ACTION_RENAMED_OLD_NAME
-  | Lwt_win.FILE_ACTION_RENAMED_NEW_NAME -> true
-
 let event_kind (_, act) =
   match act with
     Lwt_win.FILE_ACTION_ADDED            -> `CREAT
@@ -141,10 +133,8 @@ let watch_root_directory path dir =
              None ->
                ()
            | Some (subdir, nm) ->
-               let event_time =
-                 if event_is_immediate ev then 0. else time in
                let kind = event_kind ev in
-               signal_change event_time subdir nm kind
+               signal_change time subdir nm kind
          end)
       l;
     if l = [] && get_watch dir <> None then begin


### PR DESCRIPTION
For motivation and description, see #525 and commit messages.

The first commit is not directly required for the immediate events removal but it makes it easier to reason about the change. I have stared intensely at the code and unless I'm missing something, the first commit can be confirmed to be correct by just looking at it.

Fixes #525