### PR TITLE
Use the same code path for local and remote syncs

### DIFF
--- a/src/copy.ml
+++ b/src/copy.ml
@@ -144,7 +144,7 @@ let rec fingerprintPrefix fspath path offset len accu =
   end
 
 let fingerprintPrefixRemotely =
-  Remote.registerServerCmd
+  Remote.registerServerCmd'
     "fingerprintSubfile"
     (fun _ (fspath, path, len) ->
        Lwt.return (fingerprintPrefix fspath path 0L len []))
@@ -461,7 +461,7 @@ let compress conn
        Util.convertUnixErrorsToTransient "transferring file contents"
          (fun () -> raise e))
 
-let compressRemotely = Remote.registerServerCmd "compress" compress
+let compressRemotely = Remote.registerServerCmd' "compress" compress
 
 let close_all infd outfd =
   Util.convertUnixErrorsToTransient
@@ -957,17 +957,10 @@ let file rootFrom pathFrom rootTo fspathTo pathTo realPathTo
       (Fspath.toDebugString fspathTo) (Path.toString pathTo)
       (Props.toString desc));
   let timer = Trace.startTimer "Transmitting file" in
-  begin match rootFrom, rootTo with
-    (Common.Local, fspathFrom), (Common.Local, realFspathTo) ->
-      localFile
-        fspathFrom pathFrom fspathTo pathTo realPathTo
-        update desc (Osx.ressLength ress) (Some id);
-        paranoidCheck fspathTo pathTo realPathTo desc fp ress
-  | _ ->
-      transferFile
-        rootFrom pathFrom rootTo fspathTo pathTo realPathTo
-        update desc fp ress id
-  end >>= fun status ->
+  transferFile
+    rootFrom pathFrom rootTo fspathTo pathTo realPathTo
+    update desc fp ress id
+  >>= fun status ->
   Trace.showTimer timer;
   match status with
     TransferSucceeded info ->

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -602,7 +602,7 @@ type servercmd =
 let serverCmds = ref (Util.StringMap.empty : servercmd Util.StringMap.t)
 
 type serverstream =
-  connection -> Bytearray.t -> unit
+  connection option -> Bytearray.t -> unit
 let serverStreams = ref (Util.StringMap.empty : serverstream Util.StringMap.t)
 
 type header =
@@ -660,7 +660,7 @@ let processStream conn id cmdName buf =
         try Util.StringMap.find cmdName !serverStreams
         with Not_found -> raise (Util.Fatal (cmdName ^ " not registered!"))
       in
-      cmd conn buf;
+      cmd (Some conn) buf;
       Lwt.return ()
     with e ->
       Hashtbl.add streamError id e;
@@ -789,6 +789,17 @@ let registerServerCmd name f =
   registerSpecialServerCmd
     name defaultMarshalingFunctions defaultMarshalingFunctions f
 
+(* Same as [registerServerCmd] but returns a function that runs either
+   the proxy or the local version, depending on whether the call is to
+   the local host (in this case [conn] is None) or a remote one. *)
+let registerServerCmd' name f =
+  let serverSide = (fun conn args -> f (Some conn) args) in
+  let client0 = registerServerCmd name serverSide in
+  fun conn args ->
+    match conn with
+    | None -> f None args
+    | Some conn -> client0 conn args
+
 (* RegisterHostCmd is a simpler version of registerClientServer [registerServerCmd?].
    It is used to create remote procedure calls: the only communication
    between the client and server is the sending of arguments from
@@ -826,16 +837,16 @@ let registerRootCmd (cmdName : string) (cmd : (Fspath.t * 'a) -> 'b) =
   fun root args -> r (hostOfRoot root) ((snd root), args)
 
 let registerRootCmdWithConnection
-  (cmdName : string) (cmd : connection -> 'a -> 'b) =
-  let client0 = registerServerCmd cmdName cmd in
+  (cmdName : string) (cmd : connection option -> 'a -> 'b) =
+  let serverSide = (fun conn args -> cmd (Some conn) args) in
+  let client0 = registerServerCmd cmdName serverSide in
   (* Return a function that runs either the proxy or the local version,
      depending on whether the call is to the local host or a remote one *)
   fun localRoot remoteRoot args ->
-    match (hostOfRoot localRoot) with
-      "" -> let conn = hostConnection (hostOfRoot remoteRoot) in
-            cmd conn args
-    | _  -> let conn = hostConnection (hostOfRoot localRoot) in
-            client0 conn args
+    match hostOfRoot localRoot, hostOfRoot remoteRoot with
+    | "", "" -> cmd None args
+    | "", _ ->  cmd (Some (connectionToRoot remoteRoot)) args
+    | _  -> client0 (connectionToRoot localRoot) args
 
 let streamReg = Lwt_util.make_region 1
 
@@ -849,12 +860,12 @@ let streamingActivated =
 let registerStreamCmd
     (cmdName : string)
     marshalingFunctionsArgs
-    (serverSide : connection -> 'a -> unit)
+    (serverSide : connection option -> 'a -> unit)
     =
   let cmd =
     registerSpecialServerCmd
       cmdName marshalingFunctionsArgs defaultMarshalingFunctions
-      (fun conn v -> serverSide conn v; Lwt.return ())
+      (fun conn v -> serverSide (Some conn) v; Lwt.return ())
   in
   let ping =
     registerServerCmd (cmdName ^ "Ping")
@@ -889,7 +900,7 @@ let registerStreamCmd
     in
     dumpIdle conn request
   in
-  fun conn sender ->
+  let proxy conn sender =
     if not (Prefs.read streamingActivated) then
       sender (fun v -> cmd conn v)
     else begin
@@ -905,6 +916,11 @@ let registerStreamCmd
              Util.msg "Pinging remote end after streaming error\n");
            ping conn id >>= fun () -> Lwt.fail e)
     end
+  in
+  fun conn sender ->
+    match conn with
+    | None -> sender (fun v -> Lwt.return (serverSide conn v))
+    | Some conn -> proxy conn sender
 
 let commandAvailable =
   registerRootCmd "commandAvailable"

--- a/src/remote.mli
+++ b/src/remote.mli
@@ -91,6 +91,8 @@ val connectionToRoot : Common.root -> connection
 
 val registerServerCmd :
   string -> (connection -> 'a -> 'b Lwt.t) -> connection -> 'a -> 'b Lwt.t
+val registerServerCmd' :
+  string -> (connection option -> 'a -> 'b Lwt.t) -> connection option -> 'a -> 'b Lwt.t
 val registerSpecialServerCmd :
   string ->
   ('a ->
@@ -109,7 +111,7 @@ val encodeInt : int -> Bytearray.t * int * int
 val decodeInt : Bytearray.t -> int -> int
 val registerRootCmdWithConnection :
     string                          (* command name *)
- -> (connection -> 'a -> 'b Lwt.t)  (* local command *)
+ -> (connection option -> 'a -> 'b Lwt.t)  (* local command *)
  ->    Common.root                  (* root on which the command is executed *)
     -> Common.root                  (* other root *)
     -> 'a                           (* additional arguments *)
@@ -122,5 +124,5 @@ val registerStreamCmd :
   ('a ->
    (Bytearray.t * int * int) list -> (Bytearray.t * int * int) list * int) *
   (Bytearray.t -> int -> 'a) ->
-  (connection -> 'a -> unit) ->
-  connection -> (('a -> unit Lwt.t) -> 'b Lwt.t) -> 'b Lwt.t
+  (connection option -> 'a -> unit) ->
+  connection option -> (('a -> unit Lwt.t) -> 'b Lwt.t) -> 'b Lwt.t


### PR DESCRIPTION
This came out of the discussion at #571.

Closes #570 

It is my third iteration. The first iteration was very similar to this, just more hackish and with more changes in `Remote`. For second iteration, I wanted to make the `Remote` module simpler (could drop the `registerRootCmdWithConnection` function completely) but unfortunately that's not possible. It would mean the signatures of remote functions in `Copy` would have to change and that would break compatibility with 2.51. This third iteration is fully compatible with 2.51.

The code path taken by local and remote syncs is now the same. Maybe there are some optimizations that make sense locally (for example, bigger buffers? then again, all buffers are currently quite small so this question does not have to come in here). This PR does not look at that side of things at all.

I have done some very brief testing locally and remotely with ssh and socket server and also with 2.51.

(As draft so it doesn't get accidentally merged. The change itself is finished as of now.)