### PR TITLE
Include archive name in unison.dump file name

### DIFF
--- a/src/update.ml
+++ b/src/update.ml
@@ -519,7 +519,7 @@ let rec showArchive = function
 let dumpArchiveLocal (fspath,()) =
   let (name, root) = archiveName fspath MainArch in
   let archive = getArchive root in
-  let f = Util.fileInUnisonDir "unison.dump" in
+  let f = Util.fileInUnisonDir (name ^ ".unison.dump") in
   debug (fun () -> Printf.eprintf "Dumping archive into `%s'\n"
                      (System.fspathToDebugString f));
   let ch = System.open_out_gen [Open_wronly; Open_creat; Open_trunc] 0o600 f in


### PR DESCRIPTION
Currently any archive is dumped into a file named `unison.dump`. When both replicas are local, archive dump of one replica will overwrite the other. Add archive name (the hash in hex) into the file name to prevent this.