### PR TITLE
Increase IO buf size to match that of OCaml's

### DIFF
--- a/src/uutil.ml
+++ b/src/uutil.ml
@@ -111,7 +111,7 @@ let showUpdateStatus path =
 (*               Copy bytes from one file_desc to another                    *)
 (*****************************************************************************)
 
-let bufsize = 16384
+let bufsize = 65536
 let bufsizeFS = Filesize.ofInt bufsize
 let buf = Bytes.create bufsize
 


### PR DESCRIPTION
OCaml's buffered IO buf size has been 64K since 4.01. It makes sense to match that in Unison code. (OCaml's buffered IO is used for local file copies.)