### PR TITLE
Add Windows pty support and don't open the console window

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -257,10 +257,12 @@ endif
 
 # Patch to make a Windows GUI version come up with no
 # console when click-started
-#  ifeq ($(OSARCH), win32)
+ifeq ($(OSARCH), win32)
+  ifneq ($(UISTYLE), text)
 #    COBJS+=winmain.c
-#    CFLAGS+=-cclib /subsystem:windows
-#  endif
+    CFLAGS+=-ccopt "-link -Wl,--subsystem,windows"
+  endif
+endif
 
 # Gtk GUI
 ifeq ($(UISTYLE), gtk)

--- a/src/files.ml
+++ b/src/files.ml
@@ -973,7 +973,9 @@ let merge root1 path1 ui1 root2 path2 ui2 id showMergeFn =
 
       (* It's useful for now to be a bit verbose about what we're doing, but let's
          keep it easy to switch this to debug-only in some later release... *)
-      let say f = f() in
+      (* Added check on [sendLogMsgsToStderr] because in Windows the GUI may not
+         have stderr (and stdout) at all. *)
+      let say f = if !Trace.sendLogMsgsToStderr then f () in
 
       (* Check which files got created by the merge command and do something appropriate
          with them *)

--- a/src/pty.c
+++ b/src/pty.c
@@ -1,13 +1,24 @@
-/* Stub code for controlling terminals on Mac OS X. */
+/* Stub code for controlling terminals. */
 
+#ifdef _WIN32
+
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#endif /* _WIN32 */
+
+#define CAML_NAME_SPACE
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>    // alloc_tuple
 #include <caml/memory.h>   // Store_field
 #include <caml/fail.h>     // failwith
+#include <caml/unixsupport.h> // uerror, unix_error
+#include <caml/version.h>
 #include <errno.h>         // ENOSYS
-
-extern void unix_error (int errcode, char * cmdname, value arg) Noreturn;
-extern void uerror (char * cmdname, value arg) Noreturn;
 
 // openpty
 #if defined(__linux)
@@ -32,27 +43,27 @@ extern void uerror (char * cmdname, value arg) Noreturn;
 #include <sys/types.h>
 
 CAMLprim value setControllingTerminal(value fdVal) {
+  CAMLparam1(fdVal);
   int fd = Int_val(fdVal);
   if (ioctl(fd, TIOCSCTTY, (char *) 0) < 0)
     uerror("ioctl", (value) 0);
-  return Val_unit;
+  CAMLreturn(Val_unit);
 }
 
 /* c_openpty: unit -> (int * Unix.file_descr) */
 CAMLprim value c_openpty() {
+  CAMLparam0();
   int master,slave;
-  value pair;
+  CAMLlocal1(pair);
   if (openpty(&master,&slave,NULL,NULL,NULL) < 0)
     uerror("openpty", (value) 0);
-  pair = alloc_tuple(2);
+  pair = caml_alloc_tuple(2);
   Store_field(pair,0,Val_int(master));
   Store_field(pair,1,Val_int(slave));
-  return pair;
+  CAMLreturn(pair);
 }
 
 #else // not HAS_OPENPTY
-
-#define Nothing ((value) 0)
 
 CAMLprim value setControllingTerminal(value fdVal) {
   unix_error (ENOSYS, "setControllingTerminal", Nothing);
@@ -60,6 +71,311 @@ CAMLprim value setControllingTerminal(value fdVal) {
 
 CAMLprim value c_openpty() {
   unix_error (ENOSYS, "openpty", Nothing);
+}
+
+#endif
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+extern void win32_maperr(DWORD errcode);
+extern value win_alloc_handle(HANDLE h);
+
+static int Twin_multi_byte_to_wide_char(const char *s, int slen,
+                                        wchar_t *out, int outlen)
+{
+  int retcode;
+
+  CAMLassert (s != NULL);
+
+  if (slen == 0)
+    return 0;
+
+  retcode =
+    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                        s, slen, out, outlen);
+  if (retcode == 0)
+    retcode = MultiByteToWideChar(CP_ACP, 0, s, slen, out, outlen);
+
+  if (retcode == 0) {
+    win32_maperr(GetLastError());
+    uerror("", Nothing);
+  }
+
+  return retcode;
+}
+
+#if OCAML_VERSION < 40600
+static void* caml_stat_alloc_noexc(asize_t sz)
+{
+  return malloc(sz);
+}
+#endif /* OCAML_VERSION < 40600 */
+
+static wchar_t* Tcaml_stat_strdup_to_utf16(const char *s)
+{
+  wchar_t * ws;
+  int retcode;
+
+  retcode = Twin_multi_byte_to_wide_char(s, -1, NULL, 0);
+  ws = caml_stat_alloc_noexc(retcode * sizeof(*ws));
+  Twin_multi_byte_to_wide_char(s, -1, ws, retcode);
+
+  return ws;
+}
+
+#define PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE 0x00020016
+
+typedef VOID* HPCON;
+
+typedef HRESULT (WINAPI *sCreatePseudoConsole)
+          (COORD size, HANDLE hInput, HANDLE hOutput, DWORD dwFlags, HPCON* phPC);
+
+typedef void (WINAPI *sClosePseudoConsole) (HPCON hPC);
+
+sCreatePseudoConsole pCreatePseudoConsole;
+sClosePseudoConsole pClosePseudoConsole;
+
+CAMLprim value win_openpty()
+{
+  CAMLparam0();
+  CAMLlocal4(tup, tmp1, tmp2, tmp3);
+  HPCON pty;
+  HANDLE i1, i2, o1, o2;
+  COORD size = { .X = 80, .Y = 25 };
+
+  HMODULE kernel32_module = GetModuleHandleW(L"kernel32.dll");
+  if (kernel32_module == NULL) {
+    unix_error(ENOSYS, "openpty", Nothing);
+  }
+
+  /* This is the only way to use the new API while remaining compatible
+   * with older Windows versions. */
+  pCreatePseudoConsole = (sCreatePseudoConsole)
+      GetProcAddress(kernel32_module, "CreatePseudoConsole");
+  if (pCreatePseudoConsole == NULL) {
+    unix_error(ENOSYS, "openpty", Nothing);
+  }
+
+  /* Read-write pipes don't seem to work well with PTY and cause deadlocks.
+   * socketpair() is not supported by Windows and emulation code is just too
+   * much to carry around (also, emulation by PF_INET sockets is a bit messy;
+   * emulation by PF_UNIX sockets is only supported starting Windows 10 1803).
+   * Simpler to use two separate pipes then. */
+  if (!CreatePipe(&i1, &o1, NULL, 0)) {
+    win32_maperr(GetLastError());
+    uerror("openpty", Nothing);
+  }
+  if (!CreatePipe(&i2, &o2, NULL, 0)) {
+    win32_maperr(GetLastError());
+    if (o1 != INVALID_HANDLE_VALUE) CloseHandle(o1);
+    if (i1 != INVALID_HANDLE_VALUE) CloseHandle(i1);
+    uerror("openpty", Nothing);
+  }
+
+  if (pCreatePseudoConsole(size, i1, o2, 0, &pty) != S_OK) {
+    win32_maperr(GetLastError());
+    if (o1 != INVALID_HANDLE_VALUE) CloseHandle(o1);
+    if (i1 != INVALID_HANDLE_VALUE) CloseHandle(i1);
+    if (o2 != INVALID_HANDLE_VALUE) CloseHandle(o2);
+    if (i2 != INVALID_HANDLE_VALUE) CloseHandle(i2);
+    uerror("openpty", Nothing);
+  }
+
+  tmp1 = caml_alloc_tuple(2);
+  Store_field(tmp1, 0, win_alloc_handle(i2));
+  Store_field(tmp1, 1, win_alloc_handle(o1));
+
+  tmp2 = caml_alloc(1, Abstract_tag);
+  *((HPCON *) Data_abstract_val(tmp2)) = pty;
+
+  tmp3 = caml_alloc_tuple(2);
+  Store_field(tmp3, 0, win_alloc_handle(i1));
+  Store_field(tmp3, 1, win_alloc_handle(o2));
+
+  tup = caml_alloc_tuple(3);
+  Store_field(tup, 0, tmp1);
+  Store_field(tup, 1, tmp2);
+  Store_field(tup, 2, tmp3);
+
+  CAMLreturn(tup);
+}
+
+CAMLprim value win_closepty(value pty)
+{
+  CAMLparam1(pty);
+
+  HMODULE kernel32_module = GetModuleHandleW(L"kernel32.dll");
+  if (kernel32_module == NULL) {
+    unix_error(ENOSYS, "closepty", Nothing);
+  }
+
+  /* This is the only way to use the new API while remaining compatible
+   * with older Windows versions. */
+  pClosePseudoConsole = (sClosePseudoConsole)
+      GetProcAddress(kernel32_module, "ClosePseudoConsole");
+  if (pClosePseudoConsole == NULL) {
+    unix_error(ENOSYS, "closepty", Nothing);
+  }
+
+  pClosePseudoConsole(*((HPCON *) Data_abstract_val(pty)));
+
+  CAMLreturn(Val_unit);
+}
+
+static void prepareSiWithPty(value prog, STARTUPINFOEX *si, HPCON pty)
+{
+#ifndef PROC_THREAD_ATTRIBUTE_HANDLE_LIST
+  unix_error(ENOSYS, "create_process_pty", prog);
+#else
+  SIZE_T size;
+
+  ZeroMemory(si, sizeof(*si));
+  si->StartupInfo.cb = sizeof(STARTUPINFOEX);
+
+  /* 2 attributes, as PROC_THREAD_ATTRIBUTE_HANDLE_LIST will be added later. */
+  InitializeProcThreadAttributeList(NULL, 2, 0, &size);
+  si->lpAttributeList = malloc(size);
+  if (!si->lpAttributeList) {
+    unix_error(ENOMEM, "create_process_pty", prog);
+  }
+
+  if (!InitializeProcThreadAttributeList(si->lpAttributeList, 2, 0, &size)) {
+    win32_maperr(GetLastError());
+    free(si->lpAttributeList);
+    uerror("create_process_pty", prog);
+  }
+
+  if (!UpdateProcThreadAttribute(si->lpAttributeList, 0,
+      PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, pty, sizeof(pty), NULL, NULL)) {
+    win32_maperr(GetLastError());
+    DeleteProcThreadAttributeList(si->lpAttributeList);
+    free(si->lpAttributeList);
+    uerror("create_process_pty", prog);
+  }
+#endif
+}
+
+CAMLprim value w_create_process_pty_native
+  (value prog, value args, value pty, value fd1, value fd2, value fd3)
+{
+  CAMLparam5(prog, args, pty, fd1, fd2);
+  CAMLxparam1(fd3);
+  int res, flags;
+  BOOL err = FALSE;
+  PROCESS_INFORMATION pi;
+  STARTUPINFOEX si;
+  wchar_t fullname[MAX_PATH];
+  wchar_t *wprog, *wargs;
+  HANDLE hp;
+  HANDLE inherit[3];
+  HPCON hpc = *((HPCON *) Data_abstract_val(pty));
+
+#ifndef PROC_THREAD_ATTRIBUTE_HANDLE_LIST
+  unix_error(ENOSYS, "create_process_pty", prog);
+#else
+  wprog = Tcaml_stat_strdup_to_utf16(String_val(prog));
+
+  res = SearchPathW(NULL, wprog, L".exe", MAX_PATH, fullname, NULL);
+  caml_stat_free(wprog);
+  if (res == 0) {
+    win32_maperr(GetLastError());
+    uerror("create_process_pty", prog);
+  }
+
+  prepareSiWithPty(prog, &si, hpc);
+
+  hp = GetCurrentProcess();
+  if (!DuplicateHandle(hp, Handle_val(fd1), hp, &(si.StartupInfo.hStdInput),
+      0, TRUE, DUPLICATE_SAME_ACCESS)) {
+    win32_maperr(GetLastError());
+    err = TRUE;
+    goto clean1;
+  }
+  if (!DuplicateHandle(hp, Handle_val(fd2), hp, &(si.StartupInfo.hStdOutput),
+      0, TRUE, DUPLICATE_SAME_ACCESS)) {
+    win32_maperr(GetLastError());
+    err = TRUE;
+    goto clean2;
+  }
+  if (!DuplicateHandle(hp, Handle_val(fd3), hp, &(si.StartupInfo.hStdError),
+      0, TRUE, DUPLICATE_SAME_ACCESS)) {
+    win32_maperr(GetLastError());
+    err = TRUE;
+    goto clean3;
+  }
+  si.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+
+  inherit[0] = si.StartupInfo.hStdInput;
+  inherit[1] = si.StartupInfo.hStdOutput;
+  inherit[2] = si.StartupInfo.hStdError;
+  if (!UpdateProcThreadAttribute(si.lpAttributeList, 0,
+      PROC_THREAD_ATTRIBUTE_HANDLE_LIST, inherit, sizeof(HANDLE) * 3,
+      NULL, NULL)) {
+    win32_maperr(GetLastError());
+    err = TRUE;
+    goto clean4;
+  }
+
+  flags = GetPriorityClass(GetCurrentProcess());
+  flags |= EXTENDED_STARTUPINFO_PRESENT;
+
+  wargs = Tcaml_stat_strdup_to_utf16(String_val(args));
+  res = CreateProcessW(fullname, wargs, NULL, NULL, TRUE, flags,
+          NULL, NULL, &si.StartupInfo, &pi);
+  caml_stat_free(wargs);
+  if (res == 0) {
+    win32_maperr(GetLastError());
+    err = TRUE;
+  }
+
+clean4:
+  CloseHandle(si.StartupInfo.hStdError);
+clean3:
+  CloseHandle(si.StartupInfo.hStdOutput);
+clean2:
+  CloseHandle(si.StartupInfo.hStdInput);
+clean1:
+  DeleteProcThreadAttributeList(si.lpAttributeList);
+  free(si.lpAttributeList);
+
+  if (err) {
+    uerror("create_process_pty", prog);
+  }
+
+  CloseHandle(pi.hThread);
+  CAMLreturn(Val_long(pi.hProcess));
+#endif
+}
+
+CAMLprim value w_create_process_pty(value *argv, int argn)
+{
+  return w_create_process_pty_native(argv[0], argv[1], argv[2],
+                                     argv[3], argv[4], argv[5]);
+}
+
+#else // not _WIN32
+
+CAMLprim value w_create_process_pty_native
+  (value prog, value args, value pty, value fd1, value fd2, value fd3)
+{
+  unix_error(ENOSYS, "create_process_pty", Nothing);
+}
+
+CAMLprim value w_create_process_pty(value *argv, int argn)
+{
+  unix_error(ENOSYS, "create_process_pty", Nothing);
+}
+
+CAMLprim value win_openpty()
+{
+  unix_error(ENOSYS, "openpty", Nothing);
+}
+
+CAMLprim value win_closepty(value pty)
+{
+  unix_error(ENOSYS, "closepty", Nothing);
 }
 
 #endif

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -1323,7 +1323,7 @@ type preconnection =
      * Lwt_unix.file_descr
      * Unix.file_descr
      * string option
-     * Lwt_unix.file_descr option
+     * (Lwt_unix.file_descr * Lwt_unix.file_descr) option
      * Clroot.clroot
      * int)
 let openConnectionStart clroot =
@@ -1433,7 +1433,7 @@ let openConnectionReply = function
     (i1,i2,o1,o2,s,Some fdTerm,clroot,pid) ->
     (fun response ->
       (* FIX: should loop until everything is written... *)
-      ignore (Lwt_unix.run (Lwt_unix.write fdTerm (Bytes.of_string (response ^ "\n")) 0
+      ignore (Lwt_unix.run (Lwt_unix.write (snd fdTerm) (Bytes.of_string (response ^ "\n")) 0
                               (String.length response + 1))))
   | _ -> (fun _ -> ())
 

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -202,7 +202,7 @@ let create_session cmd args new_stdin new_stdout new_stderr =
             let tio = Unix.tcgetattr slaveFd in
             tio.Unix.c_echo <- false;
             Unix.tcsetattr slaveFd Unix.TCSANOW tio;
-            perform_redirections new_stdin new_stdout new_stderr;
+            perform_redirections new_stdin new_stdout slaveFd;
             Unix.execvp cmd args (* never returns *)
           with Unix.Unix_error _ ->
             Printf.eprintf "Some error in create_session child\n";

--- a/src/terminal.mli
+++ b/src/terminal.mli
@@ -7,6 +7,9 @@ val create_session :
   Unix.file_descr -> Unix.file_descr -> Unix.file_descr ->
   Lwt_unix.file_descr option * int
 
+val close_session :
+  Lwt_unix.file_descr option -> unit
+
 (* termInput fdTerm fdInput
    Wait until there is input on at least one file descriptor.
    If there is terminal input s, return Some s.

--- a/src/terminal.mli
+++ b/src/terminal.mli
@@ -5,20 +5,20 @@
 val create_session :
   string -> string array ->
   Unix.file_descr -> Unix.file_descr -> Unix.file_descr ->
-  Lwt_unix.file_descr option * int
+  (Lwt_unix.file_descr * Lwt_unix.file_descr) option * int
 
 val close_session :
-  Lwt_unix.file_descr option -> unit
+  (Lwt_unix.file_descr * Lwt_unix.file_descr) option -> unit
 
 (* termInput fdTerm fdInput
    Wait until there is input on at least one file descriptor.
    If there is terminal input s, return Some s.
    Otherwise, return None. *)
 val termInput :
-  Lwt_unix.file_descr -> Lwt_unix.file_descr -> string option
+  (Lwt_unix.file_descr * Lwt_unix.file_descr) -> Lwt_unix.file_descr -> string option
 
 val handlePasswordRequests :
-  Lwt_unix.file_descr -> (string -> string) -> unit
+  (Lwt_unix.file_descr * Lwt_unix.file_descr) -> (string -> string) -> unit
 
 (* For recognizing messages from OpenSSH *)
 val password : string -> bool

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -616,7 +616,7 @@ let cmdLineRawRoots = ref []
 
 (* BCP: WARNING: Some of the code from here is duplicated in uimacbridge...! *)
 let initPrefs ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
-              ~termInteract =
+              ?(prepDebug = fun () -> ()) ~termInteract () =
   (* Restore prefs to their default values, if necessary *)
   if not !firstTime then Prefs.resetToDefaults();
   Globals.setRawRoots !cmdLineRawRoots;
@@ -646,6 +646,8 @@ let initPrefs ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
     if Prefs.read runtests then raise (Util.Fatal
       "The 'test' flag should only be given on the command line")
   end;
+
+  if Prefs.read Trace.debugmods <> [] then prepDebug ();
 
   (* Parse the command line.  This will override settings from the profile. *)
   (* JV (6/09): always reparse the command line *)
@@ -731,13 +733,15 @@ let _ = Prefs.alias testServer "testServer"
 (* ---- *)
 
 let uiInit
+    ?(prepDebug = fun () -> ())
     ~(reportError : string -> unit)
     ~(tryAgainOrQuit : string -> bool)
     ~(displayWaitMessage : unit -> unit)
     ~(getProfile : unit -> string option)
     ~(getFirstRoot : unit -> string option)
     ~(getSecondRoot : unit -> string option)
-    ~(termInteract : (string -> string -> string) option) =
+    ~(termInteract : (string -> string -> string) option)
+    () =
 
   (* Make sure we have a directory for archives and profiles *)
   Os.createUnisonDir();
@@ -745,8 +749,13 @@ let uiInit
   (* Extract any command line profile or roots *)
   let clprofile = ref None in
   begin
+    let args = Prefs.scanCmdLine usageMsg in
+    begin
+      try if Util.StringMap.find "debug" args <> [] then prepDebug ()
+      with Not_found -> ()
+    end;
+
     try
-      let args = Prefs.scanCmdLine usageMsg in
       match Util.StringMap.find "rest" args with
         [] -> ()
       | [profile] -> clprofile := Some profile
@@ -806,7 +815,8 @@ let uiInit
 
   (* Load the profile and command-line arguments *)
   initPrefs
-    ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot ~termInteract;
+    ~profileName ~displayWaitMessage ~getFirstRoot ~getSecondRoot
+    ~prepDebug ~termInteract ();
 
   (* Turn on GC messages, if the '-debug gc' flag was provided *)
   if Trace.enabled "gc" then Gc.set {(Gc.get ()) with Gc.verbose = 0x3F};

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -559,8 +559,8 @@ let initRoots displayWaitMessage termInteract =
   if
     hasRemote && not (Prefs.read contactquietly || Prefs.read Trace.terse)
   then
-    Util.msg "Connected [%s]\n"
-      (Util.replacesubstring (Update.getRootsName()) ", " " -> ");
+    Trace.status (Printf.sprintf "Connected [%s]\n"
+      (Util.replacesubstring (Update.getRootsName()) ", " " -> "));
 
   debug (fun() ->
        Printf.eprintf "Roots: \n";

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -88,6 +88,7 @@ val usageMsg : string
 val shortUsageMsg : string
 
 val uiInit :
+    ?prepDebug:(unit -> unit) ->
     reportError:(string -> unit) ->
     tryAgainOrQuit:(string -> bool) ->
     displayWaitMessage:(unit -> unit) ->
@@ -95,6 +96,7 @@ val uiInit :
     getFirstRoot:(unit -> string option) ->
     getSecondRoot:(unit -> string option) ->
     termInteract:(string -> string -> string) option ->
+    unit ->
     unit
 
 val initPrefs :
@@ -102,7 +104,9 @@ val initPrefs :
   displayWaitMessage:(unit->unit) ->
   getFirstRoot:(unit->string option) ->
   getSecondRoot:(unit->string option) ->
+  ?prepDebug:(unit -> unit) ->
   termInteract:(string -> string -> string) option ->
+  unit ->
   unit
 
 (* Make sure remote connections (if any) corresponding to active roots

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1391,7 +1391,8 @@ let rec start interface =
       ~getSecondRoot:
       (fun () -> Util.msg "%s%s\n" Uicommon.shortUsageMsg profmgrUsageMsg; exit 1)
       ~termInteract:
-      None;
+      None
+      ();
 
     (* Some preference settings imply others... *)
     if Prefs.read silent then begin

--- a/src/update.ml
+++ b/src/update.ml
@@ -2145,10 +2145,13 @@ let commitUpdates () =
               (fun r -> removeArchiveOnRoot r NewArch)))
           end else begin
             unlockArchives () >>= (fun () ->
-            Util.msg "Dumping archives to ~/unison.dump on both hosts\n";
+            let warn =
+              if (Unix.isatty Unix.stderr) then Util.msg "%s"
+              else Trace.log in
+            warn "Dumping archives to ~/unison.dump on both hosts\n";
             Globals.allRootsIter (fun r -> dumpArchiveOnRoot r ())
               >>= (fun () ->
-            Util.msg "Finished dumping archives\n";
+            warn "Finished dumping archives\n";
             raise (Util.Fatal (
                  "Internal error: New archives are not identical.\n"
                ^ "Retaining original archives.  "


### PR DESCRIPTION
For background, see discussion at #496.

This PR consists of two parts:
1. Add Windows pty support (>= Windows 10 1809) so that the console window is not required to have a controlling terminal for ssh. For older Windows versions, the console window is opened on demand.
2. Don't open Windows console for the GUI application by default (no changes to the separately built text interface; it's a build time option, so the effect is per binary). Console window is still opened when user has requested debugging and stdout and stderr have not been redirected. Opening the console on demand is currently done only when debugging is requested; otherwise there should be no output to either stdout or stderr (with one exception, see below). Alternatively, the debugging output could be redirected to a file, I suppose. The user can still always redirect by themselves, of course.

There is one caveat with not opening the console window by default and only opening it for debugging. All other information that is output to either stdout or stderr will either not be visible or (more likely) will crash the program. For normal daily usage, this should never happen because there is no such output. The only other cases that I am aware of are when the user requests textual output directly on command line (for example, by specifying `-version` or `-help`) or when there is a command line parsing error. I don't consider those a blocker as the text ui version (separate binary) will work. In long term, one could consider capturing such output and displaying it in GUI instead.

Closes #496

**Testers wanted!** I don't have much possibility to test this patch myself. Volunteer Windows users are most welcome to test it. Binaries can be downloaded from GitHub (the Actions page).