### PR TITLE
Fix macOS builds (inotify doesn't exist on macOS)

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -244,6 +244,7 @@ jobs:
       matrix:
         job:
         - { os: ubuntu-latest  , ocaml-compiler: 4.12.x }
+        - { os: macos-latest  , ocaml-compiler: 4.12.x }
 
     runs-on: ${{ matrix.job.os }}
 

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.3)
+(lang dune 2.3)
 (name unison)

--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,9 @@
         -w -3-6-9-10-26-27-32-34-35-38-39-50-52
         -warn-error -3-6-9-10-26-27-32-34-35-39-50-52
         -no-strict-sequence)
- (c_names bytearray_stubs osxsupport pty hash_compat)
+ (foreign_stubs
+  (language c)
+  (names bytearray_stubs osxsupport pty hash_compat))
  (c_library_flags -lutil)
  (libraries str unix lwt_lib bigarray))
 

--- a/src/fsmonitor/linux/dune
+++ b/src/fsmonitor/linux/dune
@@ -3,14 +3,18 @@
 (library
  (name fswatcher)
  (wrapped false)
+ (enabled_if (= %{system} "linux"))
  (modules :standard \ watcher)
  (flags :standard -w -3-27-39)
- (c_names inotify_stubs)
+ (foreign_stubs
+  (language c)
+  (names inotify_stubs))
  (libraries unix lwt_lib))
 
 (executable
  (name watcher)
  (public_name unison-fsmonitor)
+ (enabled_if (= %{system} "linux"))
  (modules watcher)
  (flags :standard -w -27)
  (libraries fswatcher))

--- a/unison.opam
+++ b/unison.opam
@@ -12,7 +12,7 @@ dev-repo: "git://github.com/bcpierce00/unison.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03"}
-  "dune" {>= "1.3"}
+  "dune" {>= "2.3"}
   "lablgtk" {>= "2.18.6"}
 ]
 synopsis: "File-synchronization tool for Unix and Windows"


### PR DESCRIPTION
Fixes #581 
I have no idea what's the macOS equivalent of `inotify`, or even how deeply unison needs `unison-fswatcher` but at least this makes the rest compile on macOS