### PR TITLE
CI: Drop ocaml < 4.08 except for Ubuntu

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -20,13 +20,6 @@ jobs:
         - { os: macos-10.15   , ocaml-version: 4.10.2 }
         - { os: macos-10.15   , ocaml-version: 4.09.1 }
         - { os: macos-10.15   , ocaml-version: 4.08.1 }
-        - { os: macos-10.15   , ocaml-version: 4.07.1 }
-        - { os: macos-10.15   , ocaml-version: 4.06.1 }
-        - { os: macos-10.15   , ocaml-version: 4.05.0 }
-        - { os: macos-10.15   , ocaml-version: 4.04.2 }
-        - { os: macos-10.15   , ocaml-version: 4.03.0 }
-        - { os: macos-10.15   , ocaml-version: 4.02.3 }
-        - { os: macos-10.15   , ocaml-version: 4.01.0 }
         - { os: ubuntu-18.04  , ocaml-version: 4.12.0 }
         - { os: ubuntu-18.04  , ocaml-version: 4.11.2 }
         - { os: ubuntu-18.04  , ocaml-version: 4.10.2 }
@@ -46,15 +39,6 @@ jobs:
         - { os: windows-latest , ocaml-version: 4.10.2+mingw32c }
         - { os: windows-latest , ocaml-version: 4.09.1+mingw64c }
         - { os: windows-latest , ocaml-version: 4.08.1+mingw64c }
-        - { os: windows-latest , ocaml-version: 4.07.1+mingw64c }
-        - { os: windows-latest , ocaml-version: 4.06.1+mingw64c }
-        - { os: windows-latest , ocaml-version: 4.06.1+mingw32c }
-        - { os: windows-latest , ocaml-version: 4.05.0+mingw64c }
-        - { os: windows-latest , ocaml-version: 4.04.2+mingw32c }
-        - { os: windows-latest , ocaml-version: 4.03.0+mingw32c }
-        - { os: windows-latest , ocaml-version: 4.02.3+mingw64c }
-        - { os: windows-latest , ocaml-version: 4.02.3+mingw32c }
-        - { os: windows-latest , ocaml-version: 4.01.0+mingw32c }
 
     runs-on: ${{ matrix.job.os }}
 


### PR DESCRIPTION
There are too many builds in our CI.  Hving old ocaml on ubuntu is
sufficient to test building with old ocaml in almost all cases, and
there's almost no additional CI value in doing those builds on other
systems.

It's an arbitrary guess to set 4.08 as the cutoff.  My view is that
anyone with a system with ocaml older than that is woefully out of
date, as 4.08 was released 2.5 years ago.