### PR TITLE
Allow symlink following on Windows

### DIFF
--- a/src/path.ml
+++ b/src/path.ml
@@ -220,8 +220,11 @@ let followPred = Pred.create ~advanced:true "follow"
       The syntax of \\ARG{pathspec} is \
       described in \\sectionref{pathspec}{Path Specification}.")
 
+let winHasReadlink =
+  Scanf.sscanf Sys.ocaml_version "%d.%d.%d" (fun x y z -> x > 4 || x = 4 && y >= 3)
+
 let followLink path =
-     (Util.osType = `Unix || Util.isCygwin)
+     (Util.osType = `Unix || Util.isCygwin || winHasReadlink)
   && Pred.test followPred (toString path)
 
 let forceLocal p = p


### PR DESCRIPTION
`Unix.readlink` is working on Windows since OCaml 4.03. This makes it possible to enable the `follow` predicate on Windows.

This is a fix for a bug reported on the list (`follow` preference ignored on Windows).