### PR TITLE
Build fixes for MSVC

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -8,18 +8,15 @@
 ifeq (${OSCOMP},cygwingnuc) # Define this if compiling with Cygwin GNU C
   OSARCH=win32gnuc
   ETAGS=/bin/etags
-  buildexecutable:: win32rc/unison.res.lib
 else
 # Win32 system
 ifeq (${OSTYPE},cygwin32) # Cygwin Beta 19
   OSARCH=win32
   ETAGS=/bin/etags
-  buildexecutable:: win32rc/unison.res.lib
 else
 ifeq (${OSTYPE},cygwin)	  # Cygwin Beta 20
   OSARCH=win32
   ETAGS=/bin/etags
-  buildexecutable:: win32rc/unison.res.lib
 else
 
 # Unix system
@@ -110,14 +107,26 @@ CAMLFLAGS+=-I system/$(SYSTEM) -I lwt/$(SYSTEM)
 ifeq ($(OSARCH),win32)
   # Win32 system
   EXEC_EXT=.exe
-  OBJ_EXT=.o
-  OUTPUT_SEL=-o
+  ifeq ($(shell ocamlc -config 2> /dev/null | grep ext_obj),ext_obj: .obj)
+    OBJ_EXT=.obj
+  else
+    OBJ_EXT=.o
+  endif
+  ifeq ($(shell ocamlc -config 2> /dev/null | grep ccomp_type),ccomp_type: msvc)
+    OUTPUT_SEL=-Fo
+    CLIBS+=-cclib shell32.lib -cclib user32.lib -cclib "-link win32rc/unison.res"
+    STATICLIBS+=-cclib "-link win32rc/unison.res"
+    buildexecutable:: win32rc/unison.res
+  else
+    OUTPUT_SEL=-o
+    CLIBS+=-cclib "-link win32rc/unison.res.lib"
+    STATICLIBS+=-cclib "-link win32rc/unison.res.lib"
+    buildexecutable:: win32rc/unison.res.lib
+  endif
   CWD=.
   COBJS+=system/system_win_stubs$(OBJ_EXT) lwt/lwt_unix_stubs$(OBJ_EXT)
   WINOBJS=system/system_win.cmo
   SYSTEM=win
-  CLIBS+=-cclib "-link win32rc/unison.res.lib"
-  STATICLIBS+=-cclib "-link win32rc/unison.res.lib"
   buildexecutable::
 	@echo Building for Windows
 else
@@ -132,7 +141,7 @@ else
     SYSTEM=win
     CLIBS+=-cclib win32rc/unison.res.lib
     STATIC=false                      # Cygwin is not MinGW :-(
-    buildexecutable::
+    buildexecutable:: win32rc/unison.res.lib
 	@echo Building for Windows with Cygwin GNU C
   else
     CWD=$(shell pwd)
@@ -418,9 +427,10 @@ WINDRES := $(or ${EXEC_PREFIX},$(filter i686-w64-mingw32- x86_64-w64-mingw32-,$(
 ##$(info windres='${WINDRES}')
 
 win32rc/unison.res: win32rc/unison.rc win32rc/U.ico
-	$(WINDRES) win32rc/unison.rc win32rc/unison.res
+	rc win32rc/unison.rc
 
-win32rc/unison.res.lib: win32rc/unison.res
+win32rc/unison.res.lib: win32rc/unison.rc win32rc/U.ico
+	$(WINDRES) win32rc/unison.rc win32rc/unison.res
 	$(WINDRES) win32rc/unison.res win32rc/unison.res.lib
 
 %.ml: %.mll

--- a/src/fsmonitor/windows/Makefile
+++ b/src/fsmonitor/windows/Makefile
@@ -10,7 +10,7 @@ FSMOCAMLOBJS = \
    lwt/win/lwt_win.cmo \
    fsmonitor/watchercommon.cmo $(DIR)/watcher.cmo
 FSMCOBJS = \
-   system/system_win_stubs.o lwt/lwt_unix_stubs.o
+   system/system_win_stubs$(OBJ_EXT) lwt/lwt_unix_stubs$(OBJ_EXT)
 FSMOCAMLLIBS=bigarray.cma unix.cma
 
 ifeq ($(NATIVE), true)
@@ -28,5 +28,5 @@ $(FSMONITOR)$(EXEC_EXT): $(COMPATOCAMLOBJS) $(FSMCAMLOBJS) $(FSMCOBJS)
 	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
 
 clean::
-	rm -f $(DIR)/*.cm[iox] $(DIR)/*.o $(DIR)/*~
+	rm -f $(DIR)/*.cm[iox] $(DIR)/*.{o,obj} $(DIR)/*~
 	rm -f $(FSMONITOR)$(EXEC_EXT)


### PR DESCRIPTION
These are some primitive and not elegant fixes to get basic builds with MSVC working again.
Background: https://discuss.ocaml.org/t/build-unison-with-ocaml-opam-images-for-docker-for-windows/9088

I have no means of testing these changes myself as it is difficult to get compilation with MSVC working with GitHub Actions and current `setup-ocaml`. Testing was done with help of a user from unison-users.