### PR TITLE
GHA: Work around lablgtk build issues on Windows

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -136,8 +136,15 @@ jobs:
 
     - name: lablgtk install
       ## [2020-09] non-working/unavailable for MSVC or musl OCaml variants ; also, non-working for 32bit OCaml variant (see [GH:garrigue/lablgtk#64](https://github.com/garrigue/lablgtk/issues/64))
-      if: ${{ ! ( contains(matrix.job.ocaml-version, '+msvc') || contains(matrix.job.ocaml-version, '+musl') || contains(matrix.job.ocaml-version, '+32bit') ) }}
+      ## [2022-01] lablgtk 2.18.12 builds seem to hang on Windows with OCaml < 4.10.0
+      if: ${{ ! ( contains(matrix.job.ocaml-version, '+msvc') || contains(matrix.job.ocaml-version, '+musl') || contains(matrix.job.ocaml-version, '+32bit') || (contains(matrix.job.ocaml-version, '+mingw') && matrix.job.ocaml-version < '4.10.0') ) }}
       run: opam depext --install --verbose --yes lablgtk
+
+    - name: lablgtk install compatibility hack
+      ## [2022-01] lablgtk 2.18.12 builds seem to hang on Windows with OCaml < 4.10.0; this is a hack to work around the issue
+      if: ${{ contains(matrix.job.ocaml-version, '+mingw') && matrix.job.ocaml-version < '4.10.0' }}
+      shell: cmd
+      run: opam depext --install --verbose --yes lablgtk^^^<2.18.12
 
     - shell: bash
       run: |


### PR DESCRIPTION
lablgtk 2.18.12 builds on Windows hang in GHA CI if built with OCaml versions < 4.10.0 (_the actual issue is unknown, the GHA runners just time out after a few hours_).
lablgtk 2.18.12 was released for compatibility with upcoming OCaml 5, so the workaround is to just use previous lablgtk versions on Windows with OCaml < 4.10.

This workaround runs only on Windows for OCaml versions < 4.10. All other CI builds are unaffected.