### PR TITLE
Further fixes to uimac ssh interaction

### DIFF
--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -256,6 +256,10 @@ let unix_create_session cmd args new_stdin new_stdout new_stderr =
             let tio = Unix.tcgetattr slaveFd in
             tio.Unix.c_echo <- false;
             Unix.tcsetattr slaveFd Unix.TCSANOW tio;
+            (* Redirect ssh authentication errors to controlling terminal,
+               instead of new_stderr, so that they can be captured by GUI.
+               This will also redirect the remote stderr to GUI. *)
+            safe_close new_stderr;
             perform_redirections new_stdin new_stdout slaveFd;
             Unix.execvp cmd args (* never returns *)
           with Unix.Unix_error _ ->

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -262,8 +262,9 @@ let unix_create_session cmd args new_stdin new_stdout new_stderr =
             safe_close new_stderr;
             perform_redirections new_stdin new_stdout slaveFd;
             Unix.execvp cmd args (* never returns *)
-          with Unix.Unix_error _ ->
-            Printf.eprintf "Some error in create_session child\n";
+          with Unix.Unix_error (e, s1, s2) ->
+            Printf.eprintf "Error in create_session child: [%s] (%s) %s\n"
+              s1 s2 (Unix.error_message e);
             flush stderr;
             exit 127
           end

--- a/src/uimac/main.m
+++ b/src/uimac/main.m
@@ -35,7 +35,7 @@ int main(int argc, const char *argv[])
         !strcmp(argv[i],"-server") ||
         !strcmp(argv[i],"-socket") ||
         !strcmp(argv[i],"-ui")) {
-                        NSLog(@"Calling nonGuiStartup");
+                        //NSLog(@"Calling nonGuiStartup");
                         @try {
                                 ocamlCall("x", "unisonNonGuiStartup");
                         } @catch (NSException *ex) {


### PR DESCRIPTION
Further fixes to the issue first reported as #328.

The first two commits are not specific to uimac.

Commit 763c5d85298e7e9a03a920439cfa513647adb3dc redirected ssh's stderr to the pty in order to scrape any error output and present it to the GUI users (note, this only affects the GUI). This works well in general. However, uimac had a bug in its processing of ssh output (unrelated to stderr redirection). First fix for uimac was produced in PR #465 but it was not sufficient nor fully correct. This patch tries to make ssh interaction in uimac more resilient; this applies with or without stderr redirection.

~~**Testing needed.**~~