### PR TITLE
Revert "Add a feature for OCaml 4.x hash function"

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -1539,13 +1539,11 @@ uutil.cmo : \
     ubase/util.cmi \
     ubase/trace.cmi \
     ubase/projectInfo.cmo \
-    features.cmi \
     uutil.cmi
 uutil.cmx : \
     ubase/util.cmx \
     ubase/trace.cmx \
     ubase/projectInfo.cmx \
-    features.cmx \
     uutil.cmi
 uutil.cmi :
 xferhint.cmo : \

--- a/src/uutil.ml
+++ b/src/uutil.ml
@@ -32,17 +32,11 @@ let myNameAndVersion = myName ^ " " ^ myVersion
 (*                             HASHING                                       *)
 (*****************************************************************************)
 
-let featHashOCaml4Murmur3 = Features.register "hash-ocaml4-murmur3" None
-
 let hash2 x y = (17 * x + 257 * y) land 0x3FFFFFFF
 
 external hash_param : int -> int -> 'a -> int = "unsn_hash_univ_param" "noalloc"
 
-let hash x =
-  if Features.enabled featHashOCaml4Murmur3 then
-    Hashtbl.hash x
-  else (* The algorithm used before any features were defined *)
-    hash_param 10 100 x (* FIX: This algorithm should be removed eventually *)
+let hash x = hash_param 10 100 x
 
 (*****************************************************************************)
 (*                             File sizes                                    *)


### PR DESCRIPTION
This reverts commit 56f253685a84d62f6a6bdc4bb7377f4a43c18b79.

This commit, while fully working and safe, was provided more as an example of the "features" mechanism and was never intended as a long-term solution.

There is no better replacement yet but the old compatibility mode works well and is future-proof, so there is no real urgency in replacing it.

Please note that this hash function is not the one used for fingerprinting files! This hash function here is used only to compare archives on both hosts.