### PR TITLE
Restore compatibility with 2.48

### DIFF
--- a/src/globals.ml
+++ b/src/globals.ml
@@ -261,7 +261,7 @@ let ignorenotPred =
      synchronized will not work.  Instead, you should use the {\\tt path}
      preference to choose particular paths to synchronize.")
 
-let atomic = Pred.create "atomic" ~advanced:true
+let atomic = Pred.create "atomic" ~local:true ~advanced:true
   ("This preference specifies paths for directories whose "
    ^ "contents will be considered as a group rather than individually when "
    ^ "they are both modified.  "

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -1134,6 +1134,9 @@ let connectionHeader = "Unison RPC\n"
 let compatConnectionHeader = "Unison 2.51 with OCaml >= 4.01.2\n"
 (* Every supported version released prior to the RPC version negotiation
    mechanism uses this connection header string. *)
+let compat248ConnectionHeader = "Unison 2.48\n"
+(* Additionally, even 2.48 can be supported, even though that support is
+   not official. *)
 
 let rpcVersionsTag = "VERSIONS "
 let rpcVersionsStr = rpcVersionsTag ^ rpcSupportedVersionStrHdr ^ "\n"
@@ -1209,6 +1212,10 @@ let checkServerVersion conn header =
     setConnectionVersion conn 0;
     debug (fun () -> Util.msg "Selected RPC version: 2.51-compatibility\n");
     (* skip negotiation *) Lwt.return ()
+  end else if header = compat248ConnectionHeader then begin
+    setConnectionVersion conn 0;
+    debug (fun () -> Util.msg "Selected RPC version: 2.48-compatibility\n");
+    (* skip negotiation *) Lwt.return ()
   end else
     selectServerVersion conn
 
@@ -1217,7 +1224,14 @@ let rec checkHeaderRec conn buffer pos len connectionHeader =
     Lwt.return connectionHeader
   else begin
     (grab conn.inputBuffer buffer 1 >>= (fun () ->
-    if buffer.{0} <> connectionHeader.[pos] && buffer.{0} <> compatConnectionHeader.[pos] then
+    let chOk =
+      try buffer.{0} = connectionHeader.[pos] with Invalid_argument _ -> false
+    and compatChOk =
+      try buffer.{0} = compatConnectionHeader.[pos] with Invalid_argument _ -> false
+    and compat248ChOk =
+      try buffer.{0} = compat248ConnectionHeader.[pos] with Invalid_argument _ -> false
+    in
+    if not chOk && not compatChOk && not compat248ChOk then
       let prefix =
         String.sub connectionHeader 0 pos ^ Bytearray.to_string buffer in
       let rest = peekWithoutBlocking conn.inputBuffer in
@@ -1235,12 +1249,15 @@ let rec checkHeaderRec conn buffer pos len connectionHeader =
            ^ "message, or because your remote login shell is printing\n"
            ^ "something itself before starting Unison."))
     else
-    if buffer.{0} <> connectionHeader.[pos] && buffer.{0} = compatConnectionHeader.[pos] then
+    if not chOk && compatChOk then
       (* We make use of the fact that that the new header is almost a prefix
          of the old header. It is not an exact comparison here but good
          enough for this purpose. *)
       checkHeaderRec conn buffer (pos + 1)
         (String.length compatConnectionHeader) compatConnectionHeader
+    else if not chOk && compat248ChOk then
+      checkHeaderRec conn buffer (pos + 1)
+        (String.length compat248ConnectionHeader) compat248ConnectionHeader
     else
       checkHeaderRec conn buffer (pos + 1) len connectionHeader))
   end
@@ -1309,7 +1326,7 @@ let checkForMagicString conn =
   end
 
 let checkServerUpgrade conn header =
-  if header <> compatConnectionHeader then
+  if header <> compatConnectionHeader && header <> compat248ConnectionHeader then
     Lwt.return header
   else
     checkForMagicString conn >>= function
@@ -1981,7 +1998,12 @@ let forwardMsgToClient =
           Lwt.return (Trace.displayMessageLocally str)))
 
 (* Compatibility mode for 2.51 clients. *)
-let compatServerInit conn =
+let compatServerInit mode conn =
+  let compatConnectionHeader =
+    match mode with
+    | Some "2.48" -> compat248ConnectionHeader
+    | _ -> compatConnectionHeader
+  in
   dump conn [(Bytearray.of_string compatConnectionHeader, 0,
                 String.length compatConnectionHeader)] >>= fun () ->
   (* Send the magic string to notify new clients *)
@@ -2013,9 +2035,9 @@ let commandLoop ~compatMode in_ch out_ch =
   let conn = setupIO true in_ch out_ch in
   Lwt.catch
     (fun () ->
-       (if compatMode then
+       (if compatMode <> None then
          let () = setConnectionVersion conn 0 in
-         compatServerInit conn >>= (fun upgrade ->
+         compatServerInit compatMode conn >>= (fun upgrade ->
          if upgrade then begin
            (* Restore the state before starting protocol negotiation *)
            allowWrites conn.outputQueue;
@@ -2077,6 +2099,11 @@ let killServer =
 (* For backward compatibility *)
 let _ = Prefs.alias killServer "killServer"
 
+(* FIX: This code should be removed when removing 2.51-compatibility code. *)
+let is248Exe =
+  let exeName = Filename.basename (Sys.executable_name) in
+  String.length exeName >= 11 && String.sub exeName 0 11 = "unison-2.48"
+
 (* Used by the socket mechanism: Create a socket on portNum and wait
    for a request. Each request is processed by commandLoop. When a
    session finishes, the server waits for another request. *)
@@ -2102,7 +2129,8 @@ let waitOnPort hosts port =
          Lwt_unix.setsockopt connected Unix.SO_KEEPALIVE true;
          begin try
            (* Accept a connection *)
-           Lwt_unix.run (commandLoop ~compatMode:true connected connected)
+           let compatMode = Some (if is248Exe then "2.48" else "2.51") in
+           Lwt_unix.run (commandLoop ~compatMode connected connected)
          with Util.Fatal "Lost connection with the server" -> () end;
          (* The client has closed its end of the connection *)
          begin try Lwt_unix.close connected with Unix.Unix_error _ -> () end;
@@ -2143,6 +2171,15 @@ let beAServer () =
             |> Safelist.mem rpcServerCmdlineOverride)
      with Not_found -> true
   in
+  (* Additionally, do a best effort emulation of 2.48.
+     FIX: remove together with code above. *)
+  let compatMode =
+    match compatMode with
+    | true when is248Exe -> Some "2.48"
+    | true -> Some "2.51"
+    | false -> None
+  in
+  begin end;
   Lwt_unix.run
     (commandLoop ~compatMode
        (Lwt_unix.of_unix_file_descr Unix.stdin)


### PR DESCRIPTION
### Description

Many users are still using Unison 2.48 and are unable to upgrade. This patch provides a best effort compatibility with 2.48. Even though there is no indication that interop with 2.48 clients and servers would not work, **there are no guarantees of success**. If it doesn't work, however, it is very unlikely to result in data loss or corruption.

With this patch, a single Unison version will be able to interoperate with 2.48, 2.51 and the future releases. It is also able to upgrade from 2.48 without needing to rescan the replicas.

Support for 2.48 is provided according the the table below. **OCaml versions must still match.**
<table>
<tbody>
<tr><th colspan="2" rowspan="2"></th><th colspan="2">Server</th></tr>
<tr><th>2.48</th><th>With this PR</th></tr>
<tr><th rowspan="2">Client</th><th>2.48</th><td>OK, native</td><td>Special setup is needed, see below</td></tr>
<tr><th>With this PR</th><td>OK, automatically</td><td>OK, automatically</td></tr>
</tbody>
</table>

### Server for 2.48 clients

Server support for 2.48 clients is not fully automatic. For the server to support 2.48 clients, the executable must be named with `unison-2.48` prefix. Only the prefix matters. The full executable name could be `unison-2.48.exe` or `unison-2.48-but-actually-2.52` or whatever you like. By using the name `unison-2.48` there is the benefit of being able to use the `-addversionno` preference on the client (relevant only for SSH connections). With other names, use the `-servercmd` preference on client (relevant only for SSH connections).

A socket server started this way is able to serve 2.48 clients and any clients with this PR or with #626 but not 2.51 clients.

### Notes on OCaml compiler version

It is possible to see the OCaml version used to compile Unison by executing `unison -version`. 2.48 did not display the OCaml version this way and it can be a bit difficult to find out the version. The easiest way is to see what is the `ocaml` package version in the same package repository where you got `unison` package from (hint, for Linux distributions, the typical version is 4.05). If that's not possible then the other way is trying your way through various versions (take this patch compiled with 4.05 and try, then compiled with another version and try and so on).

### Testing

Volunteer testing is expected of users who would like to use this patch.