### PR TITLE
Code cleanup: Update C code to latest FFI standards

### DIFF
--- a/src/fsmonitor/solaris/fen_stubs.c
+++ b/src/fsmonitor/solaris/fen_stubs.c
@@ -33,7 +33,7 @@
 #define EV_FLAGS_NOFOLLOW EV_FLAGS_FOLLOW | FILE_NOFOLLOW
 
 
-CAMLprim value unsn_port_create()
+CAMLprim value unsn_port_create(value unit)
 {
   CAMLparam0();
 

--- a/src/hash_compat.c
+++ b/src/hash_compat.c
@@ -1,7 +1,10 @@
 /* The pre-OCaml 4.00 hash implementation */
 /* FIXME: This is included for backwards compatibility only and must be
- * REMVOED at next Unison version increase. The removal of this will
- * break Unison version compatibility. */
+ * REMOVED when a new hash function included in a stable release has been
+ * available for a few years. The removal of this function will break
+ * Unison version compatibility. There must be plenty of time given
+ * for users to upgrade (most users don't compile themselves and are at
+ * mercy of whatever package repositories they use). */
 
 /* Code copied from OCaml sources */
 /**************************************************************************/
@@ -19,7 +22,6 @@
 /*                                                                        */
 /**************************************************************************/
 
-#define CAML_NAME_SPACE
 #include <caml/mlvalues.h>
 #include <caml/custom.h>
 #ifndef Bytes_val /* Hack to know that we are on OCaml < 4.06.

--- a/src/osxsupport.c
+++ b/src/osxsupport.c
@@ -19,17 +19,18 @@ extern void unix_error (int errcode, char * cmdname, value arg) Noreturn;
 extern void uerror (char * cmdname, value arg) Noreturn;
 
 CAMLprim value isMacOSX (value nothing) {
+  CAMLparam0();
 #ifdef __APPLE__
-  return Val_true;
+  CAMLreturn(Val_true);
 #else
-  return Val_false;
+  CAMLreturn(Val_false);
 #endif
 }
 
 CAMLprim value getFileInfos (value path, value need_size) {
 #ifdef __APPLE__
 
-  CAMLparam1(path);
+  CAMLparam2(path, need_size);
   CAMLlocal3(res, fInfo, length);
   int retcode;
   struct attrlist attrList;
@@ -67,11 +68,11 @@ CAMLprim value getFileInfos (value path, value need_size) {
   fInfo = caml_alloc_string (32);
   memcpy ((char *) String_val (fInfo), attrBuf.finderInfo, 32);
   if (Bool_val (need_size))
-    length = copy_int64 (attrBuf.rsrcLength);
+    length = caml_copy_int64(attrBuf.rsrcLength);
   else
-    length = copy_int64 (0);
+    length = caml_copy_int64(0);
 
-  res = alloc_small (2, 0);
+  res = caml_alloc_small(2, 0);
   Field (res, 0) = fInfo;
   Field (res, 1) = length;
 

--- a/src/pty.c
+++ b/src/pty.c
@@ -11,7 +11,6 @@
 
 #endif /* _WIN32 */
 
-#define CAML_NAME_SPACE
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>    // alloc_tuple
 #include <caml/memory.h>   // Store_field
@@ -50,10 +49,10 @@ CAMLprim value setControllingTerminal(value fdVal) {
 }
 
 /* c_openpty: unit -> (int * Unix.file_descr) */
-CAMLprim value c_openpty() {
+CAMLprim value c_openpty(value unit) {
   CAMLparam0();
-  int master,slave;
   CAMLlocal1(pair);
+  int master, slave;
   if (openpty(&master,&slave,NULL,NULL,NULL) < 0)
     uerror("openpty", (value) 0);
   pair = caml_alloc_tuple(2);
@@ -68,7 +67,7 @@ CAMLprim value setControllingTerminal(value fdVal) {
   unix_error (ENOSYS, "setControllingTerminal", Nothing);
 }
 
-CAMLprim value c_openpty() {
+CAMLprim value c_openpty(value unit) {
   unix_error (ENOSYS, "openpty", Nothing);
 }
 
@@ -145,7 +144,7 @@ typedef void (WINAPI *sClosePseudoConsole) (HPCON hPC);
 sCreatePseudoConsole pCreatePseudoConsole;
 sClosePseudoConsole pClosePseudoConsole;
 
-CAMLprim value win_openpty()
+CAMLprim value win_openpty(value unit)
 {
   CAMLparam0();
   CAMLlocal4(tup, tmp1, tmp2, tmp3);

--- a/src/system/system_win_stubs.c
+++ b/src/system/system_win_stubs.c
@@ -369,6 +369,44 @@ typedef enum _FILE_INFORMATION_CLASS {
   FileMaximumInformation
 } FILE_INFORMATION_CLASS, *PFILE_INFORMATION_CLASS;
 
+#ifndef init_exceptions /* Removed since OCaml 4.02 */
+#include <caml/version.h> /* Available since OCaml 4.02 */
+#endif
+
+#if !defined(OCAML_VERSION) || OCAML_VERSION < 40300
+
+typedef struct _REPARSE_DATA_BUFFER {
+  ULONG  ReparseTag;
+  USHORT ReparseDataLength;
+  USHORT Reserved;
+  union {
+    struct {
+      USHORT SubstituteNameOffset;
+      USHORT SubstituteNameLength;
+      USHORT PrintNameOffset;
+      USHORT PrintNameLength;
+      ULONG Flags;
+      WCHAR PathBuffer[1];
+    } SymbolicLinkReparseBuffer;
+    struct {
+      USHORT SubstituteNameOffset;
+      USHORT SubstituteNameLength;
+      USHORT PrintNameOffset;
+      USHORT PrintNameLength;
+      WCHAR PathBuffer[1];
+    } MountPointReparseBuffer;
+    struct {
+      UCHAR  DataBuffer[1];
+    } GenericReparseBuffer;
+    struct {
+      ULONG StringCount;
+      WCHAR StringList[1];
+    } AppExecLinkReparseBuffer;
+  };
+} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
+
+#endif /* !OCAML_VERSION */
+
 typedef NTSTATUS (NTAPI *sNtQueryInformationFile)
                  (HANDLE FileHandle,
                   PIO_STATUS_BLOCK IoStatusBlock,


### PR DESCRIPTION
Make sure C code adheres to latest [OCaml FFI standards](https://ocaml.org/manual/intfc.html). This is required mainly to be future-proof, but in some cases this may also be relevant to ensure memory-safety with upcoming multicore OCaml (>= 5.00).

In particular, the patch includes the following updates:

 - Use correct names (as if `CAML_NAME_SPACE` was defined); the old symbols will no longer be available starting with OCaml 5.00
 - Always use `CAMLparam`, `CAMLlocal` and `CAMLreturn`, even if values are known to be unboxed and even if there are no allocations. This makes for a consistent approach and does not rely on certain values having to be unboxed. The consistent approach is extra important starting with OCaml 5.00 when previous single-threaded assumptions may no longer hold.
 - Add an explicit `unit` parameter for functions that have no other parameters.
 - Remove duplication of functions where the only difference is that of accessing a value as either string or bytes.
 - Remove prototype (re-)definitions that are already available via OCaml headers.

The patch does not replace the usage of `Field()` with `Store_field()`. While the former may in some cases not be safe for multi-threaded use, the issues may have been resolved by the time OCaml 5.00 is released. Further, as used in this code, `Field()` is not considered a risk.

This patch has no intentional functional changes.