### PR TITLE
Capture stderr of the ssh process in GUI, take two

### DIFF
--- a/src/remote.ml
+++ b/src/remote.ml
@@ -1360,7 +1360,7 @@ let negociateFlowControl conn =
 
 (****)
 
-let initConnection onClose in_ch out_ch =
+let initConnection ?(connReady=fun () -> ()) onClose in_ch out_ch =
   let conn = setupIO false in_ch out_ch in
   let with_timeout t =
     Lwt.choose [t;
@@ -1368,6 +1368,8 @@ let initConnection onClose in_ch out_ch =
       Lwt.fail (Util.Fatal "Timed out negotiating connection with the server")]
   in
   with_timeout (
+    peekWithBlocking conn.inputBuffer >>= fun _ ->
+    connReady (); Lwt.return () >>= fun () -> (* Connection working, notify *)
     checkHeader conn >>=
     checkServerUpgrade conn >>=
     checkServerVersion conn) >>= fun () ->
@@ -1568,16 +1570,60 @@ let buildShellConnection onClose shell host userOpt portOpt rootName termInterac
         fst (Terminal.create_session shellCmd argsarray i1 o2 Unix.stderr))
   in
   Unix.close i1; Unix.close o2;
-  begin match term, termInteract with
-  | Some fdTerm, Some callBack ->
-      Terminal.handlePasswordRequests fdTerm (callBack rootName)
-  | _ ->
-      ()
-  end;
+  let forwardShellStderr fdIn fdOut = function
+    | None -> Lwt.return ()
+    | Some s ->
+        (* When the shell connection has been established then keep
+           forwarding server's stderr to client's stderr; not to GUI. *)
+        let buf = Bytes.create 16000 in
+        let rec loop s len =
+          (* Can't use printf because if stderr is not open in Windows,
+             it will throw an exception when at_exit tries to flush it. *)
+          ignore (try if len > 0 then Unix.write fdOut s 0 len else 0
+                  with Unix.Unix_error _ -> 0);
+          Lwt.catch (fun () -> Lwt_unix.read fdIn buf 0 16000)
+            (fun _ -> debug (fun () ->
+               Util.msg "Caught an exception when reading remote stderr\n");
+               Lwt.return 0)
+          >>= function
+          | 0 -> Lwt.return ()
+          | len -> loop buf len
+        in
+        loop (Bytes.of_string s) (String.length s)
+  in
+  let est = ref false in
+  let connReady () = est := true
+  and isReady () = !est = true in
+  let getTermErr =
+    match term, termInteract with
+    | Some fdTerm, Some callBack ->
+        let (readTerm, getErr) =
+          Terminal.handlePasswordRequests fdTerm (callBack rootName) isReady in
+        Lwt.ignore_result (
+          readTerm >>=
+          forwardShellStderr (fst fdTerm) Unix.stderr);
+        getErr
+    | _ ->
+        fun () -> Lwt.return ""
+  in
   let cleanup () =
     try Terminal.close_session term with Unix.Unix_error _ -> ()
   in
-  initConnection (onClose cleanup) i2 o1
+  (* With [connReady], we know that shell connection was established (even if
+     RPC handshake failed). This hacky way of detecting the connection is used
+     because [Lwt_unix.wait_read] is not implemented under Windows.
+     By this time, we are already somewhat late in the communication process.
+     Any error output from very early stages of server startup, before other
+     output is produced, might still end up in GUI (but this is very unlikely;
+     it is more likely that the same error caused connection to be dropped). *)
+  Lwt.catch
+    (fun () -> initConnection ~connReady (onClose cleanup) i2 o1)
+    (fun e ->
+      Lwt.catch
+        (fun () -> getTermErr () >>= fun s ->
+                   if s <> "" then Util.warn s;
+                   Lwt.fail e)
+        (fun _ ->  Lwt.fail e))
 
 let canonizeLocally s unicode =
   (* We need to select the proper API in order to compute correctly the

--- a/src/terminal.mli
+++ b/src/terminal.mli
@@ -18,7 +18,8 @@ val termInput :
   (Lwt_unix.file_descr * Lwt_unix.file_descr) -> Lwt_unix.file_descr -> string option
 
 val handlePasswordRequests :
-  (Lwt_unix.file_descr * Lwt_unix.file_descr) -> (string -> string) -> unit
+  (Lwt_unix.file_descr * Lwt_unix.file_descr) -> (string -> string) ->
+  (unit -> bool) -> string option Lwt.t * (unit -> string Lwt.t)
 
 (* For recognizing messages from OpenSSH *)
 val password : string -> bool

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -136,7 +136,7 @@ let encodeException m kind e =
     Unix.Unix_error(err,fnname,param) ->
       let s =   "Error in " ^ m ^ ":\n"
               ^ (Unix.error_message err)
-              ^ " [" ^ fnname ^ "(" ^ param ^ ")]%s" ^
+              ^ " [" ^ fnname ^ "(" ^ param ^ ")]" ^
               (match err with
                  Unix.EUNKNOWNERR n -> Format.sprintf " (code %d)" n
                | _                  -> "")


### PR DESCRIPTION
This is a new attempt at improving the capture and displaying of the stderr output from the ssh process. The previous attempt and a hack were a little too naive and primitive to do any good.

This whole thing is a bit messy but I still maintain that it is better for the user this way, rather than dumping all errors into the local stderr which the GUI users normally wouldn't see. The patch is also slightly more complicated and cumbersome due to limitations on Windows.

More details are in the commit message; in a nutshell this patch is about:

 - Detecting when the ssh connection has been established and processing stderr differently. Before the connection is established, all errors are assumed to be from the ssh process and must be displayed to the user in GUI. After the connection has been established, all output from stderr is assumed to be from the remote unison process and this output is dumped on the local stderr. This also fixes a bug where the GUI could hang.
 - Decoupling Lwt threads for reading from the controlling terminal of ssh process and for prompting the user in GUI. This allows for collecting the ouput from ssh with mutiple `read`s and building a buffer before displaying it to user. This fixes an issue where a prompt was displayed to the user before all output was collected from ssh. This was not only confusing to the user, it was also dangerous as the user had an opportunity to respond to the prompt without knowing what ssh was prompting for.