### PR TITLE
Add support for Unix domain sockets

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -845,7 +845,10 @@ The full grammar is:
   \NT{user} ::= [-\_a-zA-Z0-9]+
 
   \NT{host} ::= [-\_a-zA-Z0-9.]+
+        |  \textbackslash[ [a-f0-9:.]+ \NT{zone}? \textbackslash]    IPv6 literals (no future format).
         |  \{ [\^{}\}]+ \}                   For Unix domain sockets only.
+
+  \NT{zone} ::= \%[-\_a-zA-Z0-9~\%.]+
 
   \NT{port} ::= [0-9]+
 \end{alltt}

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -842,9 +842,10 @@ The full grammar is:
             |  ssh
             |  rsh
 
-  \NT{user} ::= [-_a-zA-Z0-9]+
+  \NT{user} ::= [-\_a-zA-Z0-9]+
 
-  \NT{host} ::= [-_a-zA-Z0-9.]+
+  \NT{host} ::= [-\_a-zA-Z0-9.]+
+        |  \{ [\^{}\}]+ \}                   For Unix domain sockets only.
 
   \NT{port} ::= [0-9]+
 \end{alltt}

--- a/src/clroot.ml
+++ b/src/clroot.ml
@@ -113,24 +113,15 @@ let getUser s =
     (Some beforeAt,afterAt)
   else (None,s)
 
-(*ipv6 support*)
-let hostWithBracketsRegexp = Str.regexp "\\[.*\\]"
 (* Hostname, IP or Unix domain socket path *)
 let hostRegexp = Str.regexp "[-_a-zA-Z0-9.]+\\|{[^}]+}"
 let getHost s =
-  if Str.string_match hostWithBracketsRegexp s 0
-  then
-    let host' = Str.matched_string s in
-    let s' = Str.string_after s (String.length host') in
-    let host = String.sub host' 1 ((String.length host')-2) in
-    (Some host,s')
-  else if Str.string_match hostRegexp s 0
+  if Str.string_match hostRegexp s 0
   then
     let host = Str.matched_string s in
     let s' = Str.string_after s (String.length host) in
     (Some host,s')
-  else
-     (None,s)
+  else (None,s)
 
 let colonPortRegexp = Str.regexp ":[^/]+"
 let getPort s =

--- a/src/main.ml
+++ b/src/main.ml
@@ -95,10 +95,17 @@ let socket =
     (function None -> [] | Some(i) -> [string_of_int i])
     Umarshal.(option int)
 
-let serverHostName = "host"
+let serverHostNameAlias = "host"
+let serverHostName = "listen"
 let serverHost =
-  Prefs.createString serverHostName ""
-    "!bind the socket to this host name in server socket mode" ""
+  Prefs.createString serverHostName "" ~local:true
+    "!listen on this name or addr in server socket mode (can repeat)"
+    ("When acting as a server on a socket, Unison will by default listen "
+     ^ "on \"any\" address (0.0.0.0 and [::]).  This command-line argument "
+     ^ "allows to specify a different listening address and can be repeated "
+     ^ "to listen on multiple addresses.  Listening address can be specified "
+     ^ "as a host name or an IP address.")
+let () = Prefs.alias serverHost serverHostNameAlias
 
 (* User preference for which UI to use if there is a choice *)
 let uiPrefName = "ui"
@@ -207,13 +214,8 @@ let init () = begin
     catch_all (fun () ->
      Os.createUnisonDir();
       Remote.waitOnPort
-        (begin try
-           match Util.StringMap.find serverHostName argv with
-             []     -> None
-           | s :: _ -> Some s
-         with Not_found ->
-           None
-         end)
+        ((try Util.StringMap.find serverHostName argv with Not_found -> []) @
+         (try Util.StringMap.find serverHostNameAlias argv with Not_found -> []))
         i);
     exit 0
   with Not_found -> () end;

--- a/src/main.ml
+++ b/src/main.ml
@@ -85,15 +85,8 @@ let server =
 
 let socketPrefName = "socket"
 let socket =
-  Prefs.create socketPrefName None
+  Prefs.createString socketPrefName "" ~local:true
     "!act as a server on a socket" ""
-    (fun _ -> fun i ->
-      (try
-         Some(int_of_string i)
-       with Failure _ ->
-         raise(Prefs.IllegalValue "-socket must be followed by a number")))
-    (function None -> [] | Some(i) -> [string_of_int i])
-    Umarshal.(option int)
 
 let serverHostNameAlias = "host"
 let serverHostName = "listen"

--- a/src/remote.mli
+++ b/src/remote.mli
@@ -71,7 +71,7 @@ val commandAvailable :
 (* Enter "server mode", reading and processing commands from a remote
    client process until killed *)
 val beAServer : unit -> unit
-val waitOnPort : string option -> string -> unit
+val waitOnPort : string list -> string -> unit
 
 (* Whether the server should be killed when the client terminates *)
 val killServer : bool Prefs.t

--- a/src/ubase/prefs.ml
+++ b/src/ubase/prefs.ml
@@ -172,6 +172,12 @@ let alias pref newname =
   (* found in the map, no need for catching exception                       *)
   let (_,pspec,_) = Util.StringMap.find (Safelist.hd (name pref)) !prefs in
   prefs := Util.StringMap.add newname ("*", pspec, "") !prefs;
+  let () =
+    try
+      let loader = Util.StringMap.find (Safelist.hd (name pref)) !loaders in
+      addloader newname loader
+    with Not_found -> ()
+  in
   aliasMap := Util.StringMap.add newname (Safelist.hd (name pref)) !aliasMap;
   pref.names <- newname :: pref.names
 


### PR DESCRIPTION
What it says on the tin.

There are some collateral, somewhat loosely related, changes included.

- For TCP sockets, improve capabilities of manually specifying which addresses to listen on. Rename the command-line argument from "host", which is somewhat inaccurate and even misleading, to "listen", keeping the old name as alias. Allow the argument to be repeated so that multiple listening endpoints can be specified. Socket tests can now just add `-listen 127.0.0.1` (or `-listen ::1`, or both or just `-listen localhost`) to the server invocation. A fix was needed for the alias to properly load when client sends preferences to server.

- Change the code for parsing IPv6 literals in roots. While not strictly necessary for any of this, when working with the related code it just bugged me so much that I had to fix it.

- Add support for Unix domain sockets. I think mostly it should be pretty self-explanatory. Potential bikeshedding moment here is the syntax when specifying roots over the Unix socket. I currently settled for `socket://{/path/to/socket}/root/path`. The socket path is in curly braces. I don't know what does the latest RFC about URIs say but creating URLs over domain sockets does not seem to have a good standard way. I did not add any documentation about this support yet. Once any discussions have finished and the final design is confirmed, I will update the manual accordingly. I overloaded the `-socket` command-line argument to start the server with a Unix domain socket. When `-socket` is specified with an integer then it is treated as a port number and a TCP socket is created; otherwise it is treated as a path to a Unix socket. There are absolutely no limitations as to what the socket path may be, it is blindly passed on to the kernel. See example in the GHA patch below.

I did not add any test yet, not in Makefile, not in GHA jobs. I will add to GHA once any discussions have concluded. For those interested, I got green runs with the following patch.

```diff
diff --git a/.github/workflows/CICD.yml b/.github/workflows/CICD.yml
index 56c62298..1c0ef424 100644
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -175,6 +175,21 @@ jobs:
         sleep 1 # Wait for the server to be fully started
         ./src/unison -ui text -selftest testr1 socket://127.0.0.1:55443/testr2 -killserver
 
+    - name: Run self-tests over local socket
+      # Recent Windows versions do support Unix domain sockets
+      # but at least OCaml 4.14 is required to use that support
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        mkdir localsocket
+        chmod 700 localsocket
+        # Separate backup dir must be set for server instance so that the central
+        # backup location of both instances doesn't overlap
+        UNISONBACKUPDIR=./src/testbak4 ./src/unison -socket ./localsocket/test.sock &
+        sleep 1 # Wait for the server to be fully started
+        test -S ./localsocket/test.sock
+        ./src/unison -ui text -selftest testr3 socket://{./localsocket/test.sock}/testr4 -killserver
+
     - if: steps.vars.outputs.STATIC != 'true' ## unable to build static gtk for linux or windows/Cygwin MinGW platforms
       shell: bash
       run: |
```

Closes #163
It gets #630 to 90% completion but doesn't do any make test modifications. Volunteers needed to provide a make recipe for a portable (even some Windows versions are supposed to have Unix sockets nowadays!) test over Unix sockets.
