### PR TITLE
GHA: Add CI for docs

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -10,7 +10,36 @@ on:
   - push
 
 jobs:
+  docs:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Use OCaml
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: 4.13.x
+        opam-depext: false
+
+    - run: sudo apt-get install hevea lynx texlive-latex-base
+
+    - run: opam exec -- make docs
+
+    - name: Store user manual for the build jobs
+      uses: actions/upload-artifact@v2
+      with:
+        name: unison-docs
+        path: |
+          doc/unison-manual.txt
+          doc/unison-manual.html
+          doc/unison-manual.pdf
+
   build:
+    if: ${{ always() }}    # Don't fail if 'docs' failed
+    needs: docs
+
     strategy:
       fail-fast: false
       matrix:
@@ -188,6 +217,12 @@ jobs:
       with:
         name: unison-${{ steps.vars.outputs.REF_SHAS }}.ocaml-${{ matrix.job.ocaml-version }}.${{ matrix.job.os }}
         path: ${{ steps.vars.outputs.PKG_DIR }}/bin/*
+
+    - name: Copy user manual
+      uses: actions/download-artifact@v2
+      with:
+        name: unison-docs
+        path: '${{ steps.vars.outputs.PKG_DIR }}'
 
     - name: Package
       # if: steps.vars.outputs.DEPLOY

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -41,6 +41,7 @@ ifeq ($(HEVEA),true)
 	hevea unison-manual.tex
 	./postproc < unison-manual.html > temp.html
 	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump temp.html > unison-manual.dtxt)
+	sed -e "/^----SNIP----/,+2 d" -e "/^Junk/,$$ d" unison-manual.dtxt > unison-manual.txt
 	./docs$(EXEC_EXT)
 endif
 	printf '$(TEXDIRECTIVES)\\textversionfalse\\draftfalse' > texdirectives.tex
@@ -83,6 +84,6 @@ clean::
 	   docs docs.exe temp.dvi temp.html unison-manual.html \
 	   postproc postproc.exe postproc.ml \
 	   unison-manual.dvi unison-manual.ps unison-manual.pdf \
-	   unison-manual.info* unisonversion.tex \
+	   unison-manual.txt unison-manual.info* unisonversion.tex \
 	   contact.html faq.html faq.haux index.html
 


### PR DESCRIPTION
This adds a CI job to run `make docs`. The output is picked up by all build jobs but only packaged when publishing the artifacts. To get the docs from a non-publishing CI run, download the separate 'unison-docs' artifact.

txt, html and pdf format manuals are added in the package.

This makes building docs a pre-requisite for building binaries. It's not ideal but it's pretty fast when caches are hot. Failure in `make docs` will not stop the builds, so that CI can still function for primary builds.

Closes #412