### PR TITLE
Don't link the separate bigarray library with newer OCaml

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -243,7 +243,11 @@ OCAMLOBJS+=main.cmo
 
 # OCaml libraries for the bytecode version
 # File extensions will be substituted for the native code version
+ifeq ($(shell ocamlc -version | grep ^5.0),)
 OCAMLLIBS+=unix.cma str.cma bigarray.cma
+else
+OCAMLLIBS+=unix.cma str.cma
+endif
 
 COBJS+=osxsupport$(OBJ_EXT) pty$(OBJ_EXT) bytearray_stubs$(OBJ_EXT) hash_compat$(OBJ_EXT)
 


### PR DESCRIPTION
Bigarray has been included in Stdlib since OCaml 4.07. A separate empty bigarray library was kept around for compatibility with build recipes. The separate library is removed since OCaml 5.00.

Linking with the separate bigarray library is from now on a compatibility measure for building with OCaml < 4.07.