### PR TITLE
Fix root input in GUI

### DIFF
--- a/src/clroot.mli
+++ b/src/clroot.mli
@@ -19,3 +19,7 @@ type clroot =
 val clroot2string : clroot -> string
 
 val parseRoot : string -> clroot
+
+(* Parse a clroot with manually constructed host
+   which may or may not include the port number *)
+val fixHost : clroot -> clroot


### PR DESCRIPTION
GUI constructed `Clroot` values directly from user input, without parsing it. This caused potentially incorrect root definitions to be created.

In the same patch, GUI input validation for Unix domain socket roots and a fix to allow percent character in the host part of the root (closes #294).