### PR TITLE
adjust enabled_if in fsmonitor to match all Linux targets

### DIFF
--- a/src/fsmonitor/linux/dune
+++ b/src/fsmonitor/linux/dune
@@ -3,7 +3,13 @@
 (library
  (name fswatcher)
  (wrapped false)
- (enabled_if (= %{system} "linux"))
+ (enabled_if
+  (or
+   (= %{system} "linux")
+   (= %{system} "linux_elf")
+   (= %{system} "elf")
+   (= %{system} "linux_eabihf")
+   (= %{system} "linux_eabi")))
  (modules :standard \ watcher)
  (flags :standard -w -3-27-39)
  (foreign_stubs
@@ -14,7 +20,13 @@
 (executable
  (name watcher)
  (public_name unison-fsmonitor)
- (enabled_if (= %{system} "linux"))
+ (enabled_if
+  (or
+   (= %{system} "linux")
+   (= %{system} "linux_elf")
+   (= %{system} "elf")
+   (= %{system} "linux_eabihf")
+   (= %{system} "linux_eabi")))
  (modules watcher)
  (flags :standard -w -27)
  (libraries fswatcher))


### PR DESCRIPTION
"system" is a synthetic value which is constructed in
ocaml.git/configure, based on the configure --host=triple option.

The current single pattern matches just x86 and arm64 Linux targets.
Extend the list to cover all other targets as well.

Fixes #657

Signed-off-by: Olaf Hering <olaf@aepfle.de>