### PR TITLE
rename unison-gtk2 to unison-gui in dune build

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -23,7 +23,7 @@
 
 (executable
  (name linkgtk2)
- (public_name unison-gtk2)
+ (public_name unison-gui)
  (flags :standard -w -3-6-9-27-32-52)
  (modules linkgtk2 uigtk2)
  (libraries threads unison_lib lablgtk2))


### PR DESCRIPTION
Make the name of the executable agnostic to the used GUI tooling.
This change affects only the build with dune. The executable built
with make UISTYLE=... remains named just 'unison'.

Signed-off-by: Olaf Hering <olaf@aepfle.de>