### PR TITLE
Makefile cleanup: remove redundant dependency

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -446,8 +446,6 @@ win32rc/unison.res.lib: win32rc/unison.rc win32rc/U.ico
 	@echo "$(CAMLC): $< ---> $@"
 	$(CAMLC) $(CAMLFLAGS) $(COMPATCAMLFLAGS) -c $(CWD)/$<
 
-fswatch.cmi : ubase/prefs.cmi
-
 compat%.cmo: compat%.ml
 	@echo "$(OCAMLC): $< ---> $@"
 	$(OCAMLC) $(COMPATCAMLFLAGS) -c $(CWD)/$<


### PR DESCRIPTION
Revert an incorrect fix to a real problem in 2.48.4 which was corrected in 2.51.