### PR TITLE
Fix Windows build on OCaml 4.14

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Use OCaml
       uses: ocaml/setup-ocaml@v2
       with:
-        ocaml-compiler: 4.13.x
+        ocaml-compiler: 4.14.x
         opam-depext: false
 
     - run: sudo apt-get install hevea lynx texlive-latex-base
@@ -44,7 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         job:
-        - { os: macos-11      , ocaml-version: 4.12.1 }
+        - { os: macos-11      , ocaml-version: 4.14.0 }
+        - { os: macos-10.15   , ocaml-version: 4.14.0 }
+        - { os: macos-10.15   , ocaml-version: 4.13.1 }
         - { os: macos-10.15   , ocaml-version: 4.12.1 }
         - { os: macos-10.15   , ocaml-version: 4.11.2 }
         - { os: macos-10.15   , ocaml-version: 4.10.2 }
@@ -56,7 +58,9 @@ jobs:
         - { os: macos-10.15   , ocaml-version: 4.04.2 }
         - { os: macos-10.15   , ocaml-version: 4.03.0 }
         - { os: macos-10.15   , ocaml-version: 4.02.3 }
-        - { os: ubuntu-20.04  , ocaml-version: 4.12.1 }
+        - { os: ubuntu-20.04  , ocaml-version: 4.14.0 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.14.0 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.13.1 }
         - { os: ubuntu-18.04  , ocaml-version: 4.12.1 }
         - { os: ubuntu-18.04  , ocaml-version: 4.11.2 }
         - { os: ubuntu-18.04  , ocaml-version: 4.10.2 }
@@ -70,6 +74,8 @@ jobs:
         - { os: ubuntu-18.04  , ocaml-version: 4.03.0 }
         - { os: ubuntu-18.04  , ocaml-version: 4.02.3 }
         - { os: ubuntu-18.04  , ocaml-version: 4.01.0 }
+        - { os: windows-2019  , ocaml-version: 4.14.0+mingw64c }
+        - { os: windows-2019  , ocaml-version: 4.13.1+mingw64c }
         - { os: windows-2019  , ocaml-version: 4.12.1+mingw64c }
         - { os: windows-2019  , ocaml-version: 4.11.2+mingw64c }
         - { os: windows-2019  , ocaml-version: 4.10.2+mingw64c }

--- a/src/system/system_win_stubs.c
+++ b/src/system/system_win_stubs.c
@@ -373,7 +373,7 @@ typedef enum _FILE_INFORMATION_CLASS {
 #include <caml/version.h> /* Available since OCaml 4.02 */
 #endif
 
-#if !defined(OCAML_VERSION) || OCAML_VERSION < 40300
+#if !defined(OCAML_VERSION) || OCAML_VERSION < 40300 || OCAML_VERSION >= 41400
 
 typedef struct _REPARSE_DATA_BUFFER {
   ULONG  ReparseTag;


### PR DESCRIPTION
Windows build got broken by a change in OCaml 4.14.

Since older OCaml versions are soon to be removed from the CI anyway, might as well add additional versions now to detect build errors immediately.