### PR TITLE
Mark opam depenencies as `build` deps

### DIFF
--- a/unison.opam
+++ b/unison.opam
@@ -11,9 +11,9 @@ bug-reports: "https://github.com/bcpierce00/unison/issues"
 dev-repo: "git://github.com/bcpierce00/unison.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.03"}
-  "dune" {>= "2.3"}
-  "lablgtk" {>= "2.18.6"}
+  "ocaml" {build & >= "4.03"}
+  "dune" {build & >= "2.3"}
+  "lablgtk" {build & >= "2.18.6"}
 ]
 synopsis: "File-synchronization tool for Unix and Windows"
 description: """


### PR DESCRIPTION
According to opam docs, a `build` dependency is used 
> to indicate that there is no run-time dependency to this package: it is required but won't trigger rebuilds of your package when changed.