### PR TITLE
Fix `Props.setTime` for synced times

### DIFF
--- a/src/props.ml
+++ b/src/props.ml
@@ -518,7 +518,7 @@ let override t t' =
 
 let replace t v =
   match t with
-    Synced _    -> t
+    Synced _    -> Synced v
   | NotSynced _ -> NotSynced v
 
 let strip t =


### PR DESCRIPTION
See commit message for further details. This change has no impact on the current code but it is required for the next PR to function properly.