### PR TITLE
Makefile: add manpage to "all" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ text:
 test:
 	./src/unison -ui text -selftest
 
-all: src
+all: src manpage
 
 src:
 	$(MAKE) -C src


### PR DESCRIPTION
This is a point fix, avoiding the (needed) grand restructuring, but it
enables packaging systems that want to build by calling a single
target to build the unison binary and the man page.  Basically, I'm
taking the view that no one should want to avoid the man page, at
least by default.