### PR TITLE
README: Remove CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Unison File Synchronizer
 
-[![Build status](https://github.com/bcpierce00/unison/workflows/CI/badge.svg)](https://github.com/bcpierce00/unison/actions?query=workflow%3ACI)
-
 ## Meta
 
 ***Please read this entire README and


### PR DESCRIPTION
The CI build status badge is meaningless and often incorrect (and even more so in historical/released README). I propose to remove it from README.