### PR TITLE
GHA: Run apt-get update on Ubuntu runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - run: sudo apt-get update
+
     - name: Checkout code
       uses: actions/checkout@v2
 
@@ -52,6 +54,7 @@ jobs:
         - { os: macos-10.15   , ocaml-version: 4.10.2  , publish: true }
         - { os: macos-10.15   , ocaml-version: 4.09.1  , publish: true }
         - { os: macos-10.15   , ocaml-version: 4.08.1  , publish: true }
+        - { os: ubuntu-22.04  , ocaml-version: 4.14.0 }
         - { os: ubuntu-20.04  , ocaml-version: 4.14.0 }
         - { os: ubuntu-18.04  , ocaml-version: 4.14.0  , publish: true }
         - { os: ubuntu-18.04  , ocaml-version: 4.13.1  , publish: true }
@@ -74,6 +77,9 @@ jobs:
     runs-on: ${{ matrix.job.os }}
 
     steps:
+    - if: contains(matrix.job.os, 'ubuntu')
+      run: sudo apt-get update
+
     - if: runner.os == 'Windows'
       name: "Windows: Stash away the default MSYS installation"
       continue-on-error: true
@@ -337,6 +343,9 @@ jobs:
     runs-on: ${{ matrix.job.os }}
 
     steps:
+    - if: contains(matrix.job.os, 'ubuntu')
+      run: sudo apt-get update
+
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
       uses: ocaml/setup-ocaml@v2
       with:
@@ -639,12 +648,16 @@ jobs:
         job:
         - { os: ubuntu-18.04   , ocaml-compiler: 4.11.x }
         - { os: ubuntu-20.04   , ocaml-compiler: 4.12.x }
+        - { os: ubuntu-22.04   , ocaml-compiler: 4.12.x }
         - { os: macos-10.15    , ocaml-compiler: 4.11.x }
         - { os: macos-11       , ocaml-compiler: 4.12.x }
 
     runs-on: ${{ matrix.job.os }}
 
     steps:
+    - if: contains(matrix.job.os, 'ubuntu')
+      run: sudo apt-get update
+
     - name: Checkout code
       uses: actions/checkout@v2
 
@@ -664,11 +677,14 @@ jobs:
       fail-fast: false
       matrix:
         job:
-        - { os: ubuntu-18.04   , ocaml-compiler: 4.14.x }
+        - { os: ubuntu-22.04   , ocaml-compiler: 4.14.x }
 
     runs-on: ${{ matrix.job.os }}
 
     steps:
+    - if: contains(matrix.job.os, 'ubuntu')
+      run: sudo apt-get update
+
     - name: Checkout code
       uses: actions/checkout@v2
 


### PR DESCRIPTION
Run apt-get update on Ubuntu runners. Also add some Ubuntu 22.04 jobs.