### PR TITLE
Makefile: Remove include of src/Makefile.OCaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ docs:
 manpage:
 	$(MAKE) -C man
 
-include src/Makefile.OCaml
-
 depend::
 	$(MAKE) -C src depend
 


### PR DESCRIPTION
Including a makefile in a different directory, unless it's designed
for that, can't work because the assumptions about $CWD do not hold.

With the include, "make depend" fails.