### PR TITLE
GHA: Work around setup-ocaml issue on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,7 +152,7 @@ jobs:
       if: contains(matrix.job.ocaml-version, '+msvc')
 
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v2.0.3
       with:
         ocaml-compiler: "${{ steps.vars.outputs.OCAML_COMPILER }}"
         opam-pin: false
@@ -363,7 +363,7 @@ jobs:
       run: sudo apt-get update
 
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v2.0.3
       with:
         ocaml-compiler: "${{ matrix.job.ocaml-version }}"
         opam-pin: false


### PR DESCRIPTION
setup-ocaml 2.0.4 breaks builds on Windows. Temporarily lock the version to 2.0.3 until the upstream issue is fixed.