### PR TITLE
GHA: Pin Cygwin mingw64-binutils version to 2.37

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,6 +151,18 @@ jobs:
         arch: "${{ steps.vars.outputs.MSVC_ARCH }}"
       if: contains(matrix.job.ocaml-version, '+msvc')
 
+    - name: "Windows: Cygwin setup"
+      if: runner.os == 'Windows'
+      run: Invoke-WebRequest 'https://cygwin.com/setup-x86_64.exe' -OutFile 'setup-x86_64.exe'
+
+    # [2022-05] Cygwin mingw64 binutils 2.38 produces invalid GUI binaries.
+    # Pin binutils to version 2.37 as a workaround.
+    - name: "Windows: mingw64 binutils workaround hack"
+      if: runner.os == 'Windows'
+      # The setup does not complete properly in powershell for some reason
+      shell: cmd
+      run: .\setup-x86_64.exe --quiet-mode --root D:\cygwin --site http://cygwin.mirror.constant.com --symlink-type=sys --packages mingw64-i686-binutils=2.37-2,mingw64-x86_64-binutils=2.37-2
+
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
       uses: ocaml/setup-ocaml@v2.0.3
       with:


### PR DESCRIPTION
This is a workaround for issue #744

Cygwin mingw64-binutils upgrade from 2.37 to 2.38 broke the GUI binaries in Windows. Binaries are produced without error but they don't start.