### PR TITLE
Improve a commit log fix for Windows

### DIFF
--- a/src/os.ml
+++ b/src/os.ml
@@ -191,8 +191,10 @@ and delete fspath path =
       | `ABSENT ->
           ())
 
-let renameFspath fname source target =
+let rename fname sourcefspath sourcepath targetfspath targetpath =
+  let source = Fspath.concat sourcefspath sourcepath in
   let source' = Fspath.toPrintString source in
+  let target = Fspath.concat targetfspath targetpath in
   let target' = Fspath.toPrintString target in
   if source = target then
     raise (Util.Transient ("Rename ("^fname^"): identical source and target " ^ source'));
@@ -208,11 +210,6 @@ let renameFspath fname source target =
         else if Fs.file_exists targetDouble then
           Fs.unlink targetDouble
       end)
-
-let rename fname sourcefspath sourcepath targetfspath targetpath =
-  let source = Fspath.concat sourcefspath sourcepath in
-  let target = Fspath.concat targetfspath targetpath in
-  renameFspath fname source target
 
 let symlink =
   if Fs.hasSymlink () then

--- a/src/os.mli
+++ b/src/os.mli
@@ -16,7 +16,6 @@ val childrenOf : Fspath.t -> Path.local -> Name.t list
 val readLink : Fspath.t -> Path.local -> string
 val symlink : Fspath.t -> Path.local -> string -> unit
 
-val renameFspath : string -> Fspath.t -> Fspath.t -> unit
 val rename : string -> Fspath.t -> Path.local -> Fspath.t -> Path.local -> unit
 val createDir : Fspath.t -> Path.local -> Props.t -> unit
 val delete : Fspath.t -> Path.local -> unit

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -461,7 +461,8 @@ let padto n s = s ^ (String.make (max 0 (n - String.length s)) ' ')
 (*              Building pathnames in the user's home dir                    *)
 (*****************************************************************************)
 
-let homeDirStr = 
+let homeDir () =
+  System.fspathFromString
     (if (osType = `Unix) || isCygwin then
        safeGetenv "HOME"
      else if osType = `Win32 then
@@ -481,9 +482,6 @@ let homeDirStr =
        "c:/" (* Default *)
      else
        assert false (* osType can't be anything else *))
-
-let homeDir () =
-  System.fspathFromString homeDirStr
 
 let fileInHomeDir n = System.fspathConcat (homeDir ()) n
 


### PR DESCRIPTION
Revert an old fix to a commit log issue in Windows and replace it with an improved one.

The old fix has a number of problems. It is very heavy-handed. It runs on all platforms, even though it is a fix to a Windows-specific issue. It invokes many-many syscalls, most of which are unnecessary. And it makes too invasive changes in other code that is not relevant to this issue at all.

The new fix is run on Windows only, restoring other platforms to the state they had before the original fix was merged.