### PR TITLE
Partially fix building with OCaml trunk

### DIFF
--- a/src/osxsupport.c
+++ b/src/osxsupport.c
@@ -4,6 +4,7 @@
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>
+#include <caml/unixsupport.h>
 #ifdef __APPLE__
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -14,9 +15,6 @@
 #include <string.h>
 #endif
 #include <errno.h>
-
-extern void unix_error (int errcode, char * cmdname, value arg) Noreturn;
-extern void uerror (char * cmdname, value arg) Noreturn;
 
 CAMLprim value isMacOSX (value nothing) {
   CAMLparam0();


### PR DESCRIPTION
OCaml trunk has merged a commit which changes names of public symbols. There are some compatibility macros defined, which makes this patch tiny, but not all symbols have compatibility macros (an issue for Windows builds).

This patch is aimed at Unix-like platforms (issue #753). Windows builds will be fixed separately.