### PR TITLE
Remove more of old compiler compatibility code

### DIFF
--- a/src/fsmonitor/windows/Makefile
+++ b/src/fsmonitor/windows/Makefile
@@ -13,7 +13,7 @@ FSMOCAMLOBJS = \
 FSMCOBJS = \
    bytearray_stubs$(OBJ_EXT) \
    system/system_win_stubs$(OBJ_EXT) lwt/lwt_unix_stubs$(OBJ_EXT)
-FSMOCAMLLIBS=bigarray.cma unix.cma
+FSMOCAMLLIBS=unix.cma
 
 ifeq ($(NATIVE), true)
   FSMCAMLOBJS=$(subst .cmo,.cmx, $(FSMOCAMLOBJS))

--- a/src/path.ml
+++ b/src/path.ml
@@ -225,12 +225,8 @@ let followPred = Pred.create "follow"
       The syntax of \\ARG{pathspec} is \
       described in \\sectionref{pathspec}{Path Specification}.")
 
-let winHasReadlink =
-  Scanf.sscanf Sys.ocaml_version "%d.%d.%d" (fun x y z -> x > 4 || x = 4 && y >= 3)
-
 let followLink path =
-     (Util.osType = `Unix || Util.isCygwin || winHasReadlink)
-  && Pred.test followPred (toString path)
+  Pred.test followPred (toString path)
 
 let forceLocal p = p
 let makeGlobal p = p


### PR DESCRIPTION
Minimum supported OCaml version is currently 4.08.

Remove `readlink` check on Windows (checks for >= 4.03).

Remove bigarray from fsmonitor/windows linking instruction (was needed for < 4.07).