### PR TITLE
Assortment of fixes to hangs and connection cleanup issues

### DIFF
--- a/src/copy.ml
+++ b/src/copy.ml
@@ -24,19 +24,14 @@ let debug = Trace.debug "copy"
 let protect f g =
   try
     f ()
-  with Sys_error _ | Unix.Unix_error _ | Util.Transient _ as e ->
+  with e ->
     begin try g () with Sys_error _  | Unix.Unix_error _ -> () end;
     raise e
 
 let lwt_protect f g =
   Lwt.catch f
     (fun e ->
-       begin match e with
-         Sys_error _ | Unix.Unix_error _ | Util.Transient _ ->
-           begin try g () with Sys_error _  | Unix.Unix_error _ -> () end
-       | _ ->
-           ()
-       end;
+       begin try g () with Sys_error _  | Unix.Unix_error _ -> () end;
        Lwt.fail e)
 
 (****)

--- a/src/copy.ml
+++ b/src/copy.ml
@@ -477,7 +477,7 @@ let processTransferInstruction conn (file_id, ti) =
   Util.convertUnixErrorsToTransient
     "processing a transfer instruction"
     (fun () ->
-       ignore (Remote.MsgIdMap.find file_id !decompressor ti))
+       ignore ((fst (Remote.MsgIdMap.find file_id !decompressor)) ti))
 
 let marshalTransferInstruction =
   (fun _ (file_id, (data, pos, len)) rem ->
@@ -497,6 +497,20 @@ let showPrefixProgress id kind =
     `DATA_APPEND len -> Uutil.showProgress id len "r"
   | _                -> ()
 
+(* There is an issue that not all threads are immediately cancelled when there
+   is a connection error. A waiting thread (in this case probably a thread
+   in the Lwt region for RPC streaming) may get started and open the infd but
+   never complete. lwt_protect is never triggered in this scenario. Not sure
+   why exactly but probably because the thread just stops (as eventually the
+   connection cleanup kicks in and all threads are stopped). As a hacky
+   solution, keep track of all open fds and close them when the connection
+   breaks. *)
+let compressorFds = Hashtbl.create 17
+let closeCompressors () =
+  Hashtbl.iter (fun fd _ -> close_in_noerr fd) compressorFds;
+  Hashtbl.clear compressorFds
+let () = Remote.at_conn_close closeCompressors
+
 let compress conn
      ((biOpt, fspathFrom, pathFrom, fileKind), (sizeFrom, id, file_id)) =
   Lwt.catch
@@ -507,6 +521,7 @@ let compress conn
                already started *)
             if fileKind <> `RESS then Abort.check id;
             let infd = openFileIn fspathFrom pathFrom fileKind in
+            Hashtbl.add compressorFds infd true;
             lwt_protect
               (fun () ->
                  showPrefixProgress id fileKind;
@@ -523,10 +538,11 @@ let compress conn
                  compr
                    (fun ti -> processTransferInstructionRemotely (file_id, ti))
                        >>= fun () ->
+                 Hashtbl.remove compressorFds infd;
                  close_in infd;
                  Lwt.return ())
               (fun () ->
-                 close_in_noerr infd)))
+                 Hashtbl.remove compressorFds infd; close_in_noerr infd)))
     (fun e ->
        (* We cannot wrap the code above with the handler below,
           as the code is executed asynchronously. *)
@@ -675,7 +691,7 @@ let transferFileContents
     Lwt.catch
       (fun () ->
          debug (fun () -> Util.msg "Starting the actual transfer\n");
-         decompressor := Remote.MsgIdMap.add file_id decompr !decompressor;
+         decompressor := Remote.MsgIdMap.add file_id (decompr, (infd, outfd)) !decompressor;
          compressRemotely connFrom
            ((bi, fspathFrom, pathFrom, fileKind), (srcFileSize, id, file_id))
            >>= fun () ->
@@ -689,6 +705,13 @@ let transferFileContents
            Remote.MsgIdMap.remove file_id !decompressor; (* For GC *)
          close_all_no_error infd outfd;
          Lwt.fail e))
+
+let closeDecompressors () =
+  let tmp = !decompressor in
+  decompressor := Remote.MsgIdMap.empty;
+  tmp |> Remote.MsgIdMap.iter (fun _ (_, (infd, outfd)) ->
+    close_all_no_error infd outfd)
+let () = Remote.at_conn_close closeDecompressors
 
 (****)
 
@@ -743,6 +766,11 @@ let reallyTransferFile
 (****)
 
 let filesBeingTransferred = Hashtbl.create 17
+
+let resetFileTransferState () =
+  (* The waiting threads should be collected by GC *)
+  Hashtbl.clear filesBeingTransferred
+let () = Remote.at_conn_close resetFileTransferState
 
 let wakeupNextTransfer fp =
   match

--- a/src/remote.mli
+++ b/src/remote.mli
@@ -150,3 +150,13 @@ val registerStreamCmd :
   (connection -> Bytearray.t -> int -> 'a) ->
   (connection -> 'a -> unit) ->
   connection -> (('a -> unit Lwt.t) -> 'b Lwt.t) -> 'b Lwt.t
+
+(* Register a function to be run when the connection between client and server
+   is closed. The function should not raise exceptions. If it does then running
+   some of the other registered functions may be skipped (which is not an issue
+   as the exception is likely going to quit the process).
+
+   Registered functions are only expected to be run when the connection is
+   closed but the process keeps running (a socket server, for example). Do not
+   use it as a substitute for [at_exit]. *)
+val at_conn_close : ?only_server:bool -> (unit -> unit) -> unit

--- a/src/update.ml
+++ b/src/update.ml
@@ -434,6 +434,10 @@ let loadArchiveLocal fspath (thisRoot: string) :
   Util.convertUnixErrorsToFatal "loading archive" (fun () ->
     if System.file_exists fspath then
       let c = System.open_in_bin fspath in
+      let close_on_error f =
+        try f () with e -> close_in_noerr c; raise e
+      in
+      close_on_error (fun () ->
       let header = input_line c in
       (* Sanity check on archive format *)
       if header<>formatString then begin
@@ -488,7 +492,8 @@ let loadArchiveLocal fspath (thisRoot: string) :
           Some (archive, hash, magic, properties)
         with Failure s | Umarshal.Error s -> raise (Util.Fatal (Printf.sprintf
            "Archive file seems damaged (%s): \
-            use the -ignorearchives option, or throw away archives on both machines and try again" s))
+            use the -ignorearchives option, or \
+            throw away archives on both machines and try again" s)))
     else
       (debug (fun() ->
          Util.msg "Archive %s not found\n"


### PR DESCRIPTION
There was a reproducer in #762 which revealed several different issues.

There is an assortment of fixes in this PR (see more details in commit messages) that work with and without `halfduplex` but in all likelyhood nothing here actually fixes the underlying issue of #762 (random hangs without `halfduplex`).