### PR TITLE
Fix usage of `caml_alloc_small()` in C stubs

### DIFF
--- a/src/lwt/lwt_unix_stubs.c
+++ b/src/lwt/lwt_unix_stubs.c
@@ -519,8 +519,8 @@ value win_pipe(long readMode, long writeMode) {
   readfd = caml_win32_alloc_handle(readh);
   writefd = caml_win32_alloc_handle(writeh);
   res = caml_alloc_small(2, 0);
-  Store_field(res, 0, readfd);
-  Store_field(res, 1, writefd);
+  Field(res, 0) = readfd;
+  Field(res, 1) = writefd;
   CAMLreturn (res);
 }
 

--- a/src/system/system_win_stubs.c
+++ b/src/system/system_win_stubs.c
@@ -483,17 +483,17 @@ CAMLprim value win_init_console(value unit)
 
     /* Return only handles that are not already redirected by user. */
     if (!GetFileType(in_orig)) {
-      tmp = caml_alloc_small(1, 0);
+      tmp = caml_alloc(1, 0);
       Store_field(tmp, 0, caml_win32_alloc_handle(in));
       Store_field(ret, 0, tmp);
     }
     if (!GetFileType(out_orig)) {
-      tmp = caml_alloc_small(1, 0);
+      tmp = caml_alloc(1, 0);
       Store_field(tmp, 0, caml_win32_alloc_handle(out));
       Store_field(ret, 1, tmp);
     }
     if (!GetFileType(err_orig)) {
-      tmp = caml_alloc_small(1, 0);
+      tmp = caml_alloc(1, 0);
       Store_field(tmp, 0, caml_win32_alloc_handle(err));
       Store_field(ret, 2, tmp);
     }


### PR DESCRIPTION
Fix a violation of an OCaml GC rule in two C functions.