### PR TITLE
Make GUI-only Windows binary more discoverable

### DIFF
--- a/src/system/system_generic.ml
+++ b/src/system/system_generic.ml
@@ -115,6 +115,9 @@ let terminalStateFunctions () =
     startReading = (fun () -> ());
     stopReading = (fun () -> ()) }
 
+let has_stdout ~info:_ = true
+let has_stderr ~info:_ = true
+
 (****)
 
 let fingerprint f =

--- a/src/system/system_intf.ml
+++ b/src/system/system_intf.ml
@@ -107,4 +107,7 @@ type terminalStateFunctions =
     startReading : unit -> unit; stopReading : unit -> unit }
 val terminalStateFunctions : unit -> terminalStateFunctions
 
+val has_stdout : info:string -> bool
+val has_stderr : info:string -> bool
+
 end

--- a/src/system/system_win.ml
+++ b/src/system/system_win.ml
@@ -198,3 +198,6 @@ let terminalStateFunctions () =
     rawTerminal = (fun () -> setConsoleMode 0x19; setConsoleOutputCP 65001);
     startReading = (fun () -> setConsoleMode 0x18);
     stopReading = (fun () -> setConsoleMode 0x19) }
+
+external has_stdout : info:string -> bool = "win_hasconsole_gui_stdout"
+external has_stderr : info:string -> bool = "win_hasconsole_gui_stderr"

--- a/src/system/system_win_stubs.c
+++ b/src/system/system_win_stubs.c
@@ -440,6 +440,33 @@ CAMLprim value win_stat(value path, value lstat)
 
 /****/
 
+static value win_hasconsole_gui_msg(DWORD h, const char *s)
+{
+  const char *u = "This is a GUI-only executable. Text console output "
+                  "is not supported. To get text output, use the "
+                  "executable intended for it (usually called unison.exe "
+                  "or unison-text.exe) or redirect the output.";
+
+  if (!GetFileType((HANDLE) GetStdHandle(h))) {
+    MessageBoxA(NULL, strcmp(s, "") != 0 ? s : u, "Information", MB_OK);
+    return Val_false;
+  } else {
+    return Val_true;
+  }
+}
+
+CAMLprim value win_hasconsole_gui_stdout(value s)
+{
+  CAMLparam1(s);
+  CAMLreturn(win_hasconsole_gui_msg(STD_OUTPUT_HANDLE, String_val(s)));
+}
+
+CAMLprim value win_hasconsole_gui_stderr(value s)
+{
+  CAMLparam1(s);
+  CAMLreturn(win_hasconsole_gui_msg(STD_ERROR_HANDLE, String_val(s)));
+}
+
 CAMLprim value win_init_console(value unit)
 {
   CAMLparam0();

--- a/src/ubase/uarg.ml
+++ b/src/ubase/uarg.ml
@@ -43,6 +43,13 @@ let usage speclist errmsg =
 
 let current = ref 0;;
 
+let eprintf fmt =
+  Printf.ksprintf (fun s ->
+    if System.has_stderr ~info:s then Printf.eprintf "%s" s else exit 2) fmt
+
+let verify_stdout () =
+  if not (System.has_stdout ~info:"") then exit 37
+
 let parse speclist anonfun errmsg =
   let argv = System.argv () in
   let initpos = !current in
@@ -50,7 +57,7 @@ let parse speclist anonfun errmsg =
     let progname =
       if initpos < Array.length argv then argv.(initpos) else "(?)" in
     begin match error with
-      | Unknown s when s = "-help" -> ()
+      | Unknown s when s = "-help" -> verify_stdout ()
       | Unknown s ->
           eprintf "%s: unknown option `%s'.\n" progname s
       | Missing s ->

--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -678,8 +678,13 @@ let statistics () =
 
 (* ------ *)
 
+let gui_safe_eprintf fmt =
+  Printf.ksprintf (fun s ->
+    if System.has_stderr ~info:s then Printf.eprintf "%s%!" s) fmt
+
 let fatalError ?(quit=false) message =
   let () =
+    Trace.sendLogMsgsToStderr := false; (* We don't know if stderr is available *)
     try Trace.log (message ^ "\n")
     with Util.Fatal _ -> () in (* Can't allow fatal errors in fatal error handler *)
   let title = "Fatal error" in
@@ -687,7 +692,7 @@ let fatalError ?(quit=false) message =
     try toplevelWindow ()
     with Util.Fatal err ->
       begin
-        Printf.eprintf "\n%s:\n%s\n\n%!" title err;
+        gui_safe_eprintf "\n%s:\n%s\n\n%s\n\n" title err message;
         exit 1
       end
   in


### PR DESCRIPTION
Another fix for #778.

The following normally text-only output is now handled differently by the GUI-only binary:
- `-version` output is displayed in a GUI message box.
- `-doc` produces a generic message explaining the GUI-only binary.
- `-ui text` produces a generic message explaining the GUI-only binary.
- `-help` produces a generic message explaining the GUI-only binary.
- command line parsing errors are displayed in a GUI message box.
- GTK init errors are displayed in a GUI message box.

@rivy could you also test and see how this fits into your workflow.