### PR TITLE
Small improvements to status display in text UI

### DIFF
--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -328,6 +328,23 @@ let percentageOfTotal current total =
 
 let percent2string p = Printf.sprintf "%3d%%" (truncate (max 0. (min 100. p)))
 
+let gib = 1073741824.
+let mib = 1048576.
+let kib = 1024.
+let bytes2string v =
+  if v > 1_048_051_711L then
+    Printf.sprintf "%.2f GiB" (Int64.to_float v /. gib)
+  else if v > 104_805_171L then
+    Printf.sprintf "%.0f MiB" (Int64.to_float v /. mib)
+  else if v > 1_023_487L then
+    Printf.sprintf "%.1f MiB" (Int64.to_float v /. mib)
+  else if v > 102_348L then
+    Printf.sprintf "%.0f KiB" (Int64.to_float v /. kib)
+  else if v > 999L then
+    Printf.sprintf "%.1f KiB" (Int64.to_float v /. kib)
+  else
+    Printf.sprintf "%Ld B" v
+
 let extractValueFromOption = function
     None -> raise (Fatal "extractValueFromOption failed")
   | Some(v) -> v

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -83,6 +83,7 @@ val percentageOfTotal :
   int        (* percentage of total *)
 val monthname : int -> string
 val percent2string : float -> string
+val bytes2string : int64 -> string
 
 (* Just like the versions in the Unix module, but raising Transient
    instead of Unix_error *)

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -814,10 +814,14 @@ let doTransport reconItemList =
     let t1 = Unix.gettimeofday () in
     let remTime =
       if v <= 0. then "--:--"
-      else if v >= 100. then "00:00"
+      else if v >= 100. then "00:00:00"
       else
         let t = truncate ((t1 -. t0) *. (100. -. v) /. v +. 0.5) in
-        Format.sprintf "%02d:%02d" (t / 60) (t mod 60)
+        let u = t mod 3600 in
+        let h = t / 3600 in
+        let m = u / 60 in
+        let sec = u mod 60 in
+        Format.sprintf "%02d:%02d:%02d" h m sec
     in
     t1, Format.sprintf "%s  %s ETA" (Util.percent2string v) remTime
   in

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -801,12 +801,16 @@ let doTransport reconItemList =
          (fun s item -> Uutil.Filesize.add item.bytesToTransfer s)
          Uutil.Filesize.zero items)
   in
+  let totalBytesToTransferStr = Util.bytes2string
+    (Uutil.Filesize.toInt64 !totalBytesToTransfer) in
   let t0 = Unix.gettimeofday () in
   let calcProgress i bytes dbg =
     let i = Uutil.File.toLine i in
     let item = items.(i) in
     item.bytesTransferred <- Uutil.Filesize.add item.bytesTransferred bytes;
     totalBytesTransferred := Uutil.Filesize.add !totalBytesTransferred bytes;
+    let totalBytesTransferredStr = Util.bytes2string
+      (Uutil.Filesize.toInt64 !totalBytesTransferred) in
     let v =
       (Uutil.Filesize.percentageOfTotalSize
          !totalBytesTransferred !totalBytesToTransfer)
@@ -823,7 +827,9 @@ let doTransport reconItemList =
         let sec = u mod 60 in
         Format.sprintf "%02d:%02d:%02d" h m sec
     in
-    t1, Format.sprintf "%s  %s ETA" (Util.percent2string v) remTime
+    let stat = Format.sprintf "%s  (%s of %s)  %s ETA" (Util.percent2string v)
+      totalBytesTransferredStr totalBytesToTransferStr remTime in
+    t1, stat
   in
   let tlog = ref t0 in
   let showProgress i bytes dbg =


### PR DESCRIPTION
First, display ETA as hh:mm:ss instead of current mm:ss to improve the progress status during large long-running syncs.
What was previously displayed as `1234:56 ETA` is now displayed as `20:34:56 ETA`.

Second, add a display of transferred bytes. Likewise, to improve the progress status during large syncs.
What was previously displayed as `14%  xx:xx ETA` is now displayed as `14%  (175 MiB of 1.22 GiB)  xx:xx ETA`.

A small bike-shedding moment is the choice of units, MB (base 10) or MiB (base 2). I've currently chosen a hybrid: base 2 for display and base 10 for the thresholds. In other words, 999 B is followed by 1 KiB (rounded) and so on.