### PR TITLE
Improve GTK performance when clearing the list

### DIFF
--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -3480,7 +3480,9 @@ let createToplevelWindow () =
   let clearMainWindow () =
     grDisactivateAll ();
     make_busy toplevelWindow;
+    mainWindow#set_model None;
     mainWindowModel#clear ();
+    mainWindow#set_model (Some mainWindowModel#coerce);
     theState := [||];
     detailsWindow#buffer#set_text ""
   in


### PR DESCRIPTION
Large operations on the backing model of the main list in GUI can take extremely long time when done while the model is attached to the list. These operations can take tens of minutes when the list is tens of thousands or hundreds of thousands items long. This happens even with bulk operations like clearing the list.

Make clearing the list almost instantaneous by detaching the model from the list, clearing it, and then re-attaching it to the list.