### PR TITLE
Improve the etags `make` recipe

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -204,7 +204,7 @@ testmerge:
 .PHONY: tags
 
 tags:
-	-if [ -f "`which $(ETAGS)`" ]; then \
+	@-if command -v $(ETAGS) > /dev/null ; then \
 	    $(ETAGS) *.mli */*.mli *.ml */*.ml */*.m *.c */*.c *.txt \
 		     *Makefile* \
 	  ; fi


### PR DESCRIPTION
I've noticed that some packaging repositories list `emacs` as a build dependency for `unison` (yes, really!). I don't know how that could have happened but if this recipe had something to do with it then better fix it for good.