### PR TITLE
CI.yml: Drop old ocaml versions on all but ubuntu

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,32 +47,19 @@ jobs:
       matrix:
         job:
         - { os: macos-11      , ocaml-version: 4.14.0 }
-        - { os: macos-10.15   , ocaml-version: 4.14.0  , publish: true }
-        - { os: macos-10.15   , ocaml-version: 4.13.1  , publish: true }
-        - { os: macos-10.15   , ocaml-version: 4.12.1  , publish: true }
-        - { os: macos-10.15   , ocaml-version: 4.11.2  , publish: true }
-        - { os: macos-10.15   , ocaml-version: 4.10.2  , publish: true }
-        - { os: macos-10.15   , ocaml-version: 4.09.1  , publish: true }
-        - { os: macos-10.15   , ocaml-version: 4.08.1  , publish: true }
+        - { os: macos-10.15   , ocaml-version: 4.14.0           , publish: true }
         - { os: ubuntu-22.04  , ocaml-version: 4.14.0 }
         - { os: ubuntu-20.04  , ocaml-version: 4.14.0 }
-        - { os: ubuntu-18.04  , ocaml-version: 4.14.0  , publish: true }
-        - { os: ubuntu-18.04  , ocaml-version: 4.13.1  , publish: true }
-        - { os: ubuntu-18.04  , ocaml-version: 4.12.1  , publish: true }
-        - { os: ubuntu-18.04  , ocaml-version: 4.11.2  , publish: true }
-        - { os: ubuntu-18.04  , ocaml-version: 4.10.2  , publish: true }
+        - { os: ubuntu-18.04  , ocaml-version: 4.14.0           , publish: true }
+        - { os: ubuntu-18.04  , ocaml-version: 4.13.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.12.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.11.2 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.10.2 }
         - { os: ubuntu-18.04  , ocaml-version: 4.10.2+musl+static+flambda  , publish: true }
-        - { os: ubuntu-18.04  , ocaml-version: 4.09.1  , publish: true }
-        - { os: ubuntu-18.04  , ocaml-version: 4.08.1  , publish: true }
-        - { os: windows-2022  , ocaml-version: 4.14.0+mingw64c }
-        - { os: windows-2019  , ocaml-version: 4.14.0+mingw64c  , publish: true }
-        - { os: windows-2019  , ocaml-version: 4.13.1+mingw64c  , publish: true }
-        - { os: windows-2019  , ocaml-version: 4.12.1+mingw64c  , publish: true }
-        - { os: windows-2019  , ocaml-version: 4.11.2+mingw64c  , publish: true }
-        - { os: windows-2019  , ocaml-version: 4.10.2+mingw64c  , publish: true }
-        - { os: windows-2019  , ocaml-version: 4.10.2+mingw32c  , publish: true }
-        - { os: windows-2019  , ocaml-version: 4.09.1+mingw64c  , publish: true }
-        - { os: windows-2019  , ocaml-version: 4.08.1+mingw64c  , publish: true }
+        - { os: ubuntu-18.04  , ocaml-version: 4.09.1 }
+        - { os: ubuntu-18.04  , ocaml-version: 4.08.1           , publish: true }
+        - { os: windows-2022  , ocaml-version: 4.14.0+mingw64c  , publish: true }
+        - { os: windows-2019  , ocaml-version: 4.14.0+mingw32c  , publish: true }
 
     runs-on: ${{ matrix.job.os }}
 
@@ -200,6 +187,9 @@ jobs:
 
     - run: opam exec -- make test
 
+    ## There is still code to run tests with old ocaml on Windows.
+    ## That remains intentionally so that someone could turn it on if
+    ## desired.
     - name: Run self-tests over RPC
       if: runner.os == 'Windows' && !contains(matrix.job.ocaml-version, '4.14')
       shell: bash
@@ -368,22 +358,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # This list is intended to balance good enough coverage and
+        # limited resource usage.
         job:
         - { os: ubuntu-18.04  , ocaml-version: 4.14.x  , ref: v2.52.1 }
-        - { os: ubuntu-18.04  , ocaml-version: 4.14.x  , ref: v2.52.0 }
         - { os: ubuntu-18.04  , ocaml-version: 4.14.x  , ref: v2.51.5 }
         - { os: ubuntu-18.04  , ocaml-version: 4.08.x  , ref: v2.51.5 }
         - { os: ubuntu-18.04  , ocaml-version: 4.08.x  , ref: v2.51.2 }
         - { os: ubuntu-18.04  , ocaml-version: 4.08.x  , ref: 2.48.4 }
         - { os: windows-2019  , ocaml-version: ocaml-variants.4.14.0+mingw64c  , ref: v2.52.1 }
-        - { os: windows-2019  , ocaml-version: ocaml-variants.4.14.0+mingw64c  , ref: v2.52.0 }
-        - { os: windows-2019  , ocaml-version: ocaml-variants.4.14.0+mingw64c  , ref: v2.51.5 }
         - { os: windows-2019  , ocaml-version: ocaml-variants.4.08.1+mingw32c  , ref: v2.51.5 }
         - { os: windows-2019  , ocaml-version: ocaml-variants.4.08.1+mingw64c  , ref: v2.51.2 }
         - { os: windows-2019  , ocaml-version: ocaml-variants.4.08.1+mingw64c  , ref: 2.48.4 }
         - { os: macos-11      , ocaml-version: 4.14.x  , ref: v2.52.1 }
-        - { os: macos-11      , ocaml-version: 4.14.x  , ref: v2.52.0 }
-        - { os: macos-11      , ocaml-version: 4.14.x  , ref: v2.51.5 }
         - { os: macos-10.15   , ocaml-version: 4.08.x  , ref: v2.51.5 }
         - { os: macos-10.15   , ocaml-version: 4.08.x  , ref: v2.51.2 }
         - { os: macos-10.15   , ocaml-version: 4.08.x  , ref: 2.48.4 }
@@ -1041,16 +1028,17 @@ jobs:
         _prev/src/unison -ui text -selftest testr_c socket://127.0.0.1:55443/testr_s -killserver
 
 
+  ## We know the code is ok with various ocaml versions, so this is
+  ## just checking the dune build process.  Therefore build each OS
+  ## family just once.  Pick a different ocaml version because that's
+  ## better coverage without adding a build.
   opam_dune_build:
     strategy:
       fail-fast: false
       matrix:
         job:
-        - { os: ubuntu-18.04   , ocaml-compiler: 4.11.x }
-        - { os: ubuntu-20.04   , ocaml-compiler: 4.12.x }
         - { os: ubuntu-22.04   , ocaml-compiler: 4.12.x }
-        - { os: macos-10.15    , ocaml-compiler: 4.11.x }
-        - { os: macos-11       , ocaml-compiler: 4.12.x }
+        - { os: macos-11       , ocaml-compiler: 4.11.x }
 
     runs-on: ${{ matrix.job.os }}
 


### PR DESCRIPTION
Drop ocaml 4.08 to 4.13 on macos and windows, on the theory that building on ubuntu is sufficient to show portability to older ocaml, and because windows builds in particular are too flaky.  With the new scheme, it is possible that there might be an undetected issue with older ocaml in OS-specific code, but basically I'd rather take that risk than have to intervene in most CI runs.