### PR TITLE
Make sed invocation more compatible

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -6,9 +6,9 @@ all:: $(NAME).1
 	$(MAKE) -C ../src UISTYLE=text
 
 $(NAME).1: $(NAME).1.in opt_short.tmp opt_full.tmp
-	sed -e '/@OPTIONS_SHORT@/r./opt_short.tmp' \
+	sed -e '/@OPTIONS_SHORT@/r ./opt_short.tmp' \
 		-e '/@OPTIONS_SHORT@/d' \
-		-e '/@OPTIONS_FULL@/r./opt_full.tmp' \
+		-e '/@OPTIONS_FULL@/r ./opt_full.tmp' \
 		-e '/@OPTIONS_FULL@/d' $(NAME).1.in > $(NAME).1
 
 # Listing of preferences


### PR DESCRIPTION
Some versions of `sed` require a space between a command and an argument. The space is actually a POSIX requirement, with no space being an optional extension.