### PR TITLE
opam file: Remove wrong build tag and unnecessary dependency

### DIFF
--- a/unison.opam
+++ b/unison.opam
@@ -11,10 +11,9 @@ bug-reports: "https://github.com/bcpierce00/unison/issues"
 dev-repo: "git://github.com/bcpierce00/unison.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {build & >= "4.08"}
-  "ocamlfind" {build}
-  "dune" {build & >= "2.3"}
-  "lablgtk3" {build & >= "3.1.0"}
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.3"}
+  "lablgtk3" {>= "3.1.0"}
 ]
 synopsis: "File-synchronization tool for Unix and Windows"
 description: """


### PR DESCRIPTION
* ocamlfind is not used when using dune as far as i can see
* the use of the `{build}` tag makes unison completely disjoint with the rest of the opam state (e.g. if someone updates lablgtk they expect the packages that are using it to also use the new lablgtk). Using it this way is a hack rather than a feature.