### PR TITLE
Clean up after terminated fsmonitor child process

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -440,6 +440,7 @@ fswatch.cmo : \
     uutil.cmi \
     ubase/util.cmi \
     ubase/trace.cmi \
+    terminal.cmi \
     system.cmi \
     ubase/prefs.cmi \
     path.cmi \
@@ -451,6 +452,7 @@ fswatch.cmx : \
     uutil.cmx \
     ubase/util.cmx \
     ubase/trace.cmx \
+    terminal.cmx \
     system.cmx \
     ubase/prefs.cmx \
     path.cmx \

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -242,11 +242,11 @@ OCAMLOBJS += \
           lwt/pqueue.cmo lwt/lwt.cmo lwt/lwt_util.cmo \
           lwt/$(SYSTEM)/lwt_unix_impl.cmo lwt/lwt_unix.cmo \
           \
-          features.cmo uutil.cmo case.cmo pred.cmo \
+          features.cmo uutil.cmo case.cmo pred.cmo terminal.cmo \
           fileutil.cmo name.cmo path.cmo fspath.cmo fs.cmo fingerprint.cmo \
           abort.cmo osx.cmo fswatch.cmo propsdata.cmo \
           props.cmo fileinfo.cmo os.cmo lock.cmo clroot.cmo common.cmo \
-          tree.cmo checksum.cmo terminal.cmo transfer.cmo xferhint.cmo \
+          tree.cmo checksum.cmo transfer.cmo xferhint.cmo \
           remote.cmo external.cmo negotiate.cmo globals.cmo fswatchold.cmo \
           fpcache.cmo update.cmo copy.cmo stasher.cmo \
 	  files.cmo sortri.cmo recon.cmo transport.cmo \

--- a/src/fsmonitor.py
+++ b/src/fsmonitor.py
@@ -323,7 +323,7 @@ if sys.platform == 'darwin':
             #make a list of all files in question (all files in path w/o dirs)
             try:
                     names = os.listdir(path)
-            except os.error, msg:
+            except os.error:
             #path does not exist (anymore?). Add it to the results
                     mydebug("adding nonexisting path %s for sync",path)
                     result.append(path)
@@ -541,7 +541,7 @@ if sys.platform == 'win32':
                         while 1:
                                 sleep(3600)
                 except KeyboardInterrupt:
-                        print "Cleaning up."
+                        print("Cleaning up.")
 
 #################################################
 # END Windows specific code

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -182,6 +182,9 @@ let perform_redirections new_stdin new_stdout new_stderr =
   Unix.dup2 newnewstderr Unix.stderr; Unix.close newnewstderr
 
 let rec safe_waitpid pid =
+  (* This function is intentionally synchronous so that it can be run during
+     cleanup code when Lwt threads might be stopped or otherwise be in an
+     unreliable state. *)
   let kill_noerr si = try Unix.kill pid si with Unix.Unix_error _ -> () in
   let t = Unix.gettimeofday () in
   let rec aux st =


### PR DESCRIPTION
Next in the series of cleaning up after yourself. Reap child processes and clean up resources if necessary.
(And fix some Python syntax errors.)