### PR TITLE
Set close-on-exec everywhere

### DIFF
--- a/src/copy.ml
+++ b/src/copy.ml
@@ -327,7 +327,7 @@ let openFileOut' fspath path kind len =
   match kind with
     `DATA ->
       let fullpath = Fspath.concat fspath path in
-      let flags = [Unix.O_WRONLY;Unix.O_CREAT] in
+      let flags = [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_CLOEXEC] in
       let perm = 0o600 in
       begin match Util.osType with
         `Win32 ->

--- a/src/fswatch.ml
+++ b/src/fswatch.ml
@@ -314,10 +314,8 @@ let connected () = !conn <> None
 let startProcess () =
   try
     let w = Lazy.force watcher in
-    let (i1,o1) = Lwt_unix.pipe_out () in
-    let (i2,o2) = Lwt_unix.pipe_in () in
-    Lwt_unix.set_close_on_exec i2;
-    Lwt_unix.set_close_on_exec o1;
+    let (i1,o1) = Lwt_unix.pipe_out ~cloexec:true () in
+    let (i2,o2) = Lwt_unix.pipe_in ~cloexec:true () in
     let pid = Util.convertUnixErrorsToFatal "starting filesystem watcher"
       (fun () -> System.create_process w [|w|] i1 o2 Unix.stderr) in
     Unix.close i1; Unix.close o2;

--- a/src/lwt/generic/lwt_unix_impl.ml
+++ b/src/lwt/generic/lwt_unix_impl.ml
@@ -155,7 +155,7 @@ let rec run thread =
              | `Accept res ->
                   wrap_syscall inputs fd res
                     (fun () ->
-                       let (s, _) as v = Unix.accept fd in
+                       let (s, _) as v = Unix.accept ~cloexec:true fd in
                        if not windows_hack then Unix.set_nonblock s;
                        v)
              | `Wait res ->
@@ -257,20 +257,20 @@ let pipe () =
   fd_pair
 *)
 
-let pipe_in () =
-  let (in_fd, out_fd) as fd_pair = Unix.pipe() in
+let pipe_in ?cloexec () =
+  let (in_fd, out_fd) as fd_pair = Unix.pipe ?cloexec () in
   if not windows_hack then
     Unix.set_nonblock in_fd;
   fd_pair
 
-let pipe_out () =
-  let (in_fd, out_fd) as fd_pair = Unix.pipe() in
+let pipe_out ?cloexec () =
+  let (in_fd, out_fd) as fd_pair = Unix.pipe ?cloexec () in
   if not windows_hack then
     Unix.set_nonblock out_fd;
   fd_pair
 
-let socket dom typ proto =
-  let s = Unix.socket dom typ proto in
+let socket ?cloexec dom typ proto =
+  let s = Unix.socket ?cloexec dom typ proto in
   if not windows_hack then Unix.set_nonblock s;
   s
 

--- a/src/lwt/lwt_unix.mli
+++ b/src/lwt/lwt_unix.mli
@@ -39,10 +39,10 @@ val write : file_descr -> bytes -> int -> int -> int Lwt.t
 val write_substring : file_descr -> string -> int -> int -> int Lwt.t
 val wait_read : file_descr -> unit Lwt.t
 val wait_write : file_descr -> unit Lwt.t
-val pipe_in : unit -> file_descr * Unix.file_descr
-val pipe_out : unit -> Unix.file_descr * file_descr
+val pipe_in : ?cloexec:bool -> unit -> file_descr * Unix.file_descr
+val pipe_out : ?cloexec:bool -> unit -> Unix.file_descr * file_descr
 val socket :
-  Unix.socket_domain -> Unix.socket_type -> int -> file_descr
+  ?cloexec:bool -> Unix.socket_domain -> Unix.socket_type -> int -> file_descr
 val bind : file_descr -> Unix.sockaddr -> unit
 val setsockopt : file_descr -> Unix.socket_bool_option -> bool -> unit
 val accept : file_descr -> (file_descr * Unix.sockaddr) Lwt.t

--- a/src/osx.ml
+++ b/src/osx.ml
@@ -509,7 +509,7 @@ let openRessIn fspath path =
       Unix.in_channel_of_descr
         (Fs.openfile
            (Fspath.concat fspath (ressPath path))
-           [Unix.O_RDONLY] 0o444)
+           [Unix.O_RDONLY; O_CLOEXEC] 0o444)
     with Unix.Unix_error ((Unix.ENOENT | Unix.ENOTDIR), _, _) ->
       let (doublePath, inch, entries) = openDouble fspath path in
       try
@@ -527,7 +527,7 @@ let openRessOut fspath path length =
       let p = Fspath.concat fspath (ressPath path) in
       debug (fun () -> Util.msg "openRessOut %s\n" (Fspath.toString p));
       Unix.out_channel_of_descr
-        (Fs.openfile p [Unix.O_WRONLY;Unix.O_CREAT] 0o600)
+        (Fs.openfile p [Unix.O_WRONLY; O_CREAT; O_CLOEXEC] 0o600)
     with Unix.Unix_error ((Unix.ENOENT | Unix.ENOTDIR), _, _) ->
       debug (fun () -> Util.msg "Opening AppleDouble file for resource fork\n");
       let path = Fspath.appleDouble (Fspath.concat fspath path) in

--- a/src/props_xattr.c
+++ b/src/props_xattr.c
@@ -176,6 +176,10 @@
 #define UNSN_HAS_XATTR
 #endif
 
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
 #define UNSN_XATTR_NOT_SUPPORTED_EX "XattrNotSupported"
 
 
@@ -380,7 +384,7 @@ static int unsn_set_xattr_os(const char *path, const char *attrname,
    * This implementation does not synchronize any of those params,
    * as xattrs are conceptually treated as name-value pairs.
    * It is unknown if this will cause problems with real use cases. */
-  int fd = attropen(path, attrname, O_CREAT|O_WRONLY|O_TRUNC);
+  int fd = attropen(path, attrname, O_CREAT|O_WRONLY|O_TRUNC|O_CLOEXEC);
   if (fd == -1) {
     unsn_xattr_fail("Error opening extended attribute for writing: %s");
   }
@@ -441,7 +445,7 @@ static int unsn_remove_xattr_os(const char *path, const char *attrname)
     unsn_xattr_not_supported();
   }
 
-  int fd = attropen(path, ".", O_RDONLY);
+  int fd = attropen(path, ".", O_RDONLY|O_CLOEXEC);
   if (fd == -1) {
     unsn_xattr_fail("Error opening extended attribute for removing: %s");
   }
@@ -484,7 +488,7 @@ static ssize_t unsn_length_xattr_os(const char *path, const char *attrname)
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
   return extattr_get_file(path, EXTATTR_NAMESPACE_USER, attrname, NULL, 0);
 #elif defined(__Solaris__)
-  int fd = attropen(path, attrname, O_RDONLY);
+  int fd = attropen(path, attrname, O_RDONLY|O_CLOEXEC);
   if (fd == -1) {
     unsn_xattr_fail("Error opening extended attribute for querying length: %s");
   }
@@ -513,7 +517,7 @@ static ssize_t unsn_get_xattr_os(const char *path, const char *attrname,
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
   return extattr_get_file(path, EXTATTR_NAMESPACE_USER, attrname, buf, size);
 #elif defined(__Solaris__)
-  int fd = attropen(path, attrname, O_RDONLY);
+  int fd = attropen(path, attrname, O_RDONLY|O_CLOEXEC);
   if (fd == -1) {
     unsn_xattr_fail("Error opening extended attribute for reading: %s");
   }
@@ -648,7 +652,7 @@ static ssize_t unsn_list_xattr_aux(const char *path, DIR **dirp)
     return 0;
   }
 
-  int fd = attropen(path, ".", O_RDONLY);
+  int fd = attropen(path, ".", O_RDONLY|O_CLOEXEC);
   if (fd == -1) {
     unsn_list_xattr_fail();
   }

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -1651,7 +1651,7 @@ let buildSocket host port kind ?(err="") ai =
     Lwt.catch
       (fun () ->
          let socket =
-           Lwt_unix.socket
+           Lwt_unix.socket ~cloexec:true
              ai.Unix.ai_family ai.Unix.ai_socktype ai.Unix.ai_protocol
          in
          Lwt.catch
@@ -1830,13 +1830,11 @@ let buildShellConnection shell host userOpt portOpt rootName termInteract =
     Safelist.concat
       (Safelist.map (fun s -> Util.splitIntoWords s ' ') preargs) in
   let argsarray = Array.of_list args in
-  let (i1,o1) = Lwt_unix.pipe_out () in
-  let (i2,o2) = Lwt_unix.pipe_in () in
+  let (i1,o1) = Lwt_unix.pipe_out ~cloexec:true () in
+  let (i2,o2) = Lwt_unix.pipe_in ~cloexec:true () in
   (* We need to make sure that there is only one reader and one
      writer by pipe, so that, when one side of the connection
      dies, the other side receives an EOF or a SIGPIPE. *)
-  Lwt_unix.set_close_on_exec i2;
-  Lwt_unix.set_close_on_exec o1;
   (* We add CYGWIN=binmode to the environment before calling
      ssh because the cygwin implementation on Windows sometimes
      puts the pipe in text mode (which does end of line
@@ -2089,13 +2087,11 @@ let openConnectionStart clroot =
             Safelist.concat
               (Safelist.map (fun s -> Util.splitIntoWords s ' ') preargs) in
           let argsarray = Array.of_list args in
-          let (i1,o1) = Lwt_unix.pipe_out() in
-          let (i2,o2) = Lwt_unix.pipe_in() in
+          let (i1,o1) = Lwt_unix.pipe_out ~cloexec:true () in
+          let (i2,o2) = Lwt_unix.pipe_in ~cloexec:true () in
           (* We need to make sure that there is only one reader and one
              writer by pipe, so that, when one side of the connection
              dies, the other side receives an EOF or a SIGPIPE. *)
-          Lwt_unix.set_close_on_exec i2;
-          Lwt_unix.set_close_on_exec o1;
           (* We add CYGWIN=binmode to the environment before calling
              ssh because the cygwin implementation on Windows sometimes
              puts the pipe in text mode (which does end of line

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -295,6 +295,8 @@ let unix_create_session cmd args new_stdin new_stdout new_stderr =
   match openpty () with
     None -> fallback_session cmd args new_stdin new_stdout new_stderr
   | Some (masterFd, slaveFd) ->
+      Unix.set_close_on_exec masterFd;
+      Unix.set_close_on_exec slaveFd;
 (*
       Printf.printf "openpty returns %d--%d\n" (dumpFd fdM) (dumpFd fdS); flush stdout;
       Printf.printf "new_stdin=%d, new_stdout=%d, new_stderr=%d\n"


### PR DESCRIPTION
Another simple hygiene patch. `keep-on-exec` is the default for historical reasons but it should be `close-on-exec` by default, of course.