### PR TITLE
Make repeat mode slightly fault tolerant

### DIFF
--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -809,8 +809,7 @@ let cmdLineRawRoots = ref []
 let clearClRoots () = cmdLineRawRoots := []
 
 (* BCP: WARNING: Some of the code from here is duplicated in uimacbridge...! *)
-let initPrefs ~profileName ~displayWaitMessage ~promptForRoots
-              ?(prepDebug = fun () -> ()) ~termInteract () =
+let initPrefs ~profileName ~promptForRoots ?(prepDebug = fun () -> ()) () =
   initComplete := false;
   (* Restore prefs to their default values *)
   Prefs.resetToDefaults ();
@@ -920,16 +919,15 @@ let initPrefs ~profileName ~displayWaitMessage ~promptForRoots
   (* If no paths were specified, then synchronize the whole replicas *)
   if Prefs.read Globals.paths = [] then Prefs.set Globals.paths [Path.empty];
 
-  initRoots displayWaitMessage termInteract;
-
   initComplete := true
 
-let refreshConnection ~displayWaitMessage ~termInteract =
-  if !initComplete &&  (Safelist.length (Globals.rawRoots ()) > 1) then
+let connectRoots ?termInteract ~displayWaitMessage () =
+  let numRoots = Safelist.length (Globals.rawRoots ()) in
+  if !initComplete && numRoots > 1 then
   let numConn = ref 0 in
   Lwt_unix.run (Globals.allRootsIter
     (fun r -> if Remote.isRootConnected r then incr numConn; Lwt.return ()));
-  if !numConn < 2 then initRoots displayWaitMessage termInteract
+  if !numConn < numRoots then initRoots displayWaitMessage termInteract
 
 (**********************************************************************
                        Common startup sequence

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -100,22 +100,20 @@ val uiInitClRootsAndProfile :
 
 val initPrefs :
   profileName:string ->
-  displayWaitMessage:(unit->unit) ->
   promptForRoots:(unit -> (string * string) option) ->
   ?prepDebug:(unit -> unit) ->
-  termInteract:(string -> string -> string) option ->
   unit ->
   unit
 
 val clearClRoots : unit -> unit
 
 (* Make sure remote connections (if any) corresponding to active roots
-   are still established and re-establish them if necessary.
-   [refreshConnection] is like [initPrefs] but without reloading the profile
-   and re-initializing the prefs. *)
-val refreshConnection :
+   are established and (re-)establish them if necessary.
+   [initPrefs] must be called before [connectRoots]. *)
+val connectRoots :
+  ?termInteract:(string -> string -> string) ->
   displayWaitMessage:(unit -> unit) ->
-  termInteract:(string -> string -> string) option ->
+  unit ->
   unit
 
 val validateAndFixupPrefs : unit -> unit Lwt.t

--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -943,7 +943,7 @@ let getPassword rootName msg =
   | `OK                   -> pwd
   end
 
-let termInteract = Some getPassword
+let termInteract = getPassword
 
 (* ------ *)
 
@@ -4001,9 +4001,10 @@ let createToplevelWindow () =
     Trace.status "Loading profile";
     unsynchronizedPaths := None;
     profileInitSuccess := false;
-    Uicommon.initPrefs ~profileName:p
+    Uicommon.initPrefs ~profileName:p ~promptForRoots ~prepDebug ();
+    Uicommon.connectRoots
       ~displayWaitMessage:(fun () -> if not reload then displayWaitMessage ())
-      ~promptForRoots ~prepDebug ~termInteract ();
+      ~termInteract ();
     profileInitSuccess := true;
     !updateFromProfile ()
   in
@@ -4017,7 +4018,7 @@ let createToplevelWindow () =
     clearMainWindow ();
     if not (Prefs.profileUnchanged ()) || not (!profileInitSuccess) then
       loadProfile n true
-    else Uicommon.refreshConnection ~displayWaitMessage ~termInteract
+    else Uicommon.connectRoots ~displayWaitMessage ~termInteract ()
   in
 
   let detectCmd () =


### PR DESCRIPTION
Unison has a concept of distinguishing transient errors and fatal errors. Due to historical reasons (I think), fatal errors were not treated as fatal to the sync attempt but fatal to the entire process. This does make sense for the one-shot CLI sync but it does not make sense for repeat mode or for the GUI.

This approach had the unfortunate consequence of the code leaking resources and not cleaning up to keep shared persistent state consistent after a fatal error. It simply didn't matter because the process was going to be terminated anyway.

For the GUI, this was partially fixed some time ago: #649. The fatal errors are no longer fatal to the entire process and the GUI can keep running. But proper cleanup was still missing and resource leaks were still there.

Series of commits recently merged (mainly #809) have added cleanups and plugged resource leaks. I can't be sure that everything has been covered now but I feel comfortable enough to open this PR - keeping the repeat mode in TUI running even in case of (some) fatal errors.

Review is best done commit by commit.