### PR TITLE
opam/dune: Reset maintainer

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -8,7 +8,7 @@
 
 (license GPL-3.0-or-later)
 
-(maintainers "juergen@hoetzel.info")
+(maintainers "unison-hackers@lists.seas.upenn.edu")
 
 (authors "Trevor Jim" "Benjamin C. Pierce" "J\195\169r\195\180me Vouillon")
 

--- a/unison.opam
+++ b/unison.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "juergen@hoetzel.info"
+maintainer: "unison-hackers@lists.seas.upenn.edu"
 authors: [
   "Trevor Jim"
   "Benjamin C. Pierce"


### PR DESCRIPTION
The previous maintainer is no longer active, so replace the email address with the hackers list as a way to denote that they are maintained within the project.