### PR TITLE
Detect Wayland or X11 displays before choosing text UI

### DIFF
--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -4477,11 +4477,14 @@ let start = function
       let displayAvailable =
         Util.osType = `Win32
           ||
-        try System.getenv "DISPLAY" <> "" with Not_found -> false
+            (let x11_display = try Sys.getenv "DISPLAY" with Not_found -> ""
+            and wayland_display = try Sys.getenv "WAYLAND_DISPLAY" with Not_found -> ""
+            in
+              x11_display != "" || wayland_display != "")
       in
       if displayAvailable then Private.start Uicommon.Graphic
       else begin
-        Util.warn "DISPLAY not set or empty; starting the Text UI\n";
+        Util.warn "DISPLAY and WAYLAND_DISPLAY not set or empty; starting the Text UI\n";
         Uitext.Body.start Uicommon.Text
       end
 

--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -4477,10 +4477,9 @@ let start = function
       let displayAvailable =
         Util.osType = `Win32
           ||
-            (let x11_display = try Sys.getenv "DISPLAY" with Not_found -> ""
-            and wayland_display = try Sys.getenv "WAYLAND_DISPLAY" with Not_found -> ""
-            in
-              x11_display != "" || wayland_display != "")
+        (try System.getenv "DISPLAY" <> "" with Not_found -> false)
+          ||
+        (try System.getenv "WAYLAND_DISPLAY" <> "" with Not_found -> false)
       in
       if displayAvailable then Private.start Uicommon.Graphic
       else begin


### PR DESCRIPTION
Otherwise, Unison will not start its graphical interface when running in a pure-Wayland environment.