### PR TITLE
Get the POSIX strerror_r(3) definition with glibc

### DIFF
--- a/src/props_xattr.c
+++ b/src/props_xattr.c
@@ -160,6 +160,16 @@
  *
  */
 
+/* To get the correct definition of strerror_r(3) with glibc. */
+#if !defined(_POSIX_C_SOURCE) || defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE
+#endif
+
+
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>


### PR DESCRIPTION
glibc includes a non-POSIX version of strerror_r(3). POSIX-compliant version of strerror_r(3) is the default but some feature test macros must be defined in case CFLAGS change the default settings.

The same result could be achieved by just defining _DEFAULT_SOURCE but this is available only since glibc 2.19.