### PR TITLE
Fix another resource leak

### DIFF
--- a/src/remote.ml
+++ b/src/remote.ml
@@ -2134,12 +2134,12 @@ let openConnectionEnd (i1,i2,o1,o2,s,fdopt,clroot,pid) =
          Lwt.return ())
 
 let openConnectionCancel (i1,i2,o1,o2,s,fdopt,clroot,pid) =
-      try Unix.kill pid Sys.sigkill with Unix.Unix_error _ -> ();
-      try Unix.close i1 with Unix.Unix_error _ -> ();
-      try Lwt_unix.close i2 with Unix.Unix_error _ -> ();
-      try Lwt_unix.close o1 with Unix.Unix_error _ -> ();
-      try Unix.close o2 with Unix.Unix_error _ -> ();
-      try Terminal.close_session pid with Unix.Unix_error _ -> ()
+  (try Unix.kill pid Sys.sigkill with Unix.Unix_error _ -> ());
+  (try Unix.close i1 with Unix.Unix_error _ -> ());
+  (try Lwt_unix.close i2 with Unix.Unix_error _ -> ());
+  (try Lwt_unix.close o1 with Unix.Unix_error _ -> ());
+  (try Unix.close o2 with Unix.Unix_error _ -> ());
+  (try Terminal.close_session pid with Unix.Unix_error _ -> ())
 
 (****************************************************************************)
 (*                     SERVER-MODE COMMAND PROCESSING LOOP                  *)


### PR DESCRIPTION
Operator `;` has higher precedence than `try`. The code looked like it was doing the right thing but it would actually execute each following `close` only if the previous `close` failed. In the normal case all of these descriptors were leaked.

This code is currently used only by the native macOS GUI. I do not have the possibility to test this GUI.