### PR TITLE
Fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -200,7 +200,7 @@ Released 2020-10-21
 
 ## Changes in very old versions
 
-(Note that these are written 'Chagnes since' and thus the content
+(Note that these are written 'Changes since' and thus the content
 applies to the release after that.)
 
    Changes since 2.40.63:
@@ -789,7 +789,7 @@ applies to the release after that.)
           + Ignore trailing dots in filenames in case insensitive mode
           + Proper quoting of paths, files and extensions ignored using
             the UI
-          + The strings CURRENT1 and CURRENT2 are now correctly substitued
+          + The strings CURRENT1 and CURRENT2 are now correctly substituted
             when they occur in the diff preference
           + Improvements to syncing resource forks between Macs via a
             non-Mac system.
@@ -1427,7 +1427,7 @@ applies to the release after that.)
             preference is a mask indicating which permission bits should
             be synchronized. It is set by default to 0o1777: all bits but
             the set-uid and set-gid bits are synchronised (synchronizing
-            theses latter bits can be a security hazard). If you want to
+            these latter bits can be a security hazard). If you want to
             synchronize all bits, you can set the value of this preference
             to -1.
           + Added a log preference (default false), which makes Unison
@@ -1529,7 +1529,7 @@ applies to the release after that.)
             paths matching this pattern to be displayed last.
        The sorting preferences are described in more detail in the user
        manual. The sortnewfirst and sortbysize flags can also be accessed
-       from the 'Sort' menu in the grpahical user interface.
+       from the 'Sort' menu in the graphical user interface.
      * Added two new preferences that can be used to change unison's
        fundamental behavior to make it more like a mirroring tool instead
        of a synchronizer.

--- a/doc/hevea.sty
+++ b/doc/hevea.sty
@@ -1,11 +1,11 @@
-% htmlgen Verion 0.0 : html.sty
+% htmlgen Version 0.0 : html.sty
 % This is a very basic style file for latex document to be processed
 % with htmlgen. It contains definitions of LaTeX commands which are
 % processed in a special way by the translator.
 %  Mostly :
 %     - environment latexonly, not processed by htmlgen, processed by latex.
 %     - environment htmlonly , the reverse
-%      - environemnt htmlraw,  to include raw HTML in hevea output.
+%      - environment htmlraw,  to include raw HTML in hevea output.
 %
 \makeatletter%
 
@@ -148,13 +148,13 @@
 % Basic approach:
 % to comment something out, scoop up  every line in verbatim mode
 % as macro argument, then throw it away.
-% For inclusions, both the opening and closing comands
+% For inclusions, both the opening and closing commands
 % are defined as noop
 %
 % Changed \next to \html@next to prevent clashes with other sty files
 % (mike@emn.fr)
 % Changed \html@next to \htmlnext so the \makeatletter and
-% \makeatother commands could be removed (they were cuasing other
+% \makeatother commands could be removed (they were causing other
 % style files - changebar.sty - to crash) (nikos@cbl.leeds.ac.uk)
 
 

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1516,7 +1516,7 @@ A similar line of the form \texttt{source \ARG{name}} does the same except
 that it does not attempt to add a suffix to \ARG{name}.
 Similar lines of the form \texttt{include\mbox{?} \ARG{name}} or
 \texttt{source\mbox{?} \ARG{name}} do the same as their respective lines
-without the question mark except that it does not constitue an error to
+without the question mark except that it does not constitute an error to
 specify a non-existing file \ARG{name}.
 In \ARG{name} the backslash is an escape character.
 
@@ -1981,7 +1981,7 @@ without doing proper cleanup; it is therefore not recommended unless the
 
 \begin{textui}
 When not synchronizing continuously, the text interface terminates when
-synchronization is finished normally or due to a fatal error occuring.
+synchronization is finished normally or due to a fatal error occurring.
 
 In the text interface, to interrupt synchronization before it is finished,
 press ``Ctrl-C'' (or send signal \verb|SIGINT| or \verb|SIGTERM|). This will
@@ -2214,7 +2214,7 @@ Unix system).
 \item For security reasons, the Unix \verb|setuid| and \verb|setgid|
 bits are not propagated.
 \item The Unix owner and group ids can be propagated (see \verb|owner|
-and \verb|group| preferences) by mapping names or by numberic ids (see
+and \verb|group| preferences) by mapping names or by numeric ids (see
 \verb|numericids| preference).
 \end{itemize}
 

--- a/man/unison.1.in
+++ b/man/unison.1.in
@@ -284,7 +284,7 @@ When Unison starts, it first reads the profile and then the command line, so
 command-line options will override settings from the profile.
 .Sh TERMINATION
 When not synchronizing continuously, the text interface terminates when
-synchronization is finished normally or due to a fatal error occuring.
+synchronization is finished normally or due to a fatal error occurring.
 .Pp
 In the text interface, to interrupt synchronization before it is finished,
 press
@@ -379,7 +379,7 @@ option.
 .Pp
 .It Pa ~/.unison/fp*
 Fingerprint cache files. These files may be safely deleted. Keep in mind that
-deleting a fingerprint cache file means that any unsychronized changes must be
+deleting a fingerprint cache file means that any unsynchronized changes must be
 scanned again. Depending on your replicas, this may mean scanning gigabytes of
 file contents.
 .Pp

--- a/src/FEATURES.md
+++ b/src/FEATURES.md
@@ -103,7 +103,7 @@ at runtime for each remote connection.
 
 For example:
 
-- Existing code implementes feature hash-1.
+- Existing code implements feature hash-1.
 - New code implements a new hashing algorithm and adds feature hash-2.
 - Even though two different hashing algorithms must not be used at the
   same time, both implementations can co-exist as in the following

--- a/src/INSTALL.win32-msvc
+++ b/src/INSTALL.win32-msvc
@@ -218,7 +218,7 @@ above the 'lablgtk' directory.
 
   The way from public Gtk/LablGtk sources to the provided Gtk/LablGtk
 dynamic/static extension has been somehow perilous. We strongly
-recommand using the provided sources and patches as a base for your
+recommend using the provided sources and patches as a base for your
 further enhancements.
 
   To be exhaustive, here are the steps followed to create the provided

--- a/src/ROADMAP.txt
+++ b/src/ROADMAP.txt
@@ -30,7 +30,7 @@ look next.  Here's a summary of the most interesting modules:
 
 The files linktext.ml and linkgtk.ml contain linking commands for
 assembling unision with either a textual or a graphical user interface.
-(The Main module, which takes the UI as a paramter, is the only part of
+(The Main module, which takes the UI as a parameter, is the only part of
 the program that is functorized.)
 
 The module Remote handles RPC communication between clients and remote

--- a/src/TODO.txt
+++ b/src/TODO.txt
@@ -25,7 +25,7 @@ promise that anybody is going to implement it!)
          - sort the list
          - if there are any adjacent pairs where the first is a prefix of the
            second, drop the second and mark the first as deep
-         - go through the list and drop any item for whioch any PREFIX of
+         - go through the list and drop any item for which any PREFIX of
            its path matches 'ignore' and doesn't match 'ignorenot'
      - bulletproof, handling fatal errors and restarting completely from
        scratch if necessary
@@ -94,7 +94,7 @@ It would be nice if Unison could have the "power" to copy write-protected
 * If a directory does not exist in one of the host, unison (for
   security reasons, which I like) pops up a window and Quit is the only
   option. I would expect a message stating mere clearly on which host and
-  direcory and an option to create that directory. I had recently to make
+  directory and an option to create that directory. I had recently to make
   a lot of reinstalls and new pendrives and it took a long time to create
   all those dirs. Someone in the list even made a script to do the job!!!
 
@@ -265,7 +265,7 @@ should strip symbols from binary files in 'make exportnative'
 *** If a root resides on a `host' with an ever and unpredictably changing
     host name (like a public login cluster with dozens of machines and a
     shared file system), listing each possible host name for this root is
-    not feasible.  The ability of specifing patterns in rootaliases would
+    not feasible.  The ability of specifying patterns in rootaliases would
     help a lot in this case.  I'm thinking of something like this:
     rootalias = //.*//afs/cern.ch/user/n/nagya ->
     //cern.ch//afs/cern.ch/user/n/nagya [NAGY Andras <nagya@inf.elte.hu>,
@@ -376,7 +376,7 @@ should strip symbols from binary files in 'make exportnative'
   specify a user (and similarly a group) to unison.  It would be
   interpreted in a special way: if a file is owned by this user, unison
   will rather consider that the owner of the file is undefined.  So, when
-  a file owned by an unkown user is synchronized, the file owner is set
+  a file owned by an unknown user is synchronized, the file owner is set
   to the default user.  Then, on the next synchronizations, unison will
   consider that the owner has not been propagated and try again.  [Should
   be easy once the reconciler is made more modular]

--- a/src/abort.mli
+++ b/src/abort.mli
@@ -15,5 +15,5 @@ val checkAll : unit -> unit (* Raises a transient exception *)
    raised if this is the case. *)
 val check : Uutil.File.t -> unit
 
-(* Test whether the exeption is an abort exception. *)
+(* Test whether the exception is an abort exception. *)
 val testException : exn -> bool

--- a/src/fsmonitor/windows/watcher.ml
+++ b/src/fsmonitor/windows/watcher.ml
@@ -80,7 +80,7 @@ let rec follow_win_path_parent root dir path pos =
 
 let get_win_path root dir ((ev_path, act) as ev) =
   (* Blindly expand the event path to long names form. If event path
-     is not found among the watched patchs then try to find the nearest
+     is not found among the watched paths then try to find the nearest
      parent directory and report a modification on it. MSDN states the
      following: "If there is both a short and long name for the file,
      [Lwt_win.readdirectorychanges] will return one of these names,

--- a/src/fspath.ml
+++ b/src/fspath.ml
@@ -335,7 +335,7 @@ let findWorkingDir fspath path =
       try
         (* Relevant on Windows: We can (and should) use [extendedPath] only
            on the very first input, which is known to satisfy [Fspath.t]
-           invariants. Inputs used for all following loops come from the ouput
+           invariants. Inputs used for all following loops come from the output
            of [readlink] either without any processing done on it (if the link
            is an absolute path) - such paths are potentially unsuitable as
            input to [extendedPath] - or already extended (when concatenating

--- a/src/fswatch.ml
+++ b/src/fswatch.ml
@@ -64,7 +64,7 @@ Protocol description
   only further changes.
 
   Unison can wait for changes in a replica by emitting a 'WAIT hash'
-  command. It can watch several replicas by sending a serie of these
+  command. It can watch several replicas by sending a series of these
   commands. The child process is expected to respond once, by a
   'CHANGE hash1 ... hash2' response that lists the changed replicas
   among those included in a 'WAIT' command, when changes are

--- a/src/lwt/example/relay.ml
+++ b/src/lwt/example/relay.ml
@@ -24,7 +24,7 @@ let relay in_ch out_ch =
     (* If we read nothing, this means that the connection has been
        closed.  In this case, we stop relaying. *)
     if len = 0 then return () else begin
-      (* Otherwise, we write the data to the ouput socket *)
+      (* Otherwise, we write the data to the output socket *)
       let write =
         (* First wait for the previous write to terminate *)
         previous_write >>= (fun () ->

--- a/src/lwt/generic/lwt_unix_impl.ml
+++ b/src/lwt/generic/lwt_unix_impl.ml
@@ -1,6 +1,6 @@
 (*
 Non-blocking I/O and select does not (fully) work under Windows.
-The libray therefore does not use them under Windows, and will
+The library therefore does not use them under Windows, and will
 therefore have the following limitations:
 - No read will be performed while there are some threads ready to run
   or waiting to write;

--- a/src/lwt/lwt.mli
+++ b/src/lwt/lwt.mli
@@ -41,12 +41,12 @@ val try_bind : (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
 
 val choose : 'a t list -> 'a t
       (* [choose l] behaves as the first thread in [l] to terminate.
-         If several threads are already terminated, one is choosen
+         If several threads are already terminated, one is chosen
          at random. *)
 
 val ignore_result : 'a t -> unit
       (* [ignore_result t] start the thread [t] and ignores its result
-         value if the thread terminates sucessfully.  However, if the
+         value if the thread terminates successfully.  However, if the
          thread [t] fails, the exception is raised instead of being
          ignored.
          You should use this function if you want to start a thread

--- a/src/props.ml
+++ b/src/props.ml
@@ -89,7 +89,7 @@ let permMask =
     "The integer value of this preference is a mask indicating which \
      permission bits should be synchronized.  It is set by default to \
      $0o1777$: all bits but the set-uid and set-gid bits are \
-     synchronised (synchronizing theses latter bits can be a security \
+     synchronised (synchronizing these latter bits can be a security \
      hazard).  If you want to synchronize all bits, you can set the \
      value of this preference to $-1$.  If one of the replica is on \
      a FAT [Windows] filesystem, you should consider using the \

--- a/src/props_acl.c
+++ b/src/props_acl.c
@@ -445,7 +445,7 @@ CAMLprim value unison_acl_to_text(value path)
       LocalFree(sd);
 
 #ifdef ACL_DEBUG
-      printf_s(" ---> Empty ACL (no explict ACE, may have inherited ACE)\n");
+      printf_s(" ---> Empty ACL (no explicit ACE, may have inherited ACE)\n");
 #endif
       CAMLreturn(UNSN_ACL_EMPTY); /* Empty ACL (or only inherited) */
     }

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -618,7 +618,7 @@ let clientCloseRootConnection = function
 
 (* Implemented as a record to avoid polluting [Remote] namespace. If
    the number and complexity of functions grows in future then it's
-   propably a good idea to extract this code into a separate module. *)
+   probably a good idea to extract this code into a separate module. *)
 type ('a, 'b, 'c) resourceC =
   { register : 'a -> 'a; release : 'a -> 'b; release_noerr : 'a -> 'c }
 let resourceWithConnCleanup close close_noerr =
@@ -1334,11 +1334,11 @@ let sendHandshakeData conn keyw data =
       * If NOK then closes connection.
 
    3. Client receives and verifies RPC versions.
-      * If not correct verion tag or can't parse then closes connection.
+      * If not correct version tag or can't parse then closes connection.
 
    4. Client selects a version (typically the most recent one) from the
       intersection of its supported RPC versions and server's RPC versions.
-      * If interesection is empty then closes connection.
+      * If intersection is empty then closes connection.
 
    5. Client sends selected RPC version to the server.
 
@@ -1589,7 +1589,7 @@ let negociateFlowControlRemote =
   registerServerCmd "negociateFlowControl" Umarshal.unit Umarshal.bool negociateFlowControlLocal
 
 let negociateFlowControl conn =
-  (* Flow control negociation can be done asynchronously. *)
+  (* Flow control negotiation can be done asynchronously. *)
   if not (Prefs.read halfduplex) then
     Lwt.ignore_result
       (negociateFlowControlRemote conn () >>= fun needed ->

--- a/src/stasher.ml
+++ b/src/stasher.ml
@@ -158,7 +158,7 @@ let backupcurrent =
      ^ "matching \\ARG{pathspec}.  "
      ^" This file will be saved as a backup with version number 000. Such"
      ^" backups can be used as inputs to external merging programs, for instance.  See "
-     ^ "the documentatation for the \\verb|merge| preference."
+     ^ "the documentation for the \\verb|merge| preference."
      ^" For more details, see \\sectionref{merge}{Merging Conflicting Versions}."
      ^"\n\n The syntax of \\ARG{pathspec} is described in "
      ^ "\\sectionref{pathspec}{Path Specification}.")

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -1474,7 +1474,7 @@ let docs =
       \032         keep a backup of the current version of every file matching\n\
       \032         pathspec. This file will be saved as a backup with version\n\
       \032         number 000. Such backups can be used as inputs to external\n\
-      \032         merging programs, for instance. See the documentatation for the\n\
+      \032         merging programs, for instance. See the documentation for the\n\
       \032         merge preference. For more details, see the section \226\128\156Merging\n\
       \032         Conflicting Versions\226\128\157 .\n\
       \n\
@@ -1955,7 +1955,7 @@ let docs =
       \032         low-bandwidth link it may be helpful to set it lower (e.g. to 1)\n\
       \032         so that Unison doesn\226\128\153t soak up all the available bandwidth. The\n\
       \032         default is the special value 0, which mean 20 threads when file\n\
-      \032         content streaming is desactivated and 1000 threads when it is\n\
+      \032         content streaming is deactivated and 1000 threads when it is\n\
       \032         activated.\n\
       \n\
       \032  merge xxx\n\
@@ -2040,7 +2040,7 @@ let docs =
       \032         The integer value of this preference is a mask indicating which\n\
       \032         permission bits should be synchronized. It is set by default to\n\
       \032         0o1777: all bits but the set-uid and set-gid bits are\n\
-      \032         synchronised (synchronizing theses latter bits can be a security\n\
+      \032         synchronised (synchronizing these latter bits can be a security\n\
       \032         hazard). If you want to synchronize all bits, you can set the\n\
       \032         value of this preference to \226\136\1461. If one of the replica is on a\n\
       \032         FAT [Windows] filesystem, you should consider using the fat\n\
@@ -2336,7 +2336,7 @@ let docs =
       \032  similar line of the form source name does the same except that it does\n\
       \032  not attempt to add a suffix to name. Similar lines of the form include?\n\
       \032  name or source? name do the same as their respective lines without the\n\
-      \032  question mark except that it does not constitue an error to specify a\n\
+      \032  question mark except that it does not constitute an error to specify a\n\
       \032  non-existing file name. In name the backslash is an escape character.\n\
       \n\
       \032  A profile may include a preference \226\128\152label = desc\226\128\153 to provide a\n\
@@ -2748,7 +2748,7 @@ let docs =
       \032  Textual Interface:\n\
       \032    * When not synchronizing continuously, the text interface terminates\n\
       \032      when synchronization is finished normally or due to a fatal error\n\
-      \032      occuring.\n\
+      \032      occurring.\n\
       \032      In the text interface, to interrupt synchronization before it is\n\
       \032      finished, press \226\128\156Ctrl-C\226\128\157 (or send signal SIGINT or SIGTERM). This\n\
       \032      will interrupt update propagation as quickly as possible but still\n\
@@ -2951,7 +2951,7 @@ let docs =
       \032    * For security reasons, the Unix setuid and setgid bits are not\n\
       \032      propagated.\n\
       \032    * The Unix owner and group ids can be propagated (see owner and group\n\
-      \032      preferences) by mapping names or by numberic ids (see numericids\n\
+      \032      preferences) by mapping names or by numeric ids (see numericids\n\
       \032      preference).\n\
       \n\
       Access Control Lists - ACLs\n\

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -452,13 +452,13 @@ let handlePasswordRequests (fdIn, fdOut) callback isReady =
       let d = (Unix.gettimeofday ()) -. !time in
       if d < delay
         || Buffer.length scrollback = 0 then
-      (* HACK: Delay briefly (0.2 s, noticable to a human but not terrible
+      (* HACK: Delay briefly (0.2 s, noticeable to a human but not terrible
          either since some delay from the network is expected anyway) to allow
          time for output to be generated and read in as a whole. Otherwise, it
          may happen that 'Invalid password' and 'Please re-enter password'
          prompts are received separately, and this is not what we want.
          Loop by 0.01 s to let other threads run while not introducing
-         noticable latency to the user. *)
+         noticeable latency to the user. *)
       Lwt_unix.sleep (max (delay -. (max 0. d)) 0.01) >>= prompt
     else
       let query = extract () in

--- a/src/transport.ml
+++ b/src/transport.ml
@@ -45,7 +45,7 @@ let maxthreads =
       low-bandwidth link it may be helpful to set it lower (e.g. \
       to 1) so that Unison doesn't soak up all the available bandwidth. \
       The default is the special value 0, which mean 20 threads \
-      when file content streaming is desactivated and 1000 threads \
+      when file content streaming is deactivated and 1000 threads \
       when it is activated.")
 
 let maxThreads () =

--- a/src/transport.mli
+++ b/src/transport.mli
@@ -4,7 +4,7 @@
 (* Size of the pool of threads for executing transport actions. *)
 val maxThreads : unit -> int
 
-(* Run tasks concurrently in a pool of threads, aquiring tasks with
+(* Run tasks concurrently in a pool of threads, acquiring tasks with
    the supplied task dispenser function. The tasks received from
    the task dispenser must not raise uncaught exceptions or return
    with [Lwt.fail]. *)

--- a/src/uimac/MyController.m
+++ b/src/uimac/MyController.m
@@ -960,7 +960,7 @@ CAMLprim value displayStatus(value s)
     [statusText setStringValue:s];
 }
 
-// Called from ocaml to dislpay progress bar
+// Called from ocaml to display progress bar
 CAMLprim value displayGlobalProgress(value p)
 {
   id pool = [[NSAutoreleasePool alloc] init];

--- a/src/uimac/cltool.c
+++ b/src/uimac/cltool.c
@@ -1,7 +1,7 @@
 /* cltool.c
 
    This is a command-line tool for Mac OS X that looks up the unison
-   application, whereever it has been installed, and runs it.  This
+   application, wherever it has been installed, and runs it.  This
    is intended to be installed in a standard place (e.g.,
    /usr/bin/unison) to make it easy to invoke unison as a server, or
    to use unison from the command line when it has been installed with

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -501,7 +501,7 @@ let displayDiff title text =
 let displayDiffErr err = displayDiffErr (Unicode.protect err)
 
 (* If only properties have changed, we can't diff or merge.
-   'Can't diff' is produced (uicommon.ml) if diff is attemped
+   'Can't diff' is produced (uicommon.ml) if diff is attempted
    when either side has PropsChanged *)
 let filesAreDifferent status1 status2 =
   match status1, status2 with

--- a/src/unicode.mli
+++ b/src/unicode.mli
@@ -36,7 +36,7 @@ val from_utf_16 : string -> string
 val to_utf_16_filename : string -> string
 val from_utf_16_filename : string -> string
 
-(* Check wether the string contains only well-formed UTF-8 characters *)
+(* Check whether the string contains only well-formed UTF-8 characters *)
 val check_utf_8 : string -> bool
 
 (* Convert a string to UTF-8 by keeping all UTF-8 characters unchanged

--- a/src/update.ml
+++ b/src/update.ml
@@ -594,7 +594,7 @@ let storeArchiveLocal fspath thisRoot archive hash magic properties =
    It can be removed when this compatibility is no longer required. *)
 let loadedCompatArchive = ref []
 
-(* Remove the archieve under the root path [fspath] with archiveVersion [v] *)
+(* Remove the archive under the root path [fspath] with archiveVersion [v] *)
 let removeArchiveLocal ((fspath: Fspath.t), (v: archiveVersion)): unit Lwt.t =
   let f' name = Lwt.return (
      let fspath = Util.fileInUnisonDir name in
@@ -1627,7 +1627,7 @@ let directoryCheckContentUnchanged
        are updated anyway then the changes that failed to propagate may be
        missed at the next scan. If there is something to propagate then all
        archive changes must go through propagation. With the exception of
-       dirChangeFlag, which is safe to update without upating mtime. *)
+       dirChangeFlag, which is safe to update without updating mtime. *)
     if propsChanged then
       (archDesc, updated)
     else

--- a/src/update.mli
+++ b/src/update.mli
@@ -33,7 +33,7 @@ val getRootsName : unit -> string
    paths known not to be synchronized and a list of paths not to
    check. Returns structures describing dirty files/dirs (1 per path
    given in the -path preference). An option controls whether we
-   would like to use the external filesytem monitoring process. *)
+   would like to use the external filesystem monitoring process. *)
 val findUpdates :
   ?wantWatcher:bool ->
   (Path.t list * Path.t list) option ->


### PR DESCRIPTION
Found via:
- `codespell -S icons,.git -L cristal,projet,froms,fo,te,theri,couldn,ue,openin,nd`
- `typos --format brief`