### PR TITLE
Replace `ocamldep` invocation with `ocamlc -depend`

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -371,7 +371,7 @@ lwt/lwt_unix.cmx: lwt/$(SYSTEM)/lwt_unix_impl.cmx
 
 .PHONY: depend dependgraph
 depend::
-	ocamldep $(DEP_INCLFLAGS) *.mli *.ml */*.ml */*.mli */*/*.ml */*/*.mli > .depend
+	ocamlc -depend $(DEP_INCLFLAGS) *.mli *.ml */*.ml */*.mli */*/*.ml */*/*.mli > .depend
 
 dependgraph: depend
 	echo 'digraph G {' > .depend.dot.tmp


### PR DESCRIPTION
`ocamldep` is redundant and may be removed in a future compiler release. `ocamlc -depend` is a drop-in replacement for `ocamldep` (supported since OCaml 4.06).