### PR TITLE
Added detail on defining a path on MacOS

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1498,9 +1498,15 @@ for a boolean flag or
 \end{verbatim}
 for a preference of any other type.
 
-Whitespaces around {\tt p} and {\tt xxx} are ignored.
-A profile may also include blank lines and lines beginning
+A profile may include blank lines and lines beginning
 with {\tt \#}; both are ignored.
+
+Spaces and tabs before and after {\tt p} and {\tt xxx} are ignored.
+Spaces, tabs, and non-printable characters within values are not
+treated specially, so that e.g. \verb|root = /foo bar| refers to a
+directory containing a space.
+(On systems using newline for line ending, carriage returns are
+currently ignored, but this is not part of the specification.)
 
 When Unison starts, it first reads the profile and then the command
 line, so command-line options will override settings from the

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -2350,8 +2350,14 @@ let docs =
       \n\
       \032  for a preference of any other type.\n\
       \n\
-      \032  Whitespaces around p and xxx are ignored. A profile may also include\n\
-      \032  blank lines and lines beginning with #; both are ignored.\n\
+      \032  A profile may include blank lines and lines beginning with #; both are\n\
+      \032  ignored.\n\
+      \n\
+      \032  Spaces and tabs before and after p and xxx are ignored. Spaces, tabs,\n\
+      \032  and non-printable characters within values are not treated specially,\n\
+      \032  so that e.g. root = /foo bar refers to a directory containing a space.\n\
+      \032  (On systems using newline for line ending, carriage returns are\n\
+      \032  currently ignored, but this is not part of the specification.)\n\
       \n\
       \032  When Unison starts, it first reads the profile and then the command\n\
       \032  line, so command-line options will override settings from the profile.\n\


### PR DESCRIPTION
@gdt suggested that I add an edit (Aug 2022) to the manual that shares the answers that @tleedjarv graciously provided for me. I was having problems defining a root on OSX. 
OSX generally requires a backslash escape when there is a space in the path.  However, Unison doesn't need the backslash escape when defining paths on OSX.  I hope the addition helps describe the OSX special case.