### PR TITLE
Allow substrings in `force`, `prefer`, ... preferences

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -853,6 +853,7 @@ recon.cmo : \
     globals.cmi \
     fileinfo.cmi \
     common.cmi \
+    clroot.cmi \
     recon.cmi
 recon.cmx : \
     uutil.cmx \
@@ -870,6 +871,7 @@ recon.cmx : \
     globals.cmx \
     fileinfo.cmx \
     common.cmx \
+    clroot.cmx \
     recon.cmi
 recon.cmi : \
     props.cmi \

--- a/src/.depend
+++ b/src/.depend
@@ -538,7 +538,8 @@ globals.cmi : \
     pred.cmi \
     path.cmi \
     lwt/lwt.cmi \
-    common.cmi
+    common.cmi \
+    clroot.cmi
 linkgtk3.cmo : \
     uigtk3.cmi \
     main.cmo

--- a/src/copy.ml
+++ b/src/copy.ml
@@ -937,7 +937,7 @@ let formatConnectionInfo root =
       (* Find the (unique) nonlocal root *)
       match
          Safelist.find (function Clroot.ConnectLocal _ -> false | _ -> true)
-           (Safelist.map Clroot.parseRoot (Globals.rawRoots()))
+           (Globals.parsedClRawRoots ())
       with
         Clroot.ConnectByShell (_,rawhost,uo,_,_) ->
             (match uo with None -> "" | Some u -> u ^ "@")

--- a/src/globals.ml
+++ b/src/globals.ml
@@ -45,6 +45,15 @@ let setRawRoots l = Prefs.set rawroots (Safelist.rev l)
 
 let rawRoots () = Safelist.rev (Prefs.read rawroots)
 
+let parsedClrootCache = ref []
+
+let parsedClRawRoots () =
+  let key = Prefs.read rawroots in
+  match List.assq_opt key !parsedClrootCache with
+  | Some x -> x
+  | None -> let x = Safelist.map Clroot.parseRoot (rawRoots ()) in
+            parsedClrootCache := (key, x) :: !parsedClrootCache; x
+
 let wrongNumRootsExn roots =
   Util.Fatal (Printf.sprintf "Wrong number of roots: \
     2 expected, but %d provided (%s)\n(Maybe you specified \
@@ -59,7 +68,7 @@ let rawRootPair () =
 
 let theroots = ref []
 
-let uninstallRoots () = theroots := []
+let uninstallRoots () = theroots := []; parsedClrootCache := []
 
 open Lwt
 let installRoots termInteract =

--- a/src/globals.mli
+++ b/src/globals.mli
@@ -10,6 +10,9 @@ val rawRoots : unit -> string list
 val setRawRoots : string list -> unit
 val rawRootPair : unit -> string * string
 
+(* Same as [rawRoots], parsed as clroots                                     *)
+val parsedClRawRoots : unit -> Clroot.clroot list
+
 (* Parse and canonize roots from their raw names                             *)
 val installRoots : (string -> string -> string) option -> unit Lwt.t
 

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -1751,6 +1751,10 @@ let docs =
       \032         This effectively changes Unison from a synchronizer into a\n\
       \032         mirroring utility.\n\
       \n\
+      \032         You can also specify a unique prefix or suffix of the path of\n\
+      \032         one of the roots or a unique prefix of the hostname of a remote\n\
+      \032         root.\n\
+      \n\
       \032         You can also specify -force newer (or -force older) to force\n\
       \032         Unison to choose the file with the later (earlier) modtime. In\n\
       \032         this case, the -times preference must also be enabled.\n\
@@ -1767,9 +1771,13 @@ let docs =
       \032         \226\128\156Path Specification\226\128\157 for more information). This effectively\n\
       \032         changes Unison from a synchronizer into a mirroring utility.\n\
       \n\
+      \032         You can also specify a unique prefix or suffix of the path of\n\
+      \032         one of the roots or a unique prefix of the hostname of a remote\n\
+      \032         root.\n\
+      \n\
       \032         You can also specify forcepartial PATHSPEC -> newer (or\n\
-      \032         forcepartial PATHSPEC older) to force Unison to choose the file\n\
-      \032         with the later (earlier) modtime. In this case, the -times\n\
+      \032         forcepartial PATHSPEC -> older) to force Unison to choose the\n\
+      \032         file with the later (earlier) modtime. In this case, the -times\n\
       \032         preference must also be enabled.\n\
       \n\
       \032         This preference should be used only if you are sure you know\n\
@@ -1977,6 +1985,10 @@ let docs =
       \032         Including the preference -nocreation root prevents Unison from\n\
       \032         performing any file creation on root root.\n\
       \n\
+      \032         You can also specify a unique prefix or suffix of the path of\n\
+      \032         one of the roots or a unique prefix of the hostname of a remote\n\
+      \032         root.\n\
+      \n\
       \032         This preference can be included twice, once for each root, if\n\
       \032         you want to prevent any creation.\n\
       \n\
@@ -1991,6 +2003,10 @@ let docs =
       \032         Including the preference -nodeletion root prevents Unison from\n\
       \032         performing any file deletion on root root.\n\
       \n\
+      \032         You can also specify a unique prefix or suffix of the path of\n\
+      \032         one of the roots or a unique prefix of the hostname of a remote\n\
+      \032         root.\n\
+      \n\
       \032         This preference can be included twice, once for each root, if\n\
       \032         you want to prevent any deletion.\n\
       \n\
@@ -2004,6 +2020,10 @@ let docs =
       \032  noupdate xxx\n\
       \032         Including the preference -noupdate root prevents Unison from\n\
       \032         performing any file update or deletion on root root.\n\
+      \n\
+      \032         You can also specify a unique prefix or suffix of the path of\n\
+      \032         one of the roots or a unique prefix of the hostname of a remote\n\
+      \032         root.\n\
       \n\
       \032         This preference can be included twice, once for each root, if\n\
       \032         you want to prevent any update.\n\
@@ -2055,6 +2075,10 @@ let docs =
       \032         preference merge. (The syntax of root is the same as for the\n\
       \032         root preference, plus the special values newer and older.)\n\
       \n\
+      \032         You can also specify a unique prefix or suffix of the path of\n\
+      \032         one of the roots or a unique prefix of the hostname of a remote\n\
+      \032         root.\n\
+      \n\
       \032         This preference is overridden by the preferpartial preference.\n\
       \n\
       \032         This preference should be used only if you are sure you know\n\
@@ -2067,6 +2091,10 @@ let docs =
       \032         (see the section \226\128\156Path Specification\226\128\157 for more information).\n\
       \032         (The syntax of root is the same as for the root preference, plus\n\
       \032         the special values newer and older.)\n\
+      \n\
+      \032         You can also specify a unique prefix or suffix of the path of\n\
+      \032         one of the roots or a unique prefix of the hostname of a remote\n\
+      \032         root.\n\
       \n\
       \032         This preference should be used only if you are sure you know\n\
       \032         what you are doing!\n\

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -896,7 +896,7 @@ let initPrefs ~profileName ~promptForRoots ?(prepDebug = fun () -> ()) () =
 
   (* Parse the roots to validate them *)
   let parsedRoots =
-    try Safelist.map Clroot.parseRoot (Globals.rawRoots ()) with
+    try Globals.parsedClRawRoots () with
     | Invalid_argument s | Util.Fatal s | Prefs.IllegalValue s ->
         raise (Util.Fatal ("There's a problem with one of the roots:\n" ^ s))
   in

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -264,7 +264,7 @@ let do_unisonInit1 profileName =
   let localRoots,remoteRoots =
     Safelist.partition
       (function Clroot.ConnectLocal _ -> true | _ -> false)
-      (Safelist.map Clroot.parseRoot (Globals.rawRoots())) in
+      (Globals.parsedClRawRoots ()) in
 
   match remoteRoots with
     [r] ->


### PR DESCRIPTION
It always annoyed me that preferences like `force` require a complete root specification. When your root looks like `ssh://user@host.domain.com:port//a/long/path/to/the/actual/root/and/then/some`, you need to copy this whole thing to every single `force`, `prefer`, ... (there are many preferences like this) preference value, and it has to match exactly.

This patch makes all those preferences accept a substring of the root to identify it. To identify a root, the following _unique_ substrings are allowed:
 - an exact prefix or suffix of any length of a root's path
 - an exact prefix of any length of a remote root's hostname

Examples:
 - with roots `/a/long/path/to/source` and `/path/to/backup` you can specify `force=source` or `force=/a` to force the first root and `force=backup`to force the second root.
 - with root `ssh://user@host.domain.com:port//a/long/path/to/the/actual/root/and/then/some` you can simply specify `force=host`
 - with roots `root1` and `root2` you can specify `force=1` or `force=2`

Note that a prefix or suffix of an arbitrary length is accepted, so the examples above would also work with longer and shorter values, as long as one of the roots is uniquely identified.

This PR contains another change. Partially to remove any negative performance impacts caused by the substring matching, partially an improvement in its own right, results of two recurring operations are cached (the first two commits). Without this patch, clroots and values of `force`, `prefer`, ... preferences were reparsed every single time they were needed.

(_For reviewers: actual code changes are rather small; much of the diff is due to doc changes._)