### PR TITLE
Combine filesystem monitoring and time interval in repeat mode

### DIFF
--- a/src/strings.ml
+++ b/src/strings.ml
@@ -2014,7 +2014,11 @@ let docs =
       \032         stopping. If the argument is a number, Unison will pause for\n\
       \032         that many seconds before beginning again. When the argument is\n\
       \032         watch, Unison relies on an external file monitoring process to\n\
-      \032         synchronize whenever a change happens.\n\
+      \032         synchronize whenever a change happens. You can combine the two\n\
+      \032         with a + character to use file monitoring and also do a full\n\
+      \032         scan every specificed number of seconds. For example, watch+3600\n\
+      \032         will react to changes immediately and additionally do a full\n\
+      \032         scan every hour.\n\
       \n\
       \032  retry n\n\
       \032         Setting this preference causes the text-mode interface to try\n\

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -109,13 +109,16 @@ let repeat =
         raise (Prefs.IllegalValue ("Value of 'repeat' preference ("
           ^ s ^ ") should be either a number or 'watch'"))
     in
-    match s with
-    | "" -> `NoRepeat
-    | "watch" -> `Watch
-    | _ -> `Interval (parseTime s)
+    try
+      match s with
+      | "" -> `NoRepeat
+      | "watch" -> `Watch
+      | _ -> `Interval (parseTime s)
+    with
+    | Prefs.IllegalValue _ as e -> `Invalid (s, e)
   in
   let externRepeat = function
-    | `NoRepeat -> ""
+    | `NoRepeat | `Invalid _ -> ""
     | `Watch -> "watch"
     | `Interval i -> string_of_int i
   in

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -35,7 +35,7 @@ val profileLabel : string Prefs.t
 
 (* User preference: Synchronize repeatedly *)
 val repeat : [ `NoRepeat | `Interval of int | `Watch
-  | `Invalid of string * exn ] Prefs.t
+  | `WatchAndInterval of int | `Invalid of string * exn ] Prefs.t
 
 (* User preference: Try failing paths N times *)
 val retry : int Prefs.t

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -34,7 +34,8 @@ val contactingServerMsg : unit -> string
 val profileLabel : string Prefs.t
 
 (* User preference: Synchronize repeatedly *)
-val repeat : [ `NoRepeat | `Interval of int | `Watch ] Prefs.t
+val repeat : [ `NoRepeat | `Interval of int | `Watch
+  | `Invalid of string * exn ] Prefs.t
 
 (* User preference: Try failing paths N times *)
 val retry : int Prefs.t

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1376,6 +1376,7 @@ let synchronizeUntilDone () =
   | `Watch -> synchronizePathsFromFilesystemWatcher ()
   | `Interval i -> synchronizeUntilDone i
   | `NoRepeat -> synchronizeUntilDone (-1)
+  | `Invalid (_, e) -> raise e
 
 (* ----------------- Startup ---------------- *)
 

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1307,9 +1307,14 @@ let waitForChanges t =
        Lwt.choose (timeout @ l @ [safeStopWait ()]))
   end
 
-let synchronizePathsFromFilesystemWatcher () =
-  let rec loop isStart delayInfo =
+let synchronizePathsFromFilesystemWatcher fullintv =
+  let fullinterval = match fullintv with None -> 1e20 | Some i -> float i in
+  let rec loop lastFull delayInfo =
     let t = Unix.gettimeofday () in
+    let sinceFull = t -. lastFull in
+    let isFull = sinceFull > fullinterval in
+    let lastFull = if isFull then t else lastFull in
+    let nextFull = lastFull +. fullinterval in
     let (delayedPaths, readyPaths) =
       PathMap.fold
         (fun p (t', _) (delayed, ready) ->
@@ -1318,7 +1323,7 @@ let synchronizePathsFromFilesystemWatcher () =
     in
     let (exitStatus, failedPaths) =
       synchronizeOnce ~wantWatcher:true
-        (if isStart then None else Some (readyPaths, delayedPaths))
+        (if isFull then None else Some (readyPaths, delayedPaths))
     in
     (* After a failure, we retry at once, then use an exponential backoff *)
     let delayInfo =
@@ -1338,11 +1343,11 @@ let synchronizePathsFromFilesystemWatcher () =
     in
     interruptibleSleepf watchinterval;
     let nextTime =
-      PathMap.fold (fun _ (t, d) t' -> min t t') delayInfo 1e20 in
+      PathMap.fold (fun _ (t, d) t' -> min t t') delayInfo nextFull in
     if not (safeStopRequested ()) then waitForChanges nextTime;
-    if safeStopRequested () then exitStatus else loop false delayInfo
+    if safeStopRequested () then exitStatus else loop lastFull delayInfo
   in
-  loop true PathMap.empty
+  loop 0. PathMap.empty
 
 (* ----------------- Repetition ---------------- *)
 
@@ -1373,7 +1378,8 @@ let rec synchronizeUntilDone repeatinterval =
 
 let synchronizeUntilDone () =
   match Prefs.read Uicommon.repeat with
-  | `Watch -> synchronizePathsFromFilesystemWatcher ()
+  | `Watch -> synchronizePathsFromFilesystemWatcher None
+  | `WatchAndInterval i -> synchronizePathsFromFilesystemWatcher (Some i)
   | `Interval i -> synchronizeUntilDone i
   | `NoRepeat -> synchronizeUntilDone (-1)
   | `Invalid (_, e) -> raise e


### PR DESCRIPTION
Currently the repeat mode allows the user to specify either time interval only or filesystem monitoring only. It makes sense to allow combinining these two modes because filesystem monitoring may not always be fully reliable (due to bugs or platform limitations, or is just perceived a little untrustworthy).

This is not a breaking change because while this preference is sent to the server (incorrectly, among several other preferences, due to legacy limitations), the value of the preference is never parsed on the server before commit 5d6ab3cb9921a476e73e42307d40addc1b86f30a (which is not in any release so far).

_Edit:_ Include a commit to fix the potential future compatibility issue introduced by commit 5d6ab3cb9921a476e73e42307d40addc1b86f30a. @gdt this fix should be merged before the next release even if this entire PR is not merged. Let me know if you want me to split it out as a separate PR.