### PR TITLE
Fix permissions of new files when dontchmod=true

### DIFF
--- a/src/copy.ml
+++ b/src/copy.ml
@@ -328,7 +328,7 @@ let openFileOut' fspath path kind len =
     `DATA ->
       let fullpath = Fspath.concat fspath path in
       let flags = [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_CLOEXEC] in
-      let perm = 0o600 in
+      let perm = if Prefs.read Props.dontChmod then Props.perms Props.fileDefault else 0o600 in
       begin match Util.osType with
         `Win32 ->
           Fs.open_out_gen
@@ -348,7 +348,7 @@ let openFileOut' fspath path kind len =
       end
   | `DATA_APPEND len ->
       let fullpath = Fspath.concat fspath path in
-      let perm = 0o600 in
+      let perm = if Prefs.read Props.dontChmod then Props.perms Props.fileDefault else 0o600 in
       let ch = Fs.open_out_gen [Open_wronly; Open_binary] perm fullpath in
       if not (Prefs.read Props.dontChmod) then Fs.chmod fullpath perm;
       LargeFile.seek_out ch (Uutil.Filesize.toInt64 len);


### PR DESCRIPTION
As discussed on `unison-users`.

`Props.fileDefault` is based on umask.

Instead of just having `Props.fileDefault` in place of `0o600`, I added a condition on the 'dontchmod' preference. That's because if chmod _is allowed_ then before doing the final chmod the temporary file used during the sync may become world-readable (which is likely, given common defaults for umask). Similar code for `mkdir` omits this condition and always uses the default based on umask; this code has been in place since before the initial commit on GH (well before 2005).
(An alternative to this condition could be to OR the expected final perms with 0o600 for the temporary file, but that code would be even more complex.)

_Not tested on a cifs/smbfs mount._