### PR TITLE
Write root names in the log

### DIFF
--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -925,6 +925,11 @@ let initPrefs ~profileName ~promptForRoots ?(prepDebug = fun () -> ()) () =
         end
   end;
 
+  Trace.logonly "Roots:\n";
+  Globals.rawRoots () |> Safelist.iter
+    (fun s -> Trace.logonly "  "; Trace.logonly s; Trace.logonly "\n");
+  Trace.logonly "\n";
+
   (* Parse the roots to validate them *)
   let parsedRoots =
     try Globals.parsedClRawRoots () with


### PR DESCRIPTION
Include the raw root names in the log. This does no harm but can be useful when multiple syncs/profiles use the same log file (which is the default), or when an error about parsing the roots is logged.
(This won't help of course when several processes are writing to the same log file _in parallel_.)

The start of log will now look like this:
```
Unison 2.53.1 (ocaml 4.14.1) log started at 2023-03-19 at 17:42:19

Roots:
  test1
  test2

[... rest of the log ...]
```