### PR TITLE
Use reflink copy API within rsync protocol

### DIFF
--- a/src/copy.ml
+++ b/src/copy.ml
@@ -832,6 +832,14 @@ let transferFileContents
                   fspathTo pathTo fileKind srcFileSize outfd id in
               let eof =
                 Transfer.Rsync.rsyncDecompress blockSize ifd fd showProgress ti
+                  ~copyFn:(fun in_offs len ~fallback ->
+                    (* Flush the buffered output channel just in case since
+                       we manipulate the channel's underlying fd directly. *)
+                    flush fd;
+                    copyFileRange
+                      (Unix.descr_of_in_channel ifd)
+                      (Unix.descr_of_out_channel fd)
+                      in_offs len fallback (fun _ -> ()))
               in
               if eof then close_all infd outfd))
       else

--- a/src/transfer.ml
+++ b/src/transfer.ml
@@ -356,7 +356,12 @@ struct
       only 31 bits.)
   *)
   (* Block size *)
-  let computeBlockSize l = truncate (max 700. (min (sqrt l) 131072.))
+  (* Block size (including the minimum and maximum limits used here) is
+     calculated similar to the rsync reference implementation. The main
+     difference here is rounding down to a power of 2 to allow block-level
+     links on filesystems that support it. *)
+  let computeBlockSize l =
+    1 lsl (truncate (max 10. (min (Float.round (log (sqrt l) /. log 2.)) 17.)))
   (* Size of each strong checksum *)
   let checksumSize bs sl dl =
     let bits =

--- a/src/transfer.mli
+++ b/src/transfer.mli
@@ -94,6 +94,13 @@ module Rsync :
            int                   (* block size *)
         -> in_channel            (* old file descriptor *)
         -> out_channel           (* output file descriptor *)
+        -> ?copyFn:              (* function for optimized copying *)
+           (   Uutil.Filesize.t  (* input file offset *)
+            -> Uutil.Filesize.t  (* data length *)
+            -> fallback:         (* default function for copying *)
+               (Uutil.Filesize.t (* bytes copied before fallback *)
+                -> unit)
+            -> unit)
         -> (int -> unit)         (* progress report *)
         -> transfer_instruction  (* transfer instruction received *)
         -> bool


### PR DESCRIPTION
Based on #577 (the first commit is from that PR).

With #577, it was very simple to extend this support to the rsync delta copy. This is performance-wise and by space requirement like rsync's `--inplace` but it's actually _safe_ to use. This would solve #65 in some configurations (see the caveat below).

The caveat is that it only works on platforms that export an API for fs block-level links (so-called reflinks) and on a filesystem that supports reflinks. Other platforms/filesystems continue using the old code.

(Note on implementation: the reflink mode currently works the same way as the plain old copy mode, by overlapping writes for data from the original file and for data from the network. This works well enough and makes the fallback to old mode extremely simple. An alternative implementation could be to reflink clone the entire file and then overwrite the changed blocks. This is not implemented because it would make the code more complicated and it's hard (at the moment) to see any general performance benefits.)