### PR TITLE
Fix double quotes in the manpage

### DIFF
--- a/src/ubase/prefs.ml
+++ b/src/ubase/prefs.ml
@@ -688,6 +688,7 @@ let printFullManDocs () =
   let parRe = Str.regexp "\\\\par *" in
   let underRe = Str.regexp "\\\\_ *" in
   let dollarRe = Str.regexp "\\\\\\$ *" in
+  let dquotRe = Str.regexp "\"" in
   let nn1Re = Str.regexp "\\(\\( -NN-\\)+ -NN-\\|\\( -NN-\\)* -NS-\\)\\." in
   let nn2Re = Str.regexp "\\( -NN-\\)+" in
   let substMacro m s =
@@ -726,6 +727,7 @@ let printFullManDocs () =
     Str.global_replace parRe "\n" >>>
     Str.global_replace underRe "_" >>>
     Str.global_replace dollarRe "$" >>>
+    Str.global_replace dquotRe "\\&\"" >>>
     Str.global_replace nn1Re " Ns " >>>
     Str.global_replace nn2Re "\n" >>>
     Str.global_replace newlineRe "\n" >>>


### PR DESCRIPTION
Unescaped double quotes in the text are not correct. They don't break the output completely but they will not display and they may cause the space to the previous word disappear.