### PR TITLE
Allow syncing POSIX ACLs on Linux via xattrs

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -2193,6 +2193,19 @@ Unison currently supports the following platforms and ACL types:
 Not all filesystems on the listed platforms support all ACL types
 (or any ACLs at all).
 
+Synchronizing POSIX ACLs on Linux is not supported directly. However, it is
+possible to synchronize these ACLs with another Linux system by synchronizing
+extended attributes (xattrs) instead, because POSIX ACLs are stored as xattrs
+by Linux. This is disabled by default (see \sectionref{xattrs}{Extended
+Attributes - xattrs}).  A simple way to enable syncing POSIX ACLs on Linux is
+to enable the preference \verb|xattrs| and add a preference
+\verb|xattrignorenot| with a value \texttt{Path !system.posix\_acl\_*}.  The
+\verb|*| will be expanded to include both \verb|posix_acl_access| and
+\verb|posix_acl_default| attributes -- if you only want to sync either one,
+just remove the \verb|*| and type out the attribute name in full.  If you want
+to prevent other xattrs from being synced then add an \verb|xattrignore| with a
+value \texttt{Path *} (value \texttt{Regex .*} will also work).
+
 
 \SUBSECTION{Extended Attributes - xattrs}{xattrs}
 
@@ -2219,6 +2232,9 @@ and is disabled by default. To sync one or more attributes in the security
 namespace, for example, you can set the preference
 \verb|xattrignorenot| to \verb|Path !security.*| (for all) or to
 \verb|Path !security.selinux| (for one specific attribute).
+Attributes in system namespace are not synchronized, with the exception of
+\verb|system.posix_acl_default| and \verb|system.posix_acl_access| (also
+disabled by default).
 \item {\em Solaris, OpenSolaris and illumos-based OS (OpenIndiana, SmartOS,
   OmniOS, etc.)}
 \item {\em FreeBSD, NetBSD}
@@ -2256,6 +2272,9 @@ be constructed with the \verb|Path| form (where shell wildcards \verb|*| and
 Disabling the security and trusted namespaces on Linux is achieved by setting
 a default \verb|xattrignore| pattern of
 \texttt{Regex !(security|trusted)[.].*}.
+Disabling the syncing of attributes used to store POSIX ACL on Linux is
+achieved by setting a default \verb|xattrignore| pattern of
+\texttt{Path !system.posix\_acl\_*}.
 
 
 \SUBSECTION{Cross-Platform Synchronization}{crossplatform}

--- a/src/props.ml
+++ b/src/props.ml
@@ -745,7 +745,7 @@ let xattrIgnorePred =
     ~category:(`Advanced `Sync)
     ~send:xattrEnabled
     (* By default ignore the Linux xattr security and trusted namespaces *)
-    ~initial:["Regex !(security|trusted)[.].*"]
+    ~initial:["Regex !(security|trusted)[.].*"; "Path !system.posix_acl_*"]
     ("Preference \\texttt{-xattrignore \\ARG{namespec}} causes Unison to \
      ignore extended attributes with names that match \\ARG{namespec}. \
      This can be used to exclude extended attributes that would fail \
@@ -757,7 +757,9 @@ let xattrIgnorePred =
      applied to the {\\em name} of extended attribute, not to path. \
      {\\em On Linux}, attributes in the security and trusted namespaces \
      are ignored by default (this is achieved by pattern \\texttt{Regex \
-     !(security|trusted)[.].*}). To sync attributes in one or both of \
+     !(security|trusted)[.].*}); also attributes used to store POSIX ACL \
+     are ignored by default (this is achieved by pattern \\texttt{Path \
+     !system.posix\\_acl\\_*}). To sync attributes in one or both of \
      these namespaces, see the \\verb|xattrignorenot| preference. \
      Note that the namespace name must be prefixed with a \"!\" (applies \
      on Linux only). All names not prefixed with a \"!\" are taken \
@@ -782,7 +784,9 @@ let xattrIgnorenotPred =
      namespaces, you may add an \\verb|xattrignorenot| pattern like \
      \\texttt{Path !security.*} to sync all attributes in the \
      security namespace, or \\texttt{Path !security.selinux} to sync \
-     a specific attribute in an otherwise ignored namespace. \
+     a specific attribute in an otherwise ignored namespace. A pattern \
+     like \\texttt{Path !system.posix\\_acl\\_*} can be used to sync \
+     POSIX ACLs on Linux. \
      Note that the namespace name must be prefixed with a \"!\" (applies \
      on Linux only). All names not prefixed with a \"!\" are taken \
      as strictly belonging to the user namespace and therefore the \

--- a/src/props_xattr.c
+++ b/src/props_xattr.c
@@ -340,7 +340,8 @@ static void unsn_xattr_fail(const char *fmtmsg)
 static int unsn_is_system_attr_os(const char *attrname)
 {
 #if defined(__linux)
-  return (strncmp(attrname, "system.", 7) == 0);
+  return (strncmp(attrname, "system.", 7) == 0 &&
+          strncmp(attrname, "system.posix_acl_", 17) != 0);
 #elif defined(__APPLE__)
   return (strcmp(attrname, XATTR_FINDERINFO_NAME) == 0 ||
           strcmp(attrname, XATTR_RESOURCEFORK_NAME) == 0);

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -2202,12 +2202,14 @@ let docs =
       \032         form. The pattern is applied to the name of extended attribute,\n\
       \032         not to path. On Linux, attributes in the security and trusted\n\
       \032         namespaces are ignored by default (this is achieved by pattern\n\
-      \032         Regex !(security|trusted)[.].*). To sync attributes in one or\n\
-      \032         both of these namespaces, see the xattrignorenot preference.\n\
-      \032         Note that the namespace name must be prefixed with a \"!\"\n\
-      \032         (applies on Linux only). All names not prefixed with a \"!\" are\n\
-      \032         taken as strictly belonging to the user namespace and therefore\n\
-      \032         the \"!user.\" prefix is never used.\n\
+      \032         Regex !(security|trusted)[.].*); also attributes used to store\n\
+      \032         POSIX ACL are ignored by default (this is achieved by pattern\n\
+      \032         Path !system.posix_acl_*). To sync attributes in one or both of\n\
+      \032         these namespaces, see the xattrignorenot preference. Note that\n\
+      \032         the namespace name must be prefixed with a \"!\" (applies on Linux\n\
+      \032         only). All names not prefixed with a \"!\" are taken as strictly\n\
+      \032         belonging to the user namespace and therefore the \"!user.\"\n\
+      \032         prefix is never used.\n\
       \n\
       \032  xattrignorenot xxx\n\
       \032         This preference overrides the preference xattrignore. It gives a\n\
@@ -2222,11 +2224,12 @@ let docs =
       \032         one or both of these namespaces, you may add an xattrignorenot\n\
       \032         pattern like Path !security.* to sync all attributes in the\n\
       \032         security namespace, or Path !security.selinux to sync a specific\n\
-      \032         attribute in an otherwise ignored namespace. Note that the\n\
-      \032         namespace name must be prefixed with a \"!\" (applies on Linux\n\
-      \032         only). All names not prefixed with a \"!\" are taken as strictly\n\
-      \032         belonging to the user namespace and therefore the \"!user.\"\n\
-      \032         prefix is never used.\n\
+      \032         attribute in an otherwise ignored namespace. A pattern like Path\n\
+      \032         !system.posix_acl_* can be used to sync POSIX ACLs on Linux.\n\
+      \032         Note that the namespace name must be prefixed with a \"!\"\n\
+      \032         (applies on Linux only). All names not prefixed with a \"!\" are\n\
+      \032         taken as strictly belonging to the user namespace and therefore\n\
+      \032         the \"!user.\" prefix is never used.\n\
       \n\
       \032  xattrs\n\
       \032         When this flag is set to true, the extended attributes of files\n\
@@ -2960,6 +2963,19 @@ let docs =
       \032  Not all filesystems on the listed platforms support all ACL types (or\n\
       \032  any ACLs at all).\n\
       \n\
+      \032  Synchronizing POSIX ACLs on Linux is not supported directly. However,\n\
+      \032  it is possible to synchronize these ACLs with another Linux system by\n\
+      \032  synchronizing extended attributes (xattrs) instead, because POSIX ACLs\n\
+      \032  are stored as xattrs by Linux. This is disabled by default (see the\n\
+      \032  section \226\128\156Extended Attributes - xattrs\226\128\157 ). A simple way to enable\n\
+      \032  syncing POSIX ACLs on Linux is to enable the preference xattrs and add\n\
+      \032  a preference xattrignorenot with a value Path !system.posix_acl_*. The\n\
+      \032  * will be expanded to include both posix_acl_access and\n\
+      \032  posix_acl_default attributes \226\128\147 if you only want to sync either one,\n\
+      \032  just remove the * and type out the attribute name in full. If you want\n\
+      \032  to prevent other xattrs from being synced then add an xattrignore with\n\
+      \032  a value Path * (value Regex .* will also work).\n\
+      \n\
       Extended Attributes - xattrs\n\
       \n\
       \032  Unison allows synchronizing extended attributes on platforms and\n\
@@ -2983,7 +2999,10 @@ let docs =
       \032      process privileges and is disabled by default. To sync one or more\n\
       \032      attributes in the security namespace, for example, you can set the\n\
       \032      preference xattrignorenot to Path !security.* (for all) or to Path\n\
-      \032      !security.selinux (for one specific attribute).\n\
+      \032      !security.selinux (for one specific attribute). Attributes in\n\
+      \032      system namespace are not synchronized, with the exception of\n\
+      \032      system.posix_acl_default and system.posix_acl_access (also disabled\n\
+      \032      by default).\n\
       \032    * Solaris, OpenSolaris and illumos-based OS (OpenIndiana, SmartOS,\n\
       \032      OmniOS, etc.)\n\
       \032    * FreeBSD, NetBSD Attributes in user namespace.\n\
@@ -3021,7 +3040,9 @@ let docs =
       \n\
       \032  Disabling the security and trusted namespaces on Linux is achieved by\n\
       \032  setting a default xattrignore pattern of Regex\n\
-      \032  !(security|trusted)[.].*.\n\
+      \032  !(security|trusted)[.].*. Disabling the syncing of attributes used to\n\
+      \032  store POSIX ACL on Linux is achieved by setting a default xattrignore\n\
+      \032  pattern of Path !system.posix_acl_*.\n\
       \n\
       Cross-Platform Synchronization\n\
       \n\


### PR DESCRIPTION
There is no direct support for syncing POSIX ACLs on Linux via the `acl` preference. Since Linux stores POSIX ACLs as extended attributes on files and directories, an easy way to sync POSIX ACLs (between Linux systems only) is to enable xattr syncing support for these attributes (`system.posix_acl_access` and `system.posix_acl_default`).

A user can sync POSIX ACLs on Linux by enabling the `xattrs` preference and adding an `xattrignorenot` preference with value `Path !system.posix_acl_*`. To optionally prevent other xattrs from being synced, also add an `xattrignore` preference with value `Path *` (or `Regex .*`).