### PR TITLE
GHA: Fix Windows packaging (include missing DLLs)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -295,6 +295,12 @@ jobs:
       name: "Windows: Package gtk"
       shell: bash
       run: |
+        # [2023-03] Setting this PATH here (and it has to be right here) is
+        # a workaround for an unknown issue (most likely something with GHA)
+        # causing MinGW binutils not to be found (while other binutils
+        # pre-installed in the GHA images may be found instead), which in turn
+        # causes the DLL extracting functions to silently fail.
+        export PATH="/usr/${{ steps.vars.outputs.MinGW_ARCH }}-w64-mingw32/bin":${PATH}
         ## package artifact(s)
         PKG_DIR='${{ steps.vars.outputs.PKG_DIR }}'
         # collect any needed dlls/libraries

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,18 +148,6 @@ jobs:
         arch: "${{ steps.vars.outputs.MSVC_ARCH }}"
       if: contains(matrix.job.ocaml-version, '+msvc')
 
-    - name: "Windows: Cygwin setup"
-      if: runner.os == 'Windows'
-      run: Invoke-WebRequest 'https://cygwin.com/setup-x86_64.exe' -OutFile 'setup-x86_64.exe'
-
-    # [2022-05] Cygwin mingw64 binutils 2.38 produces invalid GUI binaries.
-    # Pin binutils to version 2.37 as a workaround.
-    - name: "Windows: mingw64 binutils workaround hack"
-      if: runner.os == 'Windows'
-      # The setup does not complete properly in powershell for some reason
-      shell: cmd
-      run: .\setup-x86_64.exe --quiet-mode --root D:\cygwin --site http://cygwin.mirror.constant.com --symlink-type=sys --packages mingw64-i686-binutils=2.37-2,mingw64-x86_64-binutils=2.37-2
-
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
       uses: ocaml/setup-ocaml@v2
       with:


### PR DESCRIPTION
As pointed out by https://github.com/bcpierce00/unison/issues/186#issuecomment-1477978644 the CI artifacts for Windows were not quite complete and couldn't be run on a clean install.

The CI Windows packaging step was broken. The reasons are unknown but one symptom which caused the packages to be incomplete was _something_(what?) mangling the PATH. Fixing the PATH manually also fixed the packaging (however, setting this PATH in earlier steps where other PATH entries are set does not work).

The binutils workaround is no longer available (Cygwin no longer ships binutils verson 2.37) so remove it. Fortunately, the issue that caused the workaround to be added seems to be gone.
Closes #747 