### PR TITLE
Increase max length of status messages in uitext

### DIFF
--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -57,19 +57,23 @@ let stringSetFromList l =
 (*                    Debugging / error messages                             *)
 (*****************************************************************************)
 
-let infos = ref ""
+type infos = { s : string; clr : string }
+let infos = ref { s = ""; clr = "" }
 
 let clear_infos () =
-  if !infos <> "" then begin
+  if !infos.clr <> "" then begin
+    print_string !infos.clr;
+    flush stdout
+  end else if !infos.s <> "" then begin
     print_string "\r";
-    print_string (String.make (String.length !infos) ' ');
+    print_string (String.make (String.length !infos.s) ' ');
     print_string "\r";
     flush stdout
   end
 let show_infos () =
-  if !infos <> "" then begin print_string !infos; flush stdout end
-let set_infos s =
-  if s <> !infos then begin clear_infos (); infos := s; show_infos () end
+  if !infos.s <> "" then begin print_string !infos.s; flush stdout end
+let set_infos ?(clr = "") s =
+  if s <> !infos.s then begin clear_infos (); infos := {s; clr}; show_infos () end
 
 let msg f =
   clear_infos ();

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -130,5 +130,6 @@ val format_to_string : (unit -> unit) -> string
    flush the stream after each one *)
 val msg : ('a, out_channel, unit) format -> 'a
 
-(* Set the info line *)
-val set_infos : string -> unit
+(* Set the info line.
+   [~clr] is an alternative clear sequence to clear this info only. *)
+val set_infos : ?clr:string -> string -> unit


### PR DESCRIPTION
Based on some discussion in #396, and considering that any bigger changes are realistically not going to happen quickly, I propose this intermediate solution. (Temporary things that become permanent, you know the story...)
It is _not_ a solution to #396, just to one bit of it.

### What's in this patch?

With VT100 terminal emulators we can control automatic line wrapping mode per line, and this is exactly what this patch does for the status line while scanning updates. By disabling line wrapping, the length cap (currently at 70) can be removed. Instead, status lines will be chopped off beyond the width of terminal.

This is supposed to work on all proper VT100 emulators (more info in commit message). For some, I've explicitly disabled this function; for others, very long status lines will wrap and be half-overwritten by the next. This may cause ugly output but is not harmful in any other way.