### PR TITLE
Improve fsmonitor resilience some more

### DIFF
--- a/src/fsmonitor.py
+++ b/src/fsmonitor.py
@@ -664,7 +664,7 @@ to read all the settings from there."""
             while sys.stdin.readline(): pass
             os._exit(0)
         t = threading.Thread(target=exitThread)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         if sys.platform=='darwin':

--- a/src/fswatch.ml
+++ b/src/fswatch.ml
@@ -444,6 +444,8 @@ let start hash =
     true
   end
 
+let running _ = connected ()
+
 let wait hash =
   let c = currentConnection () in
   let res = Cond.wait c.has_changes in

--- a/src/fswatch.mli
+++ b/src/fswatch.mli
@@ -4,6 +4,7 @@
 type archiveHash = string
 
 val start : archiveHash -> bool
+val running : archiveHash -> bool
 
 val startScanning : archiveHash -> Fspath.t -> Path.local -> unit
 val stopScanning : unit -> unit

--- a/src/fswatchold.ml
+++ b/src/fswatchold.ml
@@ -168,6 +168,17 @@ let start archHash fspath =
     true
   end
 
+let running archHash =
+  if StringSet.mem archHash !newWatchers then begin
+    if Fswatch.running archHash then true
+    else begin
+      newWatchers := StringSet.remove archHash !newWatchers;
+      false
+    end
+  end else false
+    ||
+  watcherRunning archHash
+
 let wait archHash =
   if StringSet.mem archHash !newWatchers then
     Fswatch.wait archHash

--- a/src/fswatchold.ml
+++ b/src/fswatchold.ml
@@ -15,9 +15,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-(* FIX: we should check that the child process has not died and
-   restart it if so... *)
-
 (* FIX: the names of the paths being watched should get included
    in the name of the watcher's state file *)
 
@@ -193,7 +190,15 @@ let wait archHash =
       if wi.lines = [] then begin
         debug (fun() -> Util.msg "Sleeping for %d seconds...\n" watchinterval);
         Lwt.bind (Lwt_unix.sleep (float watchinterval)) (fun () ->
-        loop ())
+        if watcherRunning archHash then
+          loop ()
+        else
+          (* Instead of immediately restarting the watcher, the only sensible
+             thing to do is to do a full scan (which will happen automatically
+             if the update scanner notices that watcher is not running). We
+             don't know if any updates have been missed and can no longer rely
+             on the watcher only. *)
+          Lwt.return ())
       end else
         Lwt.return ()
     in

--- a/src/fswatchold.mli
+++ b/src/fswatchold.mli
@@ -1,4 +1,5 @@
 
 val start : string -> Fspath.t -> bool
+val running : string -> bool
 val getChanges : string -> Path.t list
 val wait : string -> unit Lwt.t

--- a/src/update.ml
+++ b/src/update.ml
@@ -2402,7 +2402,8 @@ let t1 = Unix.gettimeofday () in
   in
   let paths =
     match subpaths with
-      Some (unsynchronizedPaths, blacklistedPaths) when unchangedOptions ->
+      Some (unsynchronizedPaths, blacklistedPaths) when unchangedOptions
+          && Fswatchold.running scanInfo.archHash ->
         let (>>) x f = f x in
         let paths =
           Fswatchold.getChanges scanInfo.archHash


### PR DESCRIPTION
Recover from fsmonitor process exiting unexpectedly.

A side note:
This patch also covers the fsmonitor python script. I doubt anyone is actually using that script anymore. If someone would like to continue using the python script (because the native `unison-fsmonitor` is not working for some unfixable reason or is unsupported on their platform) then the correct way to do it is to rewrite the script to work with the new fswatch protocol (as defined in `fswatch.ml`). Or use a third-party watcher that uses the new protocol.