### PR TITLE
Fix broken Windows GUI builds

### DIFF
--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -86,11 +86,13 @@ let icon =
     (Gpointer.region_of_bytes Pixmaps.icon_data)
 *)
 let icon =
-  let p = GdkPixbuf.create ~width:48 ~height:48 ~has_alpha:true () in
-  Gpointer.blit
-    ~src:(Gpointer.region_of_bytes (Bytes.of_string Pixmaps.icon_data))
-    ~dst:(GdkPixbuf.get_pixels p);
-  p
+  lazy begin
+    let p = GdkPixbuf.create ~width:48 ~height:48 ~has_alpha:true () in
+    Gpointer.blit
+      ~src:(Gpointer.region_of_bytes (Bytes.of_string Pixmaps.icon_data))
+      ~dst:(GdkPixbuf.get_pixels p);
+    p
+  end
 
 let leftPtrWatch =
   lazy (Gdk.Cursor.create `WATCH)
@@ -2742,7 +2744,7 @@ let createToplevelWindow () =
   setToplevelWindow toplevelWindow;
   (* There is already a default icon under Windows, and transparent
      icons are not supported by all version of Windows *)
-  if Util.osType <> `Win32 then toplevelWindow#set_icon (Some icon);
+  if Util.osType <> `Win32 then toplevelWindow#set_icon (Some (Lazy.force icon));
   let toplevelVBox = GPack.vbox ~packing:toplevelWindow#add () in
 
   (*******************************************************************


### PR DESCRIPTION
The cause of broken Windows GUI builds (when the EXE does not start and does not even produce any error messages) appears to be this usage of `GPointer.blit`.

There are two noteworthy things about this, though. First, this code has been there since 2005 and never caused any problems. The problems only appeared with binutils > 2.37 (which is why binutils were pinned to 2.37 in the CI script for almost a year). Second, not all machines are apparently equally impacted. On some machines, or under some conditions, the EXE would start normally.

Just for the record, referencing issues: #738, #744