### PR TITLE
Remove the custom inotify exception

### DIFF
--- a/src/fsmonitor/linux/inotify.ml
+++ b/src/fsmonitor/linux/inotify.ml
@@ -14,8 +14,6 @@
  * Inotify OCaml binding
  *)
 
-exception Error of string * int
-
 type select_event =
         | S_Access
         | S_Attrib
@@ -115,5 +113,3 @@ let read fd =
         done;
 
         List.rev !ret
-
-let _ = Callback.register_exception "inotify.error" (Error ("register_callback", 0))

--- a/src/fsmonitor/linux/inotify.mli
+++ b/src/fsmonitor/linux/inotify.mli
@@ -13,8 +13,6 @@
  *
  * Inotify OCaml binding
  *)
-exception Error of string * int
-
 type select_event =
 | S_Access
 | S_Attrib

--- a/src/fsmonitor/linux/inotify_stubs.c
+++ b/src/fsmonitor/linux/inotify_stubs.c
@@ -23,10 +23,13 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
-#include <caml/custom.h>
-#include <caml/fail.h>
-#include <caml/signals.h>
-#include <caml/callback.h>
+#include <caml/unixsupport.h>
+#include <caml/version.h>
+
+#if OCAML_VERSION_MAJOR < 5
+#define caml_unix_error unix_error
+#define caml_uerror uerror
+#endif
 
 #ifndef IN_EXCL_UNLINK
 #define IN_EXCL_UNLINK 0  /* If not supported, just ignore */
@@ -47,41 +50,30 @@ static int inotify_return_table[] = {
         IN_IGNORED, IN_ISDIR, IN_Q_OVERFLOW, IN_UNMOUNT, 0
 };
 
-static void raise_inotify_error(char const *msg)
-{
-        static const value *inotify_err = NULL;
-        value args[2];
-
-        if (!inotify_err)
-                inotify_err = caml_named_value("inotify.error");
-        args[0] = caml_copy_string(msg);
-        args[1] = Val_int(errno);
-
-        caml_raise_with_args(*inotify_err, 2, args);
-}
-
-value stub_inotify_init(value unit)
+CAMLprim value stub_inotify_init(value unit)
 {
         CAMLparam1(unit);
         int fd;
 
         fd = inotify_init();
+        if (fd == -1)
+                caml_uerror("inotify_init", Nothing);
         CAMLreturn(Val_int(fd));
 }
 
-value stub_inotify_ioctl_fionread(value fd)
+CAMLprim value stub_inotify_ioctl_fionread(value fd)
 {
         CAMLparam1(fd);
         int rc, bytes;
 
         rc = ioctl(Int_val(fd), FIONREAD, &bytes);
         if (rc == -1)
-                raise_inotify_error("ioctl fionread");
+                caml_uerror("ioctl fionread", Nothing);
 
         CAMLreturn(Val_int(bytes));
 }
 
-value stub_inotify_add_watch(value fd, value path, value mask)
+CAMLprim value stub_inotify_add_watch(value fd, value path, value mask)
 {
         CAMLparam3(fd, path, mask);
         int cv_mask, wd;
@@ -89,28 +81,28 @@ value stub_inotify_add_watch(value fd, value path, value mask)
         cv_mask = caml_convert_flag_list(mask, inotify_flag_table);
         wd = inotify_add_watch(Int_val(fd), String_val(path), cv_mask);
         if (wd < 0)
-                raise_inotify_error("add_watch");
+                caml_uerror("inotify_add_watch", Nothing);
         CAMLreturn(Val_int(wd));
 }
 
-value stub_inotify_rm_watch(value fd, value wd)
+CAMLprim value stub_inotify_rm_watch(value fd, value wd)
 {
         CAMLparam2(fd, wd);
         int ret;
 
         ret = inotify_rm_watch(Int_val(fd), Int_val(wd));
         if (ret == -1)
-                raise_inotify_error("rm_watch");
+                caml_uerror("inotify_rm_watch", Nothing);
         CAMLreturn(Val_unit);
 }
 
-value stub_inotify_struct_size(void)
+CAMLprim value stub_inotify_struct_size(void)
 {
         CAMLparam0();
         CAMLreturn(Val_int(sizeof(struct inotify_event)));
 }
 
-value stub_inotify_convert(value buf)
+CAMLprim value stub_inotify_convert(value buf)
 {
         CAMLparam1(buf);
         CAMLlocal3(event, l, tmpl);


### PR DESCRIPTION
It's just not needed and gets in the way. In the original inotify library it was most likely created to avoid dependency on the Unix library, which in this case is not a problem.

Actual errno value is also not always equal between platforms. With Unix library we always get the correct error code. In the original library this was not a concern because only Linux was targeted. inotify-compatible interfaces are now available on BSDs, Darwin (macOS) and (some) illumos-based OS.