### PR TITLE
makefiles: Avoid bashism in make clean

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -454,15 +454,15 @@ clean::
 	-$(RM) -r *.o core gmon.out *~ .*~
 	-$(RM) -r *.obj *.lib *.exp
 	-$(RM) -r *.tmp *.bak?.tmp .*.bak?.tmp
-	-$(RM) system/*.cm[iox] system/*.{o,obj} system/win/*~
-	-$(RM) system/generic/*.cm[iox] system/generic/*.{o,obj} system/generic/*~
-	-$(RM) system/win/*.cm[iox] system/win/*.{o,obj} system/win/*~
-	-$(RM) fsmonitor/*.cm[iox] fsmonitor/*.{o,obj}
+	-$(RM) system/*.cm[iox] system/*.o system/*.obj system/win/*~
+	-$(RM) system/generic/*.cm[iox] system/generic/*.o system/generic/*.obj system/generic/*~
+	-$(RM) system/win/*.cm[iox] system/win/*.o system/win/*.obj system/win/*~
+	-$(RM) fsmonitor/*.cm[iox] fsmonitor/*.o fsmonitor/*.obj
 	-$(RM) .depend.dot.tmp DEPENDENCIES.ps
 	-$(RM) ubase/*.cm[ioxa] ubase/*.cmxa ubase/*.a ubase/*.o ubase/*~ ubase/*.bak
-	-$(RM) lwt/*.cm[ioxa] lwt/*.cmxa lwt/*.a lwt/*.{o,obj} lwt/*~ lwt/*.bak
-	-$(RM) lwt/generic/*.cm[ioxa] lwt/generic/*.cmxa lwt/generic/*.a lwt/generic/*.{o,obj} lwt/generic/*~ lwt/generic/*.bak
-	-$(RM) lwt/win/*.cm[ioxa] lwt/win/*.cmxa lwt/win/*.a lwt/win/*.{o,obj} lwt/win/*~ lwt/win/*.bak
+	-$(RM) lwt/*.cm[ioxa] lwt/*.cmxa lwt/*.a lwt/*.o lwt/*.obj lwt/*~ lwt/*.bak
+	-$(RM) lwt/generic/*.cm[ioxa] lwt/generic/*.cmxa lwt/generic/*.a lwt/generic/*.o lwt/generic/*.obj lwt/generic/*~ lwt/generic/*.bak
+	-$(RM) lwt/win/*.cm[ioxa] lwt/win/*.cmxa lwt/win/*.a lwt/win/*.o lwt/win/*.obj lwt/win/*~ lwt/win/*.bak
 
 .PHONY: paths
 paths:


### PR DESCRIPTION
src/Makefile.OCaml used "*.{o,obj}" which is a bash extension.  make by default uses the system /bin/sh, and that in general does not support bash extensions.

Fixes #808 as tested on NetBSD.