### PR TITLE
Remove non-maintained make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,11 @@ clean:
 	$(MAKE) -C src clean
 
 install:
-	$(MAKE) -C src install
-
-installtext:
-	$(MAKE) -C src install UISTYLE=text
+	@printf "\n\n=========================================\n\
+To install, copy the files src/unison, src/unison-gui (optional),\n\
+src/unison-fsmonitor (optional) and src/fsmonitor.py (optional,\n\
+if unison-fsmonitor does not exist) to a freely chosen location.\n\n\
+Manual page is at man/unison.1 and user manual is at\n\
+doc/unison-manual.pdf, doc/unison-manual.html and doc/unison-manual.txt\n\
+=========================================\n\n\n"
+	@exit 1

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,10 +24,9 @@ NATIVE=true
 
 all:: strings.ml buildexecutable
 
-.PHONY: all clean install doinstall installtext text \
-	runtest repeattest \
-	selftest selftestdebug selftestremote testmerge \
-	checkin installremote
+.PHONY: all clean \
+	repeattest \
+	selftest selftestdebug selftestremote testmerge
 
 ########################################################################
 ## Miscellaneous developer-only switches
@@ -43,34 +42,7 @@ STATIC=false
 include Makefile.OCaml
 
 ######################################################################
-# Installation
-
-INSTALLDIR = $(HOME)/bin/
-
-# This has two names because on OSX the file INSTALL shadows the target 'install'!
-install: doinstall
-
-installtext:
-	$(MAKE) -C .. installtext
-
-text:
-	$(MAKE) -C .. text
-
-# Note that this is not needed (and doesn't work) for the OSX GUI version.
-# Just copy $(UIMACDIR)/build/Default/Unison.app to where you want it.
-doinstall: buildexecutable
-	@if [ ! $(NAME) ]; then \
-	    echo "makefile variable NAME not bound"; \
-	    exit 1 \
-	  ; fi
-	-mv $(INSTALLDIR)/$(NAME)$(EXEC_EXT) /tmp/$(NAME)-$(shell echo $$$$)
-	cp $(NAME)$(EXEC_EXT) $(INSTALLDIR)
-	cp $(NAME)$(EXEC_EXT) $(INSTALLDIR)$(NAME)-$(MAJORVERSION)$(EXEC_EXT)
-
 # For developers
-runtest:
-	$(MAKE) NATIVE=false DEBUG=true text
-	./unison test
 
 repeattest:
 	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text


### PR DESCRIPTION
Getting a properly working and complete install target (that will work for modern package maintainers) will take an unknown amount of time. It's better to remove the current non-maintained and incomplete install target altogether.