### PR TITLE
Improve sync progress status display (mainly TUI)

### DIFF
--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -144,3 +144,20 @@ val transportStart : unit -> unit
 val transportFinish : unit -> unit
 
 val transportItems : 'a array -> ('a -> bool) -> (int -> 'a -> unit Lwt.t) -> unit
+
+(* Statistics of update propagation *)
+module Stats : sig
+  type t
+  val init :
+       Uutil.Filesize.t (* Total size to complete 100% *)
+    -> t
+  val update :
+       t
+    -> float            (* Current absolute time *)
+    -> Uutil.Filesize.t (* Current completed size (not delta) *)
+    -> unit
+  val curRate : t -> float (* Current progress rate, very volatile *)
+  val avgRate1 : t -> float (* Moving average of the rate above, more stable *)
+  val avgRate2 : t -> float (* Double moving average, very stable *)
+  val eta : t -> ?rate:float -> string -> string (* Defaults to rate2 *)
+end

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -787,7 +787,7 @@ type stateItem =
     mutable bytesTransferred : Uutil.Filesize.t;
     mutable bytesToTransfer : Uutil.Filesize.t }
 
-let doTransport reconItemList =
+let doTransport reconItemList numskip isSkip =
   let items =
     Array.map
       (fun ri ->
@@ -796,6 +796,9 @@ let doTransport reconItemList =
           bytesToTransfer = Common.riLength ri})
       (Array.of_list reconItemList)
   in
+  let totalItemsTransferred = ref 0 in
+  let totalItemsToTransfer = Array.length items - numskip in
+  let totalItemsToTransferStr = string_of_int totalItemsToTransfer in
   let totalBytesTransferred = ref Uutil.Filesize.zero in
   let totalBytesToTransfer =
       (Array.fold_left
@@ -804,22 +807,27 @@ let doTransport reconItemList =
   in
   let totalBytesToTransferStr = Util.bytes2string
     (Uutil.Filesize.toInt64 totalBytesToTransfer) in
+  let totalToTransfer =
+    Uutil.Filesize.(add totalBytesToTransfer (ofInt totalItemsToTransfer)) in
   let sta = Uicommon.Stats.init totalBytesToTransfer in
   let calcProgress i bytes dbg =
     let i = Uutil.File.toLine i in
     let item = items.(i) in
     item.bytesTransferred <- Uutil.Filesize.add item.bytesTransferred bytes;
     totalBytesTransferred := Uutil.Filesize.add !totalBytesTransferred bytes;
-    (Uutil.Filesize.percentageOfTotalSize
-       !totalBytesTransferred totalBytesToTransfer)
+    let totalTransferred =
+      Uutil.Filesize.(add !totalBytesTransferred (ofInt !totalItemsTransferred)) in
+    Uutil.Filesize.percentageOfTotalSize totalTransferred totalToTransfer
   in
   let tlog = ref (Unix.gettimeofday ()) in
   let t = ref 0. in
+  let prevItems = ref 0 in
   let displayProgress v =
     let t1 = Unix.gettimeofday () in
     let () = Uicommon.Stats.update sta t1 !totalBytesTransferred in
-    if t1 -. !t >= 0.1 then begin
+    if t1 -. !t >= 0.1 || !prevItems <> !totalItemsTransferred then begin
       t := t1;
+      prevItems := !totalItemsTransferred;
       let remTime =
         if v <= 0. then "--:--"
         else if v >= 100. then "00:00:00"
@@ -833,7 +841,9 @@ let doTransport reconItemList =
       in
       let totalBytesTransferredStr = Util.bytes2string
         (Uutil.Filesize.toInt64 !totalBytesTransferred) in
-      let s = Format.sprintf "%s  (%s of %s)  %s ETA" (Util.percent2string v)
+      let s = Format.sprintf "%s  %d/%s  (%s of %s)  %s ETA"
+        (Util.percent2string v)
+        !totalItemsTransferred totalItemsToTransferStr
         totalBytesTransferredStr totalBytesToTransferStr remTime in
 
       if not (Prefs.read Trace.terse) && (Prefs.read Trace.debugmods = []) then
@@ -901,16 +911,23 @@ let doTransport reconItemList =
   let fFailedPaths = ref [] in
   let fPartialPaths = ref [] in
   let notstarted = ref (Array.length items) in
+  let progressItem i =
+    incr totalItemsTransferred;
+    showProgress (Uutil.File.ofLine i) Uutil.Filesize.zero "itm"
+  in
   let uiWrapper i item =
     Lwt.try_bind
       (fun () -> decr notstarted;
                  Transport.transportItem item.ri
                    (Uutil.File.ofLine i) verifyMerge)
       (fun () ->
-         if partiallyProblematic item.ri && not (problematic item.ri) then
+         let notSkip = not (isSkip item.ri) in
+         if partiallyProblematic item.ri && notSkip then
            fPartialPaths := item.ri.path1 :: !fPartialPaths;
+         if notSkip then progressItem i;
          Lwt.return ())
       (fun e ->
+        if not (isSkip item.ri) then progressItem i;
         match e with
           Util.Transient s ->
             let rem =
@@ -976,10 +993,11 @@ let rec interactAndPropagateChanges prevItemList reconItemList
       : bool * bool * bool * bool * (Path.t list)
         (* anySkipped?, anyPartial?, anyFailures?, anyCancels?, failingPaths *) =
   let (proceed,newReconItemList) = interact prevItemList reconItemList in
+  let isSkip = problematic in
   let (updatesToDo, skipped, (totalBytesToRoot1, totalBytesToRoot2)) =
     Safelist.fold_left
       (fun (howmany, skipped, (bytes1, bytes2)) ri ->
-        if problematic ri then (howmany, skipped + 1, (bytes1, bytes2))
+        if isSkip ri then (howmany, skipped + 1, (bytes1, bytes2))
         else (howmany + 1, skipped,
           match ri.replicas with
           | Problem _ -> (bytes1, bytes2)
@@ -1006,9 +1024,9 @@ let rec interactAndPropagateChanges prevItemList reconItemList
        (Util.bytes2string (Uutil.Filesize.toInt64 totalBytesToRoot2)) root1 root2
        (Util.bytes2string (Uutil.Filesize.toInt64 totalBytesToRoot1)) root2 root1)
   end;
-  let doTransp newReconItemList =
+  let doTransp () =
     try
-      doTransport newReconItemList
+      doTransport newReconItemList skipped isSkip
     with e ->
       let origbt = Printexc.get_raw_backtrace () in
       let summary =
@@ -1029,7 +1047,7 @@ let rec interactAndPropagateChanges prevItemList reconItemList
     if not (Prefs.read Globals.batch || Prefs.read Trace.terse) then newLine();
     if not (Prefs.read Trace.terse) then Trace.status "Propagating updates";
     let timer = Trace.startTimer "Transmitting all files" in
-    let (failedPaths, partialPaths, notstarted, intr) = doTransp newReconItemList in
+    let (failedPaths, partialPaths, notstarted, intr) = doTransp () in
     let failures = Safelist.length failedPaths in
     let partials = Safelist.length partialPaths in
     Trace.showTimer timer;

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -798,13 +798,12 @@ let doTransport reconItemList =
   in
   let totalBytesTransferred = ref Uutil.Filesize.zero in
   let totalBytesToTransfer =
-    ref
       (Array.fold_left
          (fun s item -> Uutil.Filesize.add item.bytesToTransfer s)
          Uutil.Filesize.zero items)
   in
   let totalBytesToTransferStr = Util.bytes2string
-    (Uutil.Filesize.toInt64 !totalBytesToTransfer) in
+    (Uutil.Filesize.toInt64 totalBytesToTransfer) in
   let t0 = Unix.gettimeofday () in
   let calcProgress i bytes dbg =
     let i = Uutil.File.toLine i in
@@ -815,7 +814,7 @@ let doTransport reconItemList =
       (Uutil.Filesize.toInt64 !totalBytesTransferred) in
     let v =
       (Uutil.Filesize.percentageOfTotalSize
-         !totalBytesTransferred !totalBytesToTransfer)
+         !totalBytesTransferred totalBytesToTransfer)
     in
     let t1 = Unix.gettimeofday () in
     let remTime =

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -890,6 +890,8 @@ let doTransport reconItemList =
       Printexc.raise_with_backtrace e origbt
   in
 
+  if not (Prefs.read Trace.terse) && (Prefs.read Trace.debugmods = []) then
+    Util.set_infos "Starting...";
   Uicommon.transportStart ();
   let fFailedPaths = ref [] in
   let fPartialPaths = ref [] in


### PR DESCRIPTION
### Motivation

There are more details in commit messages and code comments, but the basic premise is that the current ETA calculation is just not good enough, for various underlying reasons. To improve calculation of ETA, we need to improve calculation of the progress rate.

The nature of actions taken during a sync makes the rate of progress highly volatile and this is not something that can be easily changed (but maybe improved upon in future). This PR focuses on trying to get reasonably usable results out of the volatile data. In other words, it's mostly about algorithms.

### Description

Two new progress rates are calculated: a less stable one which is suitable for displaying to users and a more stable one which is suitable for ETA calculation. The less stable rate is calculated as an exponential moving average (aka exponential smoothing) of the actual sync rate (which is simply calculated as delta synced bytes over delta time). The more stable rate is calculated as an exponential moving average of the former rate (double smoothing) with an additional Gaussian filter to exclude tiny changes. I've done countless tests to end up with these algorithms and these constant values. It's impractical to go any further without an automated setup... and I'm not going to do that (just yet).

The ETA itself is no longer calculated to a resolution of 1 second (except for ETA under 2 minutes) because even with very stable calculated rate, ETA for longer syncs can change several (tens of) seconds for just a tiny rate change.

Further details are included in collapsed sections.

<details>

<summary><b>Open this section for detailed motivation with illustrations...</b></summary>

<br/>

_But is the current state really that bad?_

Yes, it is. This is a graph of a real sync, showing the actual rate and the rate used for ETA calculation. Here and onwards, all graphs represent real syncs not simulations, x-axis is always in seconds, y-axis is in bytes/s, and "Current rate" indicates the actual "raw" sync rate at any moment of time.

![image](https://user-images.githubusercontent.com/69477666/231439139-e5b2f98b-43f1-4a9f-8c25-848bab99bc53.png)

_But this isn't so bad..._  Sure it is, let's just zoom in.

![image](https://user-images.githubusercontent.com/69477666/231439896-fa0405f5-92ac-467f-860c-ed9eb1079807.png)

The ETA is calculated at 2-3x times the actual rate. A 3 minute sync is displayed as 1 minute ETA.

_Does it really matter?_  Yes, it does. The examples here are of syncs lasting a few minutes only. It gets much-much worse for syncs lasting hours.

_Are the new algorithms any better?_  Yes, this is the same graph with the ETA rate calculated by the new algorithm.

![image](https://user-images.githubusercontent.com/69477666/231440989-a13d56ce-b6f4-4802-ab17-3c45049cbc48.png)

And zoomed in...

![image](https://user-images.githubusercontent.com/69477666/231441211-50c9068d-0bbc-465f-83d9-5159193b0ff7.png)

_Ok, so that does look better. But is the code complexity worth it?_

I believe it is (but simpler code achieving the same or better results is even better!). This is a real-world example of raw input data:

![image](https://user-images.githubusercontent.com/69477666/231443424-cc60fb75-141c-445b-976c-f8b038e174fd.png)

Looks like the sync rate is zero most of the time? But it really isn't; look at the scale of y-axis! Zooming in, we see:

![image](https://user-images.githubusercontent.com/69477666/231443695-85c2eda9-91bb-48d2-8e5e-cd668862abeb.png)

Simpler algorithms are simply unable to smooth out these fluctuations while at the same time remaining capable of responding to the huge changes (between ~1MB/s to tens and hundreds of MB/s). This is what a simple moving average would look like when zoomed in (the plot lines are thinner to better show detail). This is not good enough for ETA calculation.

![image](https://user-images.githubusercontent.com/69477666/231445230-f644b0e1-8974-4f2a-a645-f50d0bee1ca8.png)

The most obvious downside of smoothing the rate for ETA calculation is that actual average rate changes (not just fluctuations) are also smoothed out. This can be seen by looking at the huge changes in the current rate on graphs above. The actual rate change looks like a right angle; just look at how long it takes for the average rate to catch up to that change.  The real trick is finding the balance between stability and responsiveness. ETA calculation requires _very_ stable input.

</details>

<details>

<summary><b>Open this section for more illustrations...</b></summary>

uigtk already had implemented a kind of exponential rate smoothing algorithm. But it was not used for calculating the ETA because it was still much too volatile. Here are some comparisons.

Zoomed out:
![image](https://user-images.githubusercontent.com/69477666/231447816-c02fce3b-7ae6-4731-968f-4cb8459f52ad.png)

And zoomed in:
![image](https://user-images.githubusercontent.com/69477666/231447943-7e07be88-b704-4e32-8c8d-4cd0b7f0bce3.png)

The zoomed in section also illustrates well why there is a need for double smoothing.

It's not always fun and games, though. Here, the algorithm just can't produce a stable rate because the volatility in input data is too much. Note that in this case the old ETA algorithm would possibly produce a better result, right up until the average rate changes around 225 seconds mark.

![image](https://user-images.githubusercontent.com/69477666/231449869-a494119c-ad62-4695-b39c-5cfdd4c16942.png)

Here, the old ETA calculation seems to be more stable:
![image](https://user-images.githubusercontent.com/69477666/231452807-fa76c605-9791-4d70-9655-e0f21d13fe9b.png)

Another example of the extreme rate volatility. Note the scale on y-axis.
![image](https://user-images.githubusercontent.com/69477666/231451170-d79c16db-4098-42fb-845f-d2939a3acce4.png)

![image](https://user-images.githubusercontent.com/69477666/231453533-507be593-5313-4737-a325-ab1920df2b7f.png)

Section of previous graph zoomed in, comparing simple moving average (avg1) to the double-smoothed rate (note that the legend has changed):
![image](https://user-images.githubusercontent.com/69477666/231454474-2d566f7e-4098-4f32-8800-e514cf262aaa.png)

</details>

### There's more

This PR also in a very minor way improves #816 (I didn't see a reason to split it out into a separate PR -- but it can be easily done). The status display in TUI now shows the number of updates in addition to bytes.

Overall, the status display in TUI has become rather busy with this. For short syncs this could be distracting. For longer syncs, I consider the additional info valuable. It now looks like this:
```
 20%  0/2  (11.6 MiB of 57.1 MiB)   6.1 MiB/s    00:00:05 ETA
```
("0/2" indicates number of completed and total items). Just recently the status display looked like this:
```
 20%  00:05 ETA
```