### PR TITLE
Makefile: Make all .PHONY declarations local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Unison file synchronizer: Makefile
 # See LICENSE for terms.
 
-.PHONY: all src docs manpage test depend clean install
-
+.PHONY: all
 all: src manpage
 
+.PHONY: src
 src:
 	$(MAKE) -C src
 
@@ -12,6 +12,7 @@ src:
 # Having docs build src/unison points out that UISTYLE is a bug; either
 # docs might build the GUI (not wanted as too heavy for docs use), or
 # whatever is built might not be rebuilt later.
+.PHONY: docs
 docs:
 	$(MAKE) -C src UISTYLE=text
 	$(MAKE) -C doc
@@ -19,20 +20,25 @@ docs:
 
 # "src" is a prerequisite to prevent parallel build errors.
 # manpage builds currently require a pre-built "unison" binary.
+.PHONY: manpage
 manpage: src
 	$(MAKE) -C man
 
+.PHONY: test
 test:
 	./src/unison -ui text -selftest
 
+.PHONY: depend
 depend:
 	$(MAKE) -C src depend
 
+.PHONY: clean
 clean:
 	$(MAKE) -C doc clean
 	$(MAKE) -C man clean
 	$(MAKE) -C src clean
 
+.PHONY: install
 install:
 	@printf "\n\n=========================================\n\
 To install, copy the files src/unison, src/unison-gui (optional),\n\

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,11 +22,8 @@ NATIVE=true
 ######################################################################
 # Building installation instructions
 
+.PHONY: all
 all:: strings.ml buildexecutable
-
-.PHONY: all clean \
-	repeattest \
-	selftest selftestdebug selftestremote testmerge
 
 ########################################################################
 ## Miscellaneous developer-only switches
@@ -44,22 +41,27 @@ include Makefile.OCaml
 ######################################################################
 # For developers
 
+.PHONY: repeattest
 repeattest:
 	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
 	./unison noprofile a.tmp b.tmp -repeat foo.tmp -debug ui
 
+.PHONY: selftest
 selftest:
 	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
 	./unison -selftest -ui text -batch
 
+.PHONY: selftestdebug
 selftestdebug:
 	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
 	./unison -selftest -ui text -batch -debug all
 
+.PHONY: selftestremote
 selftestremote:
 	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
 	./unison -selftest -ui text -batch test.tmp ssh://eniac.seas.upenn.edu/test.tmp
 
+.PHONY: testmerge
 testmerge:
 	$(MAKE) all NATIVE=false UISTYLE=text
 	-rm -rf a.tmp b.tmp
@@ -175,7 +177,6 @@ ETAGS=etags
 # after the first invocation.  The .PHONY declaration makes it work
 # again.
 .PHONY: tags
-
 tags:
 	@-if command -v $(ETAGS) > /dev/null ; then \
 	    $(ETAGS) *.mli */*.mli *.ml */*.ml */*.m *.c */*.c *.txt \
@@ -190,6 +191,7 @@ TAGS:
 ######################################################################
 # Misc
 
+.PHONY: clean
 clean::
 	-$(RM) *.log *.aux *.log *.dvi *.out *.bak
 	-$(RM) -r obsolete

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -348,10 +348,11 @@ system.cmx fspath.cmx fs.cmx: system/$(SYSTEM)/system_impl.cmx
 lwt/lwt_unix.cmo: lwt/$(SYSTEM)/lwt_unix_impl.cmo
 lwt/lwt_unix.cmx: lwt/$(SYSTEM)/lwt_unix_impl.cmx
 
-.PHONY: depend dependgraph
+.PHONY: depend
 depend::
 	ocamlc -depend $(DEP_INCLFLAGS) *.mli *.ml */*.ml */*.mli */*/*.ml */*/*.mli > .depend
 
+.PHONY: dependgraph
 dependgraph: depend
 	echo 'digraph G {' > .depend.dot.tmp
 	echo '{ rank = same; "Fileinfo"; "Props"; "Fspath"; "Os"; "Path"; }'\


### PR DESCRIPTION
This makes maintenance easier. (It also makes it more clear which targets really are phony, although that's likely not a real problem for anyone.)