### PR TITLE
Fix incomplete sync when `maxthreads = 1`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -432,9 +432,9 @@ jobs:
         index 60ccd05..45395e5 100644
         --- a/src/test.ml
         +++ b/src/test.ml
-        @@ -338,43 +338,6 @@ let test() =
-              running fast enough that the whole thing happens within a second, then the
-              update will be missed! *)
+        @@ -351,43 +351,6 @@ let test() =
+             )
+           done;
          
         -  (* Test that .git is treated atomically. *)
         -  runtest "Atomicity of certain directories 1" ["atomic = Name .git";

--- a/src/test.ml
+++ b/src/test.ml
@@ -235,12 +235,9 @@ let sync ?(verbose=false) () =
     displayRis reconItemList
   end;
   minisleep 0.1;
-  Lwt_unix.run (
-    Lwt_util.iter
-      (fun ri ->
-         Transport.transportItem ri
-           (Uutil.File.ofLine 0) (fun _ _ -> true))
-      reconItemList);
+  Uicommon.transportItems (Array.of_list reconItemList) (fun _ -> true)
+    (fun _ ri ->
+      Transport.transportItem ri (Uutil.File.ofLine 0) (fun _ _ -> true));
   Update.commitUpdates()
 
 let currentTest = ref ""
@@ -337,6 +334,22 @@ let test() =
      just written.  If the length of the contents is also the same and the test is
      running fast enough that the whole thing happens within a second, then the
      update will be missed! *)
+
+  (* Test that update propagation transport works *)
+  let maxth = [| "0"; "1"; "5"; "6"; "7" |] in
+    (* Number of threads: default (0); 1 (corner case);
+       one less, equal to, and one more than number of updates *)
+  for i = 1 to Array.length maxth do
+    runtest ("propagation 1." ^ string_of_int i) ["maxthreads = " ^ maxth.(i - 1)] (fun () ->
+      put R1 (Dir []); put R2 (Dir []); sync ();
+      let r1 = ["a", File "a"; "b", File "b"; "d1", Dir ["a", File "a1"; "b", File "b1"]]
+      and r2 = ["x", File "x"; "y", File "y"; "d2", Dir ["x", File "x2"; "y", File "y2"]] in
+      let expect = Dir (r1 @ r2) in
+      put R1 (Dir r1); put R2 (Dir r2); sync ();
+      check "1" R1 expect;
+      check "2" R2 expect
+    )
+  done;
 
   (* Test that .git is treated atomically. *)
   runtest "Atomicity of certain directories 1" ["atomic = Name .git";

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -731,8 +731,8 @@ let transportItems items pRiThisRound makeAction =
   in
 
   starting (); (* Count the dispense loop as one of the tasks to complete *)
-  Transport.run dispenseAction;
   try
+    Transport.run dispenseAction;
     Lwt_unix.run (waitAllCompleted ())
   with e -> begin
     (* Cleanup procedure must never raise exceptions. Just in case,

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1040,6 +1040,7 @@ let rec interactAndPropagateChanges prevItemList reconItemList
           ^ (match e with Sys.Break -> " by user request" | _ -> " due to a fatal error")
           ^ "\n\n"
       in
+      Util.set_infos "";
       Trace.log_color summary;
       Printexc.raise_with_backtrace e origbt
   in


### PR DESCRIPTION
Fix an issue reported on mailing list. Sync would always finish after only 2 transfers and report all other transfers as "not started". This issue only manifests with preference `maxthreads = 1`.