### PR TITLE
Fixes for Windows and Cygwin

### DIFF
--- a/src/copy.ml
+++ b/src/copy.ml
@@ -329,11 +329,11 @@ let openFileOut' fspath path kind len =
       let fullpath = Fspath.concat fspath path in
       let flags = [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_CLOEXEC] in
       let perm = if Prefs.read Props.dontChmod then Props.perms Props.fileDefault else 0o600 in
-      begin match Util.osType with
-        `Win32 ->
+      begin match Sys.win32 with
+      | true ->
           Fs.open_out_gen
             [Open_wronly; Open_creat; Open_excl; Open_binary] perm fullpath
-      | `Unix ->
+      | false ->
           let fd =
             try
               Fs.openfile fullpath (Unix.O_EXCL :: flags) perm

--- a/src/external.ml
+++ b/src/external.ml
@@ -28,7 +28,7 @@ open Lwt
 (* For backwards compatibility with OCaml < 4.12 *)
 let path =
   try
-    Str.split (Str.regexp (if Util.osType = `Win32 then ";" else ":"))
+    Str.split (Str.regexp (if Sys.win32 then ";" else ":"))
       (Sys.getenv "PATH")
   with Not_found ->
     []
@@ -51,7 +51,7 @@ let search_in_path ?(path = path) name =
 let close_process_noerr close pid x =
   let pid = pid x in
   begin try
-    Unix.kill pid (if Sys.os_type = "Win32" then Sys.sigkill else Sys.sigterm)
+    Unix.kill pid (if Sys.win32 then Sys.sigkill else Sys.sigterm)
     with Unix.Unix_error _ -> () end;
   begin try ignore (Terminal.safe_waitpid pid) with Unix.Unix_error _ -> () end;
   try ignore (close x) with Sys_error _ | Unix.Unix_error _ -> ()
@@ -110,7 +110,7 @@ let readChannelsTillEof l =
 
 
 let runExternalProgramAux ~winProc ~posixProc =
-  if Util.osType = `Win32 && not Util.isCygwin then begin
+  if Sys.win32 then begin
     debug (fun()-> Util.msg "Executing external program windows-style\n");
     let c = winProc () in
     let log = Util.trimWhitespace (readChannelTillEof c) in

--- a/src/files.ml
+++ b/src/files.ml
@@ -61,7 +61,7 @@ let clearCommitLog tmpName =
     | Sys_error _ | Unix.Unix_error _ -> commitLogName
   in
   let commitLogUnlinkPath =
-    if Util.osType = `Win32 then commitLogNameWin () else commitLogName in
+    if Sys.unix then commitLogName else commitLogNameWin () in
 
   Util.convertUnixErrorsToFatal
     "clearing commit log"
@@ -337,7 +337,7 @@ let performRename fspathTo localPathTo workingDir pathFrom pathTo prevArch =
         match (filetypeFrom, filetypeTo) with
         | (_, `ABSENT)            -> false
         | ((`FILE | `SYMLINK),
-           (`FILE | `SYMLINK))    -> Util.osType <> `Unix
+           (`FILE | `SYMLINK))    -> Sys.win32
         | _                       -> true (* Safe default *) in
       if moveFirst then begin
         debug (fun() -> Util.msg "rename: moveFirst=true\n");

--- a/src/fsmonitor/watchercommon.ml
+++ b/src/fsmonitor/watchercommon.ml
@@ -18,7 +18,7 @@
 let debug = ref false
 
 let _ =
-  if Sys.os_type = "Unix" then
+  if Sys.unix || Sys.cygwin then
     ignore(Sys.set_signal Sys.sigpipe Sys.Signal_ignore)
 
 module StringMap = Map.Make(String)

--- a/src/fswatch.ml
+++ b/src/fswatch.ml
@@ -223,7 +223,7 @@ let read_line i =
 
 let path =
     try
-       Str.split (Str.regexp (if Util.osType = `Win32 then ";" else ":"))
+       Str.split (Str.regexp (if Sys.win32 then ";" else ":"))
          (Sys.getenv "PATH")
      with Not_found ->
        []
@@ -261,7 +261,7 @@ let exec_dir = List.map Filename.dirname exec_path
 
 let watcher =
   lazy
-    (let suffix = if Util.osType = `Win32 then ".exe" else "" in
+    (let suffix = if Sys.win32 || Sys.cygwin then ".exe" else "" in
      debug (fun () -> Util.msg "File monitoring helper program...\n");
        (try
           search_in_path ~path:(exec_dir @ path)

--- a/src/lock.ml
+++ b/src/lock.ml
@@ -42,8 +42,8 @@ let acquire name =
   Util.convertUnixErrorsToTransient
     "Lock.acquire"
     (fun () ->
-       match Util.osType with
-         `Unix -> (* O_EXCL is broken under NFS... *)
+       match Sys.unix with
+       | true -> (* O_EXCL is broken under NFS... *)
            rename (unique name (Unix.getpid ()) 0o600) name
        | _ ->
            create name 0o600)

--- a/src/lwt/generic/lwt_unix_impl.ml
+++ b/src/lwt/generic/lwt_unix_impl.ml
@@ -13,7 +13,7 @@ therefore have the following limitations:
   time, this could result in a dead-lock.
 - [connect] is blocking
 *)
-let windows_hack = Sys.os_type <> "Unix"
+let windows_hack = Sys.win32
 
 module SleepQueue =
   Pqueue.Make (struct

--- a/src/os.ml
+++ b/src/os.ml
@@ -68,7 +68,7 @@ let readLink fspath path =
     (fun () ->
        let abspath = Fspath.concat fspath path in
        let l = Fs.readlink abspath in
-       if Util.osType = `Win32 then
+       if Sys.win32 || Sys.cygwin then
          Fileutil.backslashes2forwardslashes l
        else
          l
@@ -174,7 +174,7 @@ and delete fspath path =
             (allChildrenOf fspath path);
           Fs.rmdir absolutePath
       | `FILE ->
-          if Util.osType <> `Unix then begin
+          if not Sys.unix then begin
             try
               Fs.chmod absolutePath 0o600;
             with Unix.Unix_error _ -> ()
@@ -226,7 +226,7 @@ let symlink =
                   "Cannot create symlink \"%s\": \
                    symlinks are not supported on this system%s"
                   (Fspath.toPrintString (Fspath.concat fspath path))
-                  (if Util.osType = `Win32 then
+                  (if Sys.win32 || Sys.cygwin then
                      " or elevated privileges may be required"
                   else "")
                ))

--- a/src/osx.ml
+++ b/src/osx.ml
@@ -322,20 +322,14 @@ let getFileInfos dataFspath dataPath typ =
             { ressInfo =
                 if rsrcLength = 0L then NoRess else
                 AppleDoubleRess
-                  (begin match Util.osType with
-                     `Win32 -> 0
-                   | `Unix  -> (* The inode number is truncated so that
-                                  it fits in a 31 bit ocaml integer *)
-                               stats.Unix.LargeFile.st_ino land 0x3FFFFFFF
+                  (begin
+                   if Sys.win32 || Sys.cygwin then 0
+                   else (* The inode number is truncated so that
+                           it fits in a 31 bit ocaml integer *)
+                     stats.Unix.LargeFile.st_ino land 0x3FFFFFFF
                    end,
                    stats.Unix.LargeFile.st_mtime,
-                   begin match Util.osType with
-                     `Win32 -> (* Was "stats.Unix.LargeFile.st_ctime", but
-                                  this was bogus: Windows ctimes are
-                                  not reliable.  [BCP, Apr 07] *)
-                       0.
-                   | `Unix  -> 0.
-                   end,
+                   0.,
                    Uutil.Filesize.ofInt64 rsrcLength,
                    (doubleFspath, rsrcOffset));
               finfo = extractInfo typ finfo }

--- a/src/path.ml
+++ b/src/path.ml
@@ -105,7 +105,7 @@ let deconstructRev path =
 let winAbspathRx = Rx.rx "([a-zA-Z]:)?(/|\\\\).*"
 let unixAbspathRx = Rx.rx "/.*"
 let is_absolute s =
-  if Util.osType=`Win32 then Rx.match_string winAbspathRx s
+  if Sys.win32 || Sys.cygwin then Rx.match_string winAbspathRx s
   else Rx.match_string unixAbspathRx s
 
 (* Function string2path: string -> path
@@ -151,7 +151,7 @@ let is_absolute s =
 *)
 let fromString str =
   let str0 = str in
-  let str = if Util.osType = `Win32 then Fileutil.backslashes2forwardslashes str else str in
+  let str = if Sys.win32 || Sys.cygwin then Fileutil.backslashes2forwardslashes str else str in
   if is_absolute str then
     raise (Util.Transient
              (Printf.sprintf "The path '%s' is not a relative path" str));

--- a/src/props.ml
+++ b/src/props.ml
@@ -99,8 +99,8 @@ let permMask =
 
 (* Os-specific local conventions on file permissions                         *)
 let (fileDefault, dirDefault, fileSafe, dirSafe) =
-  match Util.osType with
-    `Win32 ->
+  match Sys.win32 with
+  | true ->
       debug
         (fun() ->
            Util.msg "Using windows defaults for file permissions");
@@ -108,7 +108,7 @@ let (fileDefault, dirDefault, fileSafe, dirSafe) =
        (0o700, -1), (* rwx------ *)
        (0o600, -1), (* rw------- *)
        (0o700, -1)) (* rwx------ *)
-  | `Unix ->
+  | false ->
       let umask =
         let u = Unix.umask 0 in
         ignore (Unix.umask u);

--- a/src/pty.c
+++ b/src/pty.c
@@ -31,7 +31,7 @@
 #endif
 
 // openpty
-#if defined(__linux)
+#if defined(__linux) || defined(__CYGWIN__)
 #include <pty.h>
 #define HAS_OPENPTY 1
 #endif
@@ -54,6 +54,10 @@
 
 CAMLprim value setControllingTerminal(value fdVal) {
   CAMLparam1(fdVal);
+#if defined(__CYGWIN__)
+  /* [Unix.setsid] is not implemented on Cygwin; call it here instead */
+  if (setsid() < 0) caml_uerror("setsid", Nothing);
+#endif
   int fd = Int_val(fdVal);
   if (ioctl(fd, TIOCSCTTY, (char *) 0) < 0)
     caml_uerror("ioctl", (value) 0);

--- a/src/pty.c
+++ b/src/pty.c
@@ -225,11 +225,10 @@ static void prepareSiWithPty(value prog, STARTUPINFOEX *si, HPCON pty)
 #endif
 }
 
-CAMLprim value w_create_process_pty_native
-  (value prog, value args, value pty, value fd1, value fd2, value fd3)
+CAMLprim value w_create_process_pty
+  (value prog, value args, value pty, value fd1, value fd2)
 {
   CAMLparam5(prog, args, pty, fd1, fd2);
-  CAMLxparam1(fd3);
   int res, flags;
   BOOL err = FALSE;
   PROCESS_INFORMATION pi;
@@ -237,7 +236,7 @@ CAMLprim value w_create_process_pty_native
   wchar_t fullname[MAX_PATH];
   wchar_t *wprog, *wargs;
   HANDLE hp;
-  HANDLE inherit[3];
+  HANDLE inherit[2];
   HPCON hpc = *((HPCON *) Data_abstract_val(pty));
 
 #ifndef PROC_THREAD_ATTRIBUTE_HANDLE_LIST
@@ -267,19 +266,21 @@ CAMLprim value w_create_process_pty_native
     err = TRUE;
     goto clean2;
   }
-  if (!DuplicateHandle(hp, Handle_val(fd3), hp, &(si.StartupInfo.hStdError),
-      0, TRUE, DUPLICATE_SAME_ACCESS)) {
-    caml_win32_maperr(GetLastError());
-    err = TRUE;
-    goto clean3;
-  }
+  /* hStdError is set to NULL because of Cygwin-linked child processes
+     otherwise not detecting the controlling terminal. This would not be
+     relevant for a native Windows binary but it may happen that Windows users
+     have Cygwin or MSYS2 (or Git for Windows) in path before Windows system
+     dirs, so the ssh client ends up being a Cygwin/MSYS2 binary. If hStdError
+     is not set to NULL then a Cygwin/MSYS2 ssh executed with a Windows pty
+     will not have functions that require a controlling terminal (such as
+     interactive auth). */
+  si.StartupInfo.hStdError = NULL;
   si.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
 
   inherit[0] = si.StartupInfo.hStdInput;
   inherit[1] = si.StartupInfo.hStdOutput;
-  inherit[2] = si.StartupInfo.hStdError;
   if (!UpdateProcThreadAttribute(si.lpAttributeList, 0,
-      PROC_THREAD_ATTRIBUTE_HANDLE_LIST, inherit, sizeof(HANDLE) * 3,
+      PROC_THREAD_ATTRIBUTE_HANDLE_LIST, inherit, sizeof(HANDLE) * 2,
       NULL, NULL)) {
     caml_win32_maperr(GetLastError());
     err = TRUE;
@@ -299,7 +300,6 @@ CAMLprim value w_create_process_pty_native
   }
 
 clean4:
-  CloseHandle(si.StartupInfo.hStdError);
 clean3:
   CloseHandle(si.StartupInfo.hStdOutput);
 clean2:
@@ -315,12 +315,6 @@ clean1:
   CloseHandle(pi.hThread);
   CAMLreturn(Val_long(pi.hProcess));
 #endif
-}
-
-CAMLprim value w_create_process_pty(value *argv, int argn)
-{
-  return w_create_process_pty_native(argv[0], argv[1], argv[2],
-                                     argv[3], argv[4], argv[5]);
 }
 
 CAMLprim value win_alloc_console(value unit)

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -29,7 +29,7 @@ let debugT = Trace.debug "remote+"
 *)
 
 let _ =
-  if Sys.os_type = "Unix" then
+  if Sys.unix || Sys.cygwin then
     ignore(Sys.set_signal Sys.sigpipe Sys.Signal_ignore)
 
 (*
@@ -472,7 +472,7 @@ let checkConnection ioServer =
   connectionCheck := Some ioServer;
   (* Poke on the socket to trigger an error if connection has been lost. *)
   Lwt_unix.run (
-    (if (Util.osType = `Win32) then Lwt.return 0 else
+    (if Sys.win32 then Lwt.return 0 else
     Lwt_unix.read ioServer.inputBuffer.channel ioServer.inputBuffer.buffer 0 0)
     (* Try to make sure connection cleanup, if necessary, has finished
        before returning.

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -1820,13 +1820,13 @@ let buildShellConnection shell host userOpt portOpt rootName termInteract =
     else
       "") in
   let preargs =
-      ([shellCmd]@userArgs@portArgs@
+    (userArgs @ portArgs @
        [host]@
        (if shell="ssh" then ["-e none"] else [])@
        [shellCmdArgs;remoteCmd]) in
   (* Split compound arguments at space chars, to make
      create_process happy *)
-  let args =
+  let args = [shellCmd] @
     Safelist.concat
       (Safelist.map (fun s -> Util.splitIntoWords s ' ') preargs) in
   let argsarray = Array.of_list args in

--- a/src/remote.ml
+++ b/src/remote.ml
@@ -1835,15 +1835,6 @@ let buildShellConnection shell host userOpt portOpt rootName termInteract =
   (* We need to make sure that there is only one reader and one
      writer by pipe, so that, when one side of the connection
      dies, the other side receives an EOF or a SIGPIPE. *)
-  (* We add CYGWIN=binmode to the environment before calling
-     ssh because the cygwin implementation on Windows sometimes
-     puts the pipe in text mode (which does end of line
-     translation).  Specifically, if unison is invoked from
-     a DOS command prompt or other non-cygwin context, the pipe
-     goes into text mode; this does not happen if unison is
-     invoked from cygwin's bash.  By setting CYGWIN=binmode
-     we force the pipe to remain in binary mode. *)
-  System.putenv "CYGWIN" "binmode";
   debug (fun ()-> Util.msg "Shell connection: %s (%s)\n"
            shellCmd (String.concat ", " args));
   let (term, termPid) =
@@ -2096,15 +2087,6 @@ let openConnectionStart clroot =
           (* We need to make sure that there is only one reader and one
              writer by pipe, so that, when one side of the connection
              dies, the other side receives an EOF or a SIGPIPE. *)
-          (* We add CYGWIN=binmode to the environment before calling
-             ssh because the cygwin implementation on Windows sometimes
-             puts the pipe in text mode (which does end of line
-             translation).  Specifically, if unison is invoked from
-             a DOS command prompt or other non-cygwin context, the pipe
-             goes into text mode; this does not happen if unison is
-             invoked from cygwin's bash.  By setting CYGWIN=binmode
-             we force the pipe to remain in binary mode. *)
-          System.putenv "CYGWIN" "binmode";
           debug (fun ()-> Util.msg "Shell connection: %s (%s)\n"
                    shellCmd (String.concat ", " args));
           let (term,pid) =

--- a/src/system/system_generic.ml
+++ b/src/system/system_generic.ml
@@ -81,7 +81,7 @@ let close_process_full = Unix.close_process_full
 
 (****)
 
-let isNotWindows = Sys.os_type <> "Win32"
+let isNotWindows = not Sys.win32
 
 (* Note that Cygwin provides some kind of inode numbers, but we only
    have access to the lower 32 bits on 32bit systems... *)

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -233,7 +233,9 @@ let unix_create_session cmd args new_stdin new_stdout new_stderr =
             (* new_stderr will be used by parent process only. *)
             if new_stderr <> Unix.stderr then safe_close new_stderr;
             Unix.close masterFd;
-            ignore (Unix.setsid ());
+            (* [Unix.setsid] is not implemented on Cygwin, reason unknown.
+               It will be called by [setControllingTerminal] instead. *)
+            if not Sys.cygwin then ignore (Unix.setsid ());
             setControllingTerminal slaveFd;
             (* WARNING: SETTING ECHO TO FALSE! *)
             let tio = Unix.tcgetattr slaveFd in

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -117,7 +117,7 @@ let rec safe_waitpid pid =
         Unix.sleepf 0.002;
         let dt = Unix.gettimeofday () -. t in
         if dt >= 0.5 && st = 0 then begin
-          kill_noerr Sys.(if os_type = "Win32" then sigkill else sigterm);
+          kill_noerr Sys.(if win32 then sigkill else sigterm);
           aux 1
         end else if dt >= 2.0 && st = 1 then begin
           kill_noerr Sys.sigkill;
@@ -158,7 +158,7 @@ let finally f g =
 external win_alloc_console : unit -> Unix.file_descr option = "win_alloc_console"
 
 let fallback_session cmd args new_stdin new_stdout new_stderr =
-  if Sys.os_type = "Win32" then begin
+  if Sys.win32 then begin
     (* OCaml's [Unix.create_process] hides the Windows console window of
        the child process unless the parent process already has a console.
        This is unsuitable for running interactive child processes like

--- a/src/ubase/trace.ml
+++ b/src/ubase/trace.ml
@@ -135,7 +135,7 @@ let closelog _ =
       logch := None
 
 let _ =
-  if Util.osType <> `Win32 || Util.isCygwin then
+  if Sys.unix || Sys.cygwin then
     try
       ignore (Sys.signal Sys.sigusr1 (Signal_handle closelog))
     with e ->

--- a/src/ubase/util.ml
+++ b/src/ubase/util.ml
@@ -290,18 +290,6 @@ let blockSignals sigs f =
     Printexc.raise_with_backtrace e origbt
 
 (*****************************************************************************)
-(*                         OS TYPE                                           *)
-(*****************************************************************************)
-
-let osType =
-  match Sys.os_type with
-    "Win32" | "Cygwin" -> `Win32
-  | "Unix"             -> `Unix
-  | other              -> raise (Fatal ("Unknown OS: " ^ other))
-
-let isCygwin = (Sys.os_type = "Cygwin")
-
-(*****************************************************************************)
 (*                      MISCELLANEOUS                                        *)
 (*****************************************************************************)
 
@@ -496,9 +484,9 @@ let padto n s = s ^ (String.make (max 0 (n - String.length s)) ' ')
 (*****************************************************************************)
 
 let homeDir () =
-    (if (osType = `Unix) || isCygwin then
+    (if Sys.unix || Sys.cygwin then
        safeGetenv "HOME"
-     else if osType = `Win32 then
+     else if Sys.win32 then
 (*We don't want the behavior of Unison to depends on whether it is run
   from a Cygwin shell (where HOME is set) or in any other way (where
   HOME is usually not set)

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -72,10 +72,6 @@ val padto : int -> string -> string
 (* ---------------------------------------------------------------------- *)
 (* Miscellaneous *)
 
-(* Architecture *)
-val osType : [`Unix | `Win32]
-val isCygwin: bool    (* osType will be `Win32 in this case *)
-
 (* Options *)
 val extractValueFromOption : 'a option -> 'a
 val option2string: ('a -> string) -> ('a option -> string)

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -51,7 +51,7 @@ let silent =
 
 let cbreakMode = ref None
 
-let supportSignals = Util.osType = `Unix || Util.isCygwin
+let supportSignals = Sys.unix || Sys.cygwin
 
 let rawTerminal () =
   match !cbreakMode with

--- a/src/update.ml
+++ b/src/update.ml
@@ -275,9 +275,9 @@ let archiveName251 fspath (v: archiveVersion): string * string =
        On windows systems, filenames longer than 8 bytes can cause problems, so
        we chop off all but the first 6 from the fingerprint. *)
     let significantDigits =
-      match Util.osType with
-        `Win32 -> 6
-      | `Unix -> 32
+      match Sys.unix with
+      | false -> 6
+      | true  -> 32
     in
     let thisRoot = thisRootsGlobalName fspath in
     let r = Prefs.read rootsName in
@@ -1496,7 +1496,7 @@ let fastcheck =
 
 let useFastChecking () =
       Prefs.read fastcheck = `True
-   || (Prefs.read fastcheck = `Default (*&& Util.osType = `Unix*))
+   || (Prefs.read fastcheck = `Default (*&& Sys.unix*))
 
 let immutable = Pred.create "immutable"
   ~category:(`Advanced `Sync)
@@ -2386,7 +2386,7 @@ let t1 = Unix.gettimeofday () in
       (* Directory optimization is disabled under Windows,
          as Windows does not update directory modification times
          on FAT filesystems. *)
-      dirFastCheck = useFastChecking () && Util.osType = `Unix;
+      dirFastCheck = useFastChecking () && Sys.unix;
       dirStamp; rescanProps; archHash = archiveHash fspath;
       showStatus = not !Trace.runningasserver }
   in

--- a/src/uutil.ml
+++ b/src/uutil.ml
@@ -167,7 +167,7 @@ let readWriteBounded source target len notify =
    sufficient with Windows as filenames are not allowed to contain
    double quotes. *)
 let quotes s =
-  if Util.osType = `Win32 && not Util.isCygwin then
+  if Sys.win32 then
     "\"" ^ s ^ "\""
   else
     "'" ^ Util.replacesubstring s "'" "'\\''" ^ "'"


### PR DESCRIPTION
Assortment of small changes/fixes for Windows and Cygwin. None of the changes are intended to impact other platforms, save for fat fingers. More info in commit messages.

A fix/workaround for #909 is included.