### PR TITLE
Makefile: remove UISTYLE

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,7 +165,8 @@ jobs:
 
     - shell: bash
       run: |
-        opam exec -- make src UISTYLE=text
+        opam exec -- make tui
+        opam exec -- make fsmonitor
         # stage
         # * notes: darwin/macos doesn't build `unison-fsmonitor`
         for file in ${PROJECT_EXES} ; do
@@ -240,11 +241,11 @@ jobs:
     - if: ${{ !matrix.job.static }} ## unable to build static gtk/gui
       shell: bash
       run: |
-        opam exec -- make src UISTYLE=gtk3
+        opam exec -- make gui
         # stage
         # * copy only main/first project binary
         project_exe_stem=${PROJECT_EXES%% *}
-        cp "src/${project_exe_stem}${{ steps.vars.outputs.EXE_suffix }}" "${{ steps.vars.outputs.PKG_DIR }}/bin/${project_exe_stem}-gui${{ steps.vars.outputs.EXE_suffix }}"
+        cp "src/${project_exe_stem}-gui${{ steps.vars.outputs.EXE_suffix }}" "${{ steps.vars.outputs.PKG_DIR }}/bin/"
 
     - name: "Build WinOS text+gui hybrid"
       if: ${{ runner.os == 'Windows' && !matrix.job.static }} ## WinOS, non-static (unable to build static gtk/gui)
@@ -254,10 +255,10 @@ jobs:
         # * copy only main/first project binary
         project_exe_stem=${PROJECT_EXES%% *}
         # * clean/remove build artifact(s)
-        rm "src/${project_exe_stem}${{ steps.vars.outputs.EXE_suffix }}" ##.or.# opam exec -- make -C src clean #.or.# opam exec -- make clean
+        rm "src/${project_exe_stem}-gui${{ steps.vars.outputs.EXE_suffix }}" ##.or.# opam exec -- make -C src clean #.or.# opam exec -- make clean
         # * re-create (with hybrid text+gui UI)
-        opam exec -- make src UISTYLE=gtk3 UI_WINOS=hybrid
-        cp "src/${project_exe_stem}${{ steps.vars.outputs.EXE_suffix }}" "${{ steps.vars.outputs.PKG_DIR }}/bin/${project_exe_stem}-text+gui${{ steps.vars.outputs.EXE_suffix }}"
+        opam exec -- make gui UI_WINOS=hybrid
+        cp "src/${project_exe_stem}-gui${{ steps.vars.outputs.EXE_suffix }}" "${{ steps.vars.outputs.PKG_DIR }}/bin/${project_exe_stem}-text+gui${{ steps.vars.outputs.EXE_suffix }}"
 
     - uses: actions/upload-artifact@v3
       with:
@@ -344,7 +345,7 @@ jobs:
       name: "macOS: Build and package Unison.app"
       id: macapp
       run: |
-        opam exec -- make src UISTYLE=mac
+        opam exec -- make macui
 
         # package
         APP_NAME=Unison-${{ steps.vars.outputs.PKG_VER }}-macos.app.tar.gz
@@ -480,7 +481,7 @@ jobs:
              runtest "backups 1 (remote)" ["backup = Name *"] (fun() ->
         EOF
 
-    - run: cd _new && opam exec -- make src UISTYLE=text
+    - run: cd _new && opam exec -- make tui
       shell: bash
 
     - name: Checkout ${{ matrix.job.ref }} to _prev
@@ -1103,7 +1104,7 @@ jobs:
         opam-pin: false
         opam-depext: false
 
-    - run: opam exec -- make src UISTYLE=text NATIVE=false
+    - run: opam exec -- make tui NATIVE=false
 
     - run: opam exec -- make test
 
@@ -1150,7 +1151,7 @@ jobs:
 
     - name: Build text UI
       run: |
-        opam exec -- make src UISTYLE=text
+        opam exec -- make
         mkdir -p pkg/bin
         cp src/unison pkg/bin/
         cp src/unison-fsmonitor pkg/bin/
@@ -1173,8 +1174,8 @@ jobs:
       if: ${{ !contains(matrix.job.ocaml-version, '-musl') }}
       run: |
         opam depext --install --verbose --yes lablgtk3 && opam install ocamlfind
-        opam exec -- make src UISTYLE=gtk3
-        cp src/unison pkg/bin/unison-gui
+        opam exec -- make gui
+        cp src/unison-gui pkg/bin/
 
     - name: Initialize packaging variables
       id: vars

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,13 +55,16 @@ Use `gmake` in environments where GNU make is not the default. If you are
 using OPAM then `opam exec -- make` may work for you, as opam needs to set up
 a specific environment.
 
-Presence of lablgtk3 is detected automatically. If you want to force building
-the GUI (or not), type `make UISTYLE=gtk3` or `make UISTYLE=text`.
+Presence of lablgtk3 is detected automatically to build the GUI. If you want
+to build only the GUI, type `make gui`. You can type `make tui` if you have
+lablgtk3 installed but don't want the GUI built. Type `make fsmonitor` to build
+only the filesystem monitor.
 
 There is currently no installation provided by the makefile. You can just copy
 the built binaries to where you need them. The following files are produced:
 ```
-src/unison              (the main executable)
+src/unison              (the main executable for TUI/CLI)
+src/unison-gui          (the main executable for GUI)
 src/unison-fsmonitor    (optional, on some build platforms)
 src/fsmonitor.py        (optional, if unison-fsmonitor is not built)
 man/unison.1            (optional, manual page)
@@ -117,11 +120,12 @@ To build the documentation, first build Unison without cross-compilation.
 
 #### Building
 
-For the text user interface and GTK GUI, follow the Unix instructions above.
+The Unix instructions above will build the text user interface, the GTK GUI
+and, if you're building on macOS, also the macOS native GUI.
 
-To build the macOS native GUI, execute:
+To build only the macOS native GUI, execute:
 ```
-make UISTYLE=mac
+make macui
 ```
 
 The built application will be located at `src/uimac/build/Default/Unison.app`.
@@ -164,7 +168,8 @@ make
 
 If all goes well, the following files will be produced:
 ```
-src/unison.exe              (the main executable)
+src/unison.exe              (the main executable for TUI/CLI)
+src/unison-gui.exe          (the main executable for GUI, optional, see below)
 src/unison-fsmonitor.exe    (filesystem monitor, optional)
 ```
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -50,12 +50,12 @@ endif
 
 # Listing of preferences
 prefs.tmp: ../src/$(NAME)$(EXEC_EXT)
-	-../src/unison -help > prefs.tmp
+	-../src/$(NAME)$(EXEC_EXT) -help > prefs.tmp
 prefsdocs.tmp: ../src/$(NAME)$(EXEC_EXT)
-	-../src/unison -prefsdocs 2> prefsdocs.tmp
+	-../src/$(NAME)$(EXEC_EXT) -prefsdocs 2> prefsdocs.tmp
 
 ../src/$(NAME)$(EXEC_EXT):
-	$(MAKE) -C ../src UISTYLE=text $(NAME)$(EXEC_EXT)
+	$(MAKE) -C ../src tui
 
 # Tools
 %.ml : %.mll

--- a/man/Makefile
+++ b/man/Makefile
@@ -3,7 +3,7 @@
 all: $(NAME).1
 
 ../src/$(NAME)$(EXEC_EXT):
-	$(MAKE) -C ../src UISTYLE=text
+	$(MAKE) -C ../src tui
 
 $(NAME).1: $(NAME).1.in opt_short.tmp opt_full.tmp
 	sed -e '/@OPTIONS_SHORT@/r ./opt_short.tmp' \

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,13 +7,6 @@
 # This is not advised, though: Unison runs much slower when byte-compiled.
 NATIVE=true
 
-# User interface style.  For legal values, see Makefile.OCaml.
-# You probably don't need to set this yourself -- it will be set to
-# an appropriate value automatically, depending on whether the lablgtk
-# library is available.
-#
-# UISTYLE=text
-
 ########################################################################
 ########################################################################
 #     (There should be no need to change anything from here on)       ##
@@ -23,10 +16,7 @@ NATIVE=true
 # Building installation instructions
 
 .PHONY: all
-all: buildexecutable
-
-.PHONY: buildexecutable
-buildexecutable: ;
+all: tui guimaybe macuimaybe fsmonitor
 
 ########################################################################
 ## Miscellaneous developer-only switches
@@ -48,28 +38,23 @@ include Makefile.OCaml
 # For developers
 
 .PHONY: repeattest
-repeattest:
-	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
+repeattest: tui
 	./unison noprofile a.tmp b.tmp -repeat foo.tmp -debug ui
 
 .PHONY: selftest
-selftest:
-	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
+selftest: tui
 	./unison -selftest -ui text -batch
 
 .PHONY: selftestdebug
-selftestdebug:
-	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
+selftestdebug: tui
 	./unison -selftest -ui text -batch -debug all
 
 .PHONY: selftestremote
-selftestremote:
-	$(MAKE) all NATIVE=false DEBUG=true UISTYLE=text
+selftestremote: tui
 	./unison -selftest -ui text -batch test.tmp ssh://eniac.seas.upenn.edu/test.tmp
 
 .PHONY: testmerge
-testmerge:
-	$(MAKE) all NATIVE=false UISTYLE=text
+testmerge: tui
 	-rm -rf a.tmp b.tmp
 	-rm -rf $(HOME)/.unison/backup/file.txt*
 	mkdir a.tmp b.tmp

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -318,19 +318,27 @@ clean::
 ####################################################################
 ### Filesystem monitoring
 
+NAME_FSM = $(NAME)-fsmonitor
+
 ifeq ($(OSARCH),Linux)
--include fsmonitor/linux/Makefile src/fsmonitor/linux/Makefile
-INCLFLAGS+=-I fsmonitor -I fsmonitor/linux
+  FSMDIR = fsmonitor/linux
 endif
 
 ifeq ($(OSARCH),SunOS)
--include fsmonitor/solaris/Makefile src/fsmonitor/solaris/Makefile
-INCLFLAGS+=-I fsmonitor -I fsmonitor/solaris
+  FSMDIR = fsmonitor/solaris
 endif
 
 ifeq ($(OSARCH),Win32)
--include fsmonitor/windows/Makefile src/fsmonitor/windows/Makefile
-INCLFLAGS+=-I fsmonitor -I fsmonitor/windows
+  FSMDIR = fsmonitor/windows
+endif
+
+.PHONY: fsmonitor
+ifdef FSMDIR
+  fsmonitor: buildexecutable $(NAME_FSM)$(EXEC_EXT)
+  -include $(FSMDIR)/Makefile
+else
+  fsmonitor:
+	$(info fsmonitor implementation is not available or not configured for this system. fsmonitor will not be built.)
 endif
 
 DEP_INCLFLAGS+=-I fsmonitor -I fsmonitor/linux -I fsmonitor/solaris -I fsmonitor/windows
@@ -406,7 +414,12 @@ $(NAME_GUI)$(EXEC_EXT): OCAMLLIBS += $(OCAMLLIBS_GUI)
 $(NAME_GUI)$(EXEC_EXT): CAMLFLAGS += $(CAMLFLAGS_GUI)
 $(NAME_GUI)$(EXEC_EXT): CAMLLDFLAGS += $(CAMLLDFLAGS_GUI)
 
-$(NAME)$(EXEC_EXT) $(NAME_GUI)$(EXEC_EXT): $$(CAMLOBJS) $$(COBJS)
+$(NAME_FSM)$(EXEC_EXT): OCAMLOBJS = $(FSMOCAMLOBJS)
+$(NAME_FSM)$(EXEC_EXT): OCAMLLIBS = $(FSMOCAMLLIBS)
+$(NAME_FSM)$(EXEC_EXT): CAMLFLAGS += -I fsmonitor -I $(FSMDIR)
+$(NAME_FSM)$(EXEC_EXT): COBJS = $(FSMCOBJS)
+
+$(NAME)$(EXEC_EXT) $(NAME_GUI)$(EXEC_EXT) $(NAME_FSM)$(EXEC_EXT): $$(CAMLOBJS) $$(COBJS)
 	@echo Linking $@
 	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CAMLCFLAGS) $(CAMLLIBS) $^ $(CLIBS)
 
@@ -427,6 +440,7 @@ $(NAME)-blob.o: $$(CAMLOBJS) $(COBJS)
 clean::
 	-$(RM) $(NAME) $(NAME).exe
 	-$(RM) $(NAME_GUI) $(NAME_GUI).exe
+	-$(RM) $(NAME_FSM) $(NAME_FSM).exe
 	-$(RM) $(NAME)-blob.o
 	-$(RM) -r *.cmi *.cmo *.cmx *.cma *.cmxa TAGS tags
 	-$(RM) -r *.o core gmon.out *~ .*~
@@ -436,7 +450,10 @@ clean::
 	-$(RM) system/generic/*.cm[iox] system/generic/*.o system/generic/*.obj system/generic/*~
 	-$(RM) system/win/*.cm[iox] system/win/*.o system/win/*.obj system/win/*~
 	-$(RM) win32rc/unison.res win32rc/unison.res.lib
-	-$(RM) fsmonitor/*.cm[iox] fsmonitor/*.o fsmonitor/*.obj
+	-$(RM) fsmonitor/*.cm[iox] fsmonitor/*.o fsmonitor/*.obj fsmonitor/*~
+ifdef FSMDIR
+	-$(RM) $(FSMDIR)/*.cm[iox] $(FSMDIR)/*.o $(FSMDIR)/*~
+endif
 	-$(RM) .depend.dot.tmp DEPENDENCIES.ps
 	-$(RM) ubase/*.cm[ioxa] ubase/*.cmxa ubase/*.a ubase/*.o ubase/*~ ubase/*.bak
 	-$(RM) lwt/*.cm[ioxa] lwt/*.cmxa lwt/*.a lwt/*.o lwt/*.obj lwt/*~ lwt/*.bak

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -37,17 +37,12 @@ endif
 ####################################################################
 ### Try to automatically guess UI style
 
+ifneq ($(strip $(UISTYLE)),)
+  $(error UISTYLE is no longer used. See build instructions)
+endif
+
 OCAMLLIBDIR:=$(shell $(OCAMLC) -config-var standard_library)
 
-# User interface style:
-#   Legal values are
-#     UISTYLE=text
-#     UISTYLE=gtk3
-#     UISTYLE=mac
-#
-# This should be set to an appropriate value automatically, depending
-# on whether the lablgtk library is available
-#
 # For Windows, an additional UI style modifier is available, `UI_WINOS`
 #   Legal values are
 #     UI_WINOS=         # *default*; builds unison purely as a Windows console ('text') or GUI ('gtk3') application
@@ -55,22 +50,29 @@ OCAMLLIBDIR:=$(shell $(OCAMLC) -config-var standard_library)
 # * ref: <https://github.com/bcpierce00/unison/issues/778>
 #
 LABLGTK3LIB=$(OCAMLLIBDIR)/lablgtk3
-ifeq ($(OSARCH),Darwin)
-  UISTYLE=mac
+ifeq ($(wildcard $(LABLGTK3LIB)),$(LABLGTK3LIB))
+  HAS_LABLGTK3=true
 else
+  LABLGTK3LIB=$(abspath $(OCAMLLIBDIR)/../lablgtk3)
   ifeq ($(wildcard $(LABLGTK3LIB)),$(LABLGTK3LIB))
-    UISTYLE=gtk3
-  else
-    LABLGTK3LIB=$(abspath $(OCAMLLIBDIR)/../lablgtk3)
-    ifeq ($(wildcard $(LABLGTK3LIB)),$(LABLGTK3LIB))
-      UISTYLE=gtk3
-    else
-      UISTYLE=text
-    endif
+    HAS_LABLGTK3=true
   endif
 endif
-ifeq ($(UISTYLE), gtk2)
-  $(error gtk2 GUI is no longer available.    Use  UISTYLE=gtk3  or don't specify any UISTYLE)
+
+.PHONY: guimaybe
+ifeq ($(HAS_LABLGTK3), true)
+  guimaybe: gui
+else
+  guimaybe:
+	$(info GUI library lablgtk not found. GTK GUI will not be built.)
+endif
+
+.PHONY: macuimaybe
+ifeq ($(OSARCH), Darwin)
+  macuimaybe: macui
+else
+  macuimaybe:
+	$(info Not on macOS. macOS native GUI will not be built.)
 endif
 
 ####################################################################
@@ -79,7 +81,6 @@ endif
 .PHONY: buildinfodebug
 buildinfodebug:
 	$(info $(building_for))
-	$(info UISTYLE = $(UISTYLE))
 	$(info NATIVE = $(NATIVE))
 
 buildexecutable: buildinfodebug
@@ -252,44 +253,44 @@ COBJS += osxsupport$(OBJ_EXT) pty$(OBJ_EXT) bytearray_stubs$(OBJ_EXT) \
 ### User Interface setup
 
 ## Text UI
-ifeq ($(UISTYLE), text)
-  OCAMLOBJS+=linktext.cmo
-endif
+OCAMLOBJS_TUI+=linktext.cmo
 
 ## Mac UI
-ifeq ($(UISTYLE),mac)
-  OCAMLOBJS+=uimacbridge.cmo
-  OCAMLLIBS+=threads.cma
-  INCLFLAGS+=-I +threads
-endif
+OCAMLOBJS_MAC+=uimacbridge.cmo
+OCAMLLIBS_MAC+=threads.cma
+INCLFLAGS_MAC+=-I +threads
 
 ## Graphic UI
-ifeq ($(UISTYLE), gtk3)
-  OCAMLFIND := $(shell command -v ocamlfind 2> /dev/null)
+OCAMLFIND := $(shell command -v ocamlfind 2> /dev/null)
 
-  ifndef OCAMLFIND
-    CAMLFLAGS+=-I +lablgtk3 -I +cairo2
-  else
-    CAMLFLAGS+=$(shell $(OCAMLFIND) query -i-format lablgtk3 )
-    CAMLFLAGS+=$(shell $(OCAMLFIND) query -i-format cairo2 )
-  endif
-  OCAMLOBJS+=pixmaps.cmo uigtk3.cmo linkgtk3.cmo
-  OCAMLLIBS+=lablgtk3.cma cairo.cma
+ifndef OCAMLFIND
+  CAMLFLAGS_GUI+=-I +lablgtk3 -I +cairo2
+else
+  CAMLFLAGS_GUI+=$(shell $(OCAMLFIND) query -i-format lablgtk3 )
+  CAMLFLAGS_GUI+=$(shell $(OCAMLFIND) query -i-format cairo2 )
+endif
+OCAMLOBJS_GUI+=pixmaps.cmo uigtk3.cmo linkgtk3.cmo
+OCAMLLIBS_GUI+=lablgtk3.cma cairo.cma
 
-  ifneq ($(strip $(LDFLAGS_GUI)),)
-    CAMLLDFLAGS_GUI+=-cclib "$(LDFLAGS_GUI)"
-  endif
+ifneq ($(strip $(LDFLAGS_GUI)),)
+  CAMLLDFLAGS_GUI+=-cclib "$(LDFLAGS_GUI)"
 endif
 
 ####################################################################
 ### Unison executables
 
-ifeq ($(UISTYLE),mac)
-  buildexecutable: macexecutable
-  UIMACDIR=uimac
-else
-  buildexecutable: $(NAME)$(EXEC_EXT)
-endif
+NAME_GUI = $(NAME)-gui
+
+.PHONY: tui
+tui: buildexecutable $(NAME)$(EXEC_EXT)
+
+.PHONY: gui
+gui: buildexecutable $(NAME_GUI)$(EXEC_EXT)
+
+.PHONY: macui
+macui: buildexecutable macexecutable
+
+UIMACDIR=uimac
 
 ifeq ($(OSARCH),Darwin)
 ifeq ($(strip $(XCODEFLAGS)),)
@@ -348,7 +349,7 @@ lwt/win/lwt_win.cmo: lwt/win/lwt_unix_impl.cmo system/system_win.cmo
 lwt/win/lwt_win.cmx: lwt/win/lwt_unix_impl.cmx system/system_win.cmx
 
 .PHONY: depend
-depend::
+depend:
 	ocamlc -depend $(DEP_INCLFLAGS) *.mli *.ml */*.ml */*.mli */*/*.ml */*/*.mli > .depend
 
 .PHONY: dependgraph
@@ -395,13 +396,26 @@ win32rc/unison.res.lib: win32rc/unison.rc win32rc/U.ico
 	@echo "$(CAMLC): $< ---> $@"
 	$(CAMLC) $(CAMLFLAGS) $(CAMLCFLAGS) -ccopt $(OUTPUT_SEL)$(CWD)/$@ -c $(CWD)/$<
 
-$(NAME)$(EXEC_EXT): $(CAMLOBJS) $(COBJS)
-	@echo Linking $@
-	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) $(CAMLLDFLAGS_GUI) -o $@ $(CAMLCFLAGS) $(CAMLLIBS) $^ $(CLIBS)
+# Need secondary expansion to bypass the immediate evaluation of pre-requisites
+.SECONDEXPANSION:
 
+$(NAME)$(EXEC_EXT): OCAMLOBJS += $(OCAMLOBJS_TUI)
+
+$(NAME_GUI)$(EXEC_EXT): OCAMLOBJS += $(OCAMLOBJS_GUI)
+$(NAME_GUI)$(EXEC_EXT): OCAMLLIBS += $(OCAMLLIBS_GUI)
+$(NAME_GUI)$(EXEC_EXT): CAMLFLAGS += $(CAMLFLAGS_GUI)
+$(NAME_GUI)$(EXEC_EXT): CAMLLDFLAGS += $(CAMLLDFLAGS_GUI)
+
+$(NAME)$(EXEC_EXT) $(NAME_GUI)$(EXEC_EXT): $$(CAMLOBJS) $$(COBJS)
+	@echo Linking $@
+	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CAMLCFLAGS) $(CAMLLIBS) $^ $(CLIBS)
+
+$(NAME)-blob.o: OCAMLOBJS += $(OCAMLOBJS_MAC)
+$(NAME)-blob.o: OCAMLLIBS += $(OCAMLLIBS_MAC)
+$(NAME)-blob.o: INCLFLAGS += $(INCLFLAGS_MAC)
 # Unfortunately -output-obj does not put .o files into the output, only .cmx
 # files, so we have to use $(LD) to take care of COBJS.
-$(NAME)-blob.o: $(CAMLOBJS) $(COBJS)
+$(NAME)-blob.o: $$(CAMLOBJS) $(COBJS)
 	@echo Linking $@
 	$(CAMLC) -dstartup -output-obj -verbose -cclib -keep_private_externs $(CAMLFLAGS) -o u-b.o $(CAMLCFLAGS) $(CAMLLDFLAGS) $(CAMLLIBS) $(CLIBS) $(CAMLOBJS)
 	$(LD) -r -keep_private_externs -o $@ u-b.o $(COBJS)
@@ -412,6 +426,7 @@ $(NAME)-blob.o: $(CAMLOBJS) $(COBJS)
 
 clean::
 	-$(RM) $(NAME) $(NAME).exe
+	-$(RM) $(NAME_GUI) $(NAME_GUI).exe
 	-$(RM) $(NAME)-blob.o
 	-$(RM) -r *.cmi *.cmo *.cmx *.cma *.cmxa TAGS tags
 	-$(RM) -r *.o core gmon.out *~ .*~

--- a/src/fsmonitor/linux/Makefile
+++ b/src/fsmonitor/linux/Makefile
@@ -1,29 +1,7 @@
-
-FSMONITOR = $(NAME)-fsmonitor
-
-DIR=fsmonitor/linux
 FSMOCAMLOBJS = \
    lwt/lwt.cmo lwt/pqueue.cmo lwt/generic/lwt_unix_impl.cmo lwt/lwt_unix.cmo \
-   $(DIR)/inotify.cmo $(DIR)/lwt_inotify.cmo \
-   fsmonitor/watchercommon.cmo $(DIR)/watcher.cmo
+   $(FSMDIR)/inotify.cmo $(FSMDIR)/lwt_inotify.cmo \
+   fsmonitor/watchercommon.cmo $(FSMDIR)/watcher.cmo
 FSMCOBJS = \
-  $(DIR)/inotify_stubs.o
+  $(FSMDIR)/inotify_stubs.o
 FSMOCAMLLIBS=unix.cma
-
-ifeq ($(NATIVE), true)
-  FSMCAMLOBJS=$(subst .cmo,.cmx, $(FSMOCAMLOBJS))
-  FSMCAMLLIBS=$(subst .cma,.cmxa, $(FSMOCAMLLIBS))
-else
-  FSMCAMLOBJS=$(FSMOCAMLOBJS)
-  FSMCAMLLIBS=$(FSMOCAMLLIBS)
-endif
-
-buildexecutable: $(FSMONITOR)$(EXEC_EXT)
-
-$(FSMONITOR)$(EXEC_EXT): $(FSMCAMLOBJS) $(FSMCOBJS)
-	@echo Linking $@
-	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CAMLCFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
-
-clean::
-	rm -f $(DIR)/*.cm[iox] $(DIR)/*.o $(DIR)/*~
-	rm -f $(FSMONITOR)$(EXEC_EXT)

--- a/src/fsmonitor/solaris/Makefile
+++ b/src/fsmonitor/solaris/Makefile
@@ -1,28 +1,6 @@
-
-FSMONITOR = $(NAME)-fsmonitor
-
-DIR=fsmonitor/solaris
 FSMOCAMLOBJS = \
    lwt/lwt.cmo lwt/pqueue.cmo lwt/generic/lwt_unix_impl.cmo lwt/lwt_unix.cmo \
-   fsmonitor/watchercommon.cmo ubase/safelist.cmo $(DIR)/watcher.cmo
+   fsmonitor/watchercommon.cmo ubase/safelist.cmo $(FSMDIR)/watcher.cmo
 
-FSMCOBJS = $(DIR)/fen_stubs.o
+FSMCOBJS = $(FSMDIR)/fen_stubs.o
 FSMOCAMLLIBS=unix.cma
-
-ifeq ($(NATIVE), true)
-  FSMCAMLOBJS=$(subst .cmo,.cmx, $(FSMOCAMLOBJS))
-  FSMCAMLLIBS=$(subst .cma,.cmxa, $(FSMOCAMLLIBS))
-else
-  FSMCAMLOBJS=$(FSMOCAMLOBJS)
-  FSMCAMLLIBS=$(FSMOCAMLLIBS)
-endif
-
-buildexecutable: $(FSMONITOR)$(EXEC_EXT)
-
-$(FSMONITOR)$(EXEC_EXT): $(FSMCAMLOBJS) $(FSMCOBJS)
-	@echo Linking $@
-	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CAMLCFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
-
-clean::
-	rm -f $(DIR)/*.cm[iox] $(DIR)/*.o $(DIR)/*~
-	rm -f $(FSMONITOR)$(EXEC_EXT)

--- a/src/fsmonitor/windows/Makefile
+++ b/src/fsmonitor/windows/Makefile
@@ -1,7 +1,3 @@
-
-FSMONITOR = unison-fsmonitor
-
-DIR=fsmonitor/windows
 FSMOCAMLOBJS = \
    ubase/umarshal.cmo \
    ubase/rx.cmo unicode_tables.cmo unicode.cmo \
@@ -9,7 +5,7 @@ FSMOCAMLOBJS = \
    system/win/system_impl.cmo \
    lwt/lwt.cmo lwt/pqueue.cmo lwt/win/lwt_unix_impl.cmo lwt/lwt_unix.cmo \
    lwt/win/lwt_win.cmo \
-   fsmonitor/watchercommon.cmo $(DIR)/watcher.cmo
+   fsmonitor/watchercommon.cmo $(FSMDIR)/watcher.cmo
 FSMCOBJS = \
    bytearray_stubs$(OBJ_EXT) \
    system/system_win_stubs$(OBJ_EXT) lwt/lwt_unix_stubs$(OBJ_EXT) \
@@ -17,23 +13,5 @@ FSMCOBJS = \
 FSMOCAMLLIBS=unix.cma
 
 # Additional dependencies
-$(DIR)/watcher.cmo: lwt/win/lwt_win.cmo
-$(DIR)/watcher.cmx: lwt/win/lwt_win.cmx
-
-ifeq ($(NATIVE), true)
-  FSMCAMLOBJS=$(subst .cmo,.cmx, $(FSMOCAMLOBJS))
-  FSMCAMLLIBS=$(subst .cma,.cmxa, $(FSMOCAMLLIBS))
-else
-  FSMCAMLOBJS=$(FSMOCAMLOBJS)
-  FSMCAMLLIBS=$(FSMOCAMLLIBS)
-endif
-
-buildexecutable: $(FSMONITOR)$(EXEC_EXT)
-
-$(FSMONITOR)$(EXEC_EXT): $(FSMCAMLOBJS) $(FSMCOBJS)
-	@echo Linking $@
-	$(CAMLC) -verbose $(CAMLFLAGS) $(CAMLLDFLAGS) -o $@ $(CAMLCFLAGS) $(FSMCAMLLIBS) $^ $(CLIBS)
-
-clean::
-	rm -f $(DIR)/*.cm[iox] $(DIR)/*.{o,obj} $(DIR)/*~
-	rm -f $(FSMONITOR)$(EXEC_EXT)
+$(FSMDIR)/watcher.cmo: lwt/win/lwt_win.cmo
+$(FSMDIR)/watcher.cmx: lwt/win/lwt_win.cmx


### PR DESCRIPTION
It's exactly what it says on the tin. Remove UISTYLE and build UIs as unique targets, together or separately. As a bonus, I also brushed up rules for building fsmonitor in the same style.

Now, the following applies:
```sh
make           # build the TUI + GUI if lablgtk3 found + macUI if on macOS + fsmonitor if impl available for the platform
make tui       # build just the TUI
make gui       # build just the GUI; fails if lablgtk3 is not available
make macui     # build just the macUI; fails if xcode tools are not available
make fsmonitor # build just the fsmonitor; works only if fsmonitor impl available for the platform
               # (building the fsmonitor can be forced by manually setting FSMDIR but
               # compilation will naturally fail if the code is invalid for the platform)
```
```sh
make src/unison           # (or make unison in the src dir) equivalent to make tui; primarily for internal use
make src/unison-gui       # (or make unison-gui in the src dir) equivalent to make gui; primarily for internal use
make src/unison-fsmonitor # (or make unison-fsmonitor in the src dir) equivalent to make fsmonitor; primarily for internal use
```

The CLI/TUI is named `unison`, the GUI is now named `unison-gui`.

For comparison, the _old rules_ were roughly:
```sh
make                  # if on macOS then build macUI; otherwise, if lablgtk3 is detected then build GUI, else build TUI; the latter two both named `unison`
make UISTYLE=text     # build just the TUI, named `unison`
make UISTYLE=gtk3     # build just the GUI, named `unison`
make UISTYLE=mac      # build just the macUI
make unison           # (only in src dir) same as simply `make` (also can set UISTYLE)
make unison-fsmonitor # (only in src dir) build just the fsmonitor, if impl available
# since the TUI and GUI styles both would build the same target then rebuilding
# in another UI style may become impossible without first strategically removing files
```

There are countless ways of improvement, I'm sure. This is a first step to get things moving, then we can tweak going forward.

**_Note:_** Need to update any wiki pages that still mention UISTYLE (if any).

Some remarks:

The toplevel makefile is a smell but I didn't do anything about it yet, just marked it non-parallel and delegate all "unknown" targets to the src makefile. The src makefile fully works with parallel builds.

It's all GNU make. I don't know if I've made compatibility any worse but it certainly was not compatible with non-GNU make before this either.

Note that there is a minor bug in doc/Makefile and man/Makefile where EXEC_EXT is always undefined (only relevant for Windows). I'm not going to fix it now because in practice, due to way recipes are written, things will work anyway, even on Windows.

Closes #667?