### PR TITLE
Wrap excessively long help topics in GUI

### DIFF
--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -2652,9 +2652,12 @@ let documentation ~parent sect =
   let lw = ref 1 in
   let addDocSection (shortname, (name, docstr)) =
     if shortname = "" || name = "" then () else
-    let () = lw := max !lw (String.length name) in
+    let namelen = String.length name in
+    if namelen <= 20 then lw := max !lw namelen;
     let label = GMisc.label ~markup:("<b>" ^ name ^ "</b>")
-                  ~xalign:1. ~justify:`LEFT ~ellipsize:`NONE () in
+                  ~xalign:1. ~justify:`RIGHT ~ellipsize:`NONE
+                  ~line_wrap:(namelen > 20) () in
+    label#set_width_chars 20;
     let box = GBin.frame ~border_width:8
                 ~packing:(add_nb_page label (shortname = sect)) () in
     let text = new scrolled_text ~editable:false ~wrap_mode:`NONE


### PR DESCRIPTION
The latest update to the manual made the GUI help screen look less than optimal (to put it mildly).

Here's how it looked before the manual update:
![image](https://github.com/bcpierce00/unison/assets/69477666/d6159bb4-69f0-498a-83f9-ce4da42bb566)

Here's how it looked after the manual update:
![image](https://github.com/bcpierce00/unison/assets/69477666/f898366d-f700-4f62-8a64-a61484cb3b62)

Here's how it looks with this patch:
![image](https://github.com/bcpierce00/unison/assets/69477666/fe9458c0-3fdc-48bb-b53c-7a54565e65f4)

(the differences are more dramatic when seeing the entire window)