### PR TITLE
Improve the TUI output when interrupted

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1581,6 +1581,9 @@ let getProfile default =
   !selection
 
 let handleException e =
+  (* Keep the current status line (if any) and don't repeat it any more *)
+  alwaysDisplay "\n";
+  Util.set_infos "";
   restoreTerminal();
   let msg = Uicommon.exn2string e in
   let () =


### PR DESCRIPTION
Do not repeat the currently active status line after all other output, which is not only confusing but also causes the last newline to be omitted.

Output before this change (interrupted during a scan):
```
Looking for changes
Terminated!
\ path1/subdir2sh$ _
```
(_underscore denotes position of cursor_) Notice anything weird?

Output with this change (interrupted during a scan):
```
Looking for changes
/ path1/subdir2
Terminated!
sh$ _
```

Works the same when interrupted during update propagation but I haven't tested it specifically.