### PR TITLE
Another round of docs makefile improvements

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,15 +29,18 @@ real:
 .PHONY: once
 once: $(STRINGS) docs.ml prefs.tmp prefsdocs.tmp
 	echo '\def\unisonversion{$(VERSION)}' > unisonversion.tex
+# Text versions: when using different directives then _must_ use different
+# jobname (or, output name for hevea) so that files for non-text versions are
+# not overwritten. Here, suffix -text is used.
 ifeq ($(HEVEA),true)
 	printf '$(TEXDIRECTIVES)\\textversiontrue\\draft$(DRAFT)' \
-           > texdirectives.tex
-	hevea unison-manual.tex
-	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump unison-manual.html > unison-manual.dtxt)
+           > unison-manual-text-directives.tex
+	hevea -o unison-manual-text.html unison-manual.tex
+	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump unison-manual-text.html > unison-manual.dtxt)
 	sed -e "/^----SNIP----/,+2 d" -e "/^Junk/,$$ d" unison-manual.dtxt > unison-manual.txt
 	ocaml docs.ml < unison-manual.dtxt > ../src/strings.ml
 endif
-	printf '$(TEXDIRECTIVES)\\textversionfalse\\draft$(DRAFT)' > texdirectives.tex
+	printf '$(TEXDIRECTIVES)\\textversionfalse\\draft$(DRAFT)' > unison-manual-directives.tex
 	pdflatex -draftmode unison-manual.tex
 	pdflatex -draftmode unison-manual.tex
 	pdflatex unison-manual.tex
@@ -59,11 +62,12 @@ prefsdocs.tmp: ../src/$(NAME)$(EXEC_EXT)
 clean:
 	$(RM) -r \
 	   *.dtxt *.aux *.haux *.log *.out \
-	   texdirectives.tex \
+	   *-directives.tex \
 	   junk.* *.htoc *.toc *.bak \
 	   prefs.tmp prefsdocs.tmp \
 	   docs docs.exe temp.dvi temp.html unison-manual.html \
 	   unison-manual.dvi unison-manual.ps unison-manual.pdf \
 	   unison-manual.txt unison-manual.info* unisonversion.tex \
+	   unison-manual-text.html \
 	   contact.html faq.html faq.haux index.html
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -30,7 +30,6 @@ once: $(STRINGS) docs.ml prefs.tmp prefsdocs.tmp
 ifeq ($(HEVEA),true)
 	printf '$(TEXDIRECTIVES)\\textversiontrue\\draftfalse' \
            > texdirectives.tex
-	latex unison-manual.tex
 	hevea unison-manual.tex
 	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump unison-manual.html > unison-manual.dtxt)
 	sed -e "/^----SNIP----/,+2 d" -e "/^Junk/,$$ d" unison-manual.dtxt > unison-manual.txt

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,6 +3,8 @@
 .PHONY: all
 all: unison-manual.html
 
+DRAFT = false
+
 -include ../src/Makefile.ProjectInfo
 
 STRINGS = ../icons/Unison.gif
@@ -28,14 +30,14 @@ real:
 once: $(STRINGS) docs.ml prefs.tmp prefsdocs.tmp
 	echo '\def\unisonversion{$(VERSION)}' > unisonversion.tex
 ifeq ($(HEVEA),true)
-	printf '$(TEXDIRECTIVES)\\textversiontrue\\draftfalse' \
+	printf '$(TEXDIRECTIVES)\\textversiontrue\\draft$(DRAFT)' \
            > texdirectives.tex
 	hevea unison-manual.tex
 	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump unison-manual.html > unison-manual.dtxt)
 	sed -e "/^----SNIP----/,+2 d" -e "/^Junk/,$$ d" unison-manual.dtxt > unison-manual.txt
 	ocaml docs.ml < unison-manual.dtxt > ../src/strings.ml
 endif
-	printf '$(TEXDIRECTIVES)\\textversionfalse\\draftfalse' > texdirectives.tex
+	printf '$(TEXDIRECTIVES)\\textversionfalse\\draft$(DRAFT)' > texdirectives.tex
 	pdflatex -draftmode unison-manual.tex
 	pdflatex -draftmode unison-manual.tex
 	pdflatex unison-manual.tex

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,50 +1,69 @@
  # Manual
 
 .PHONY: all
-all: unison-manual.html
+all: unison-manual.pdf unison-manual.html unison-manual.txt ../src/strings.ml
 
 DRAFT = false
 
 -include ../src/Makefile.ProjectInfo
 
-STRINGS = ../icons/Unison.gif
 SOURCES = unison-manual.tex \
-          local.tex short.tex
+          local.tex short.tex \
+          unisonversion.tex prefs.tmp prefsdocs.tmp
+FORMATS = html pdf txt dvi ps info
+FORMATS_AUX = dtxt aux htoc toc
+
+$(addprefix unison-manual., $(FORMATS) $(FORMATS_AUX)): $(SOURCES)
+
+unison-manual-directives.tex unison-manual-text-directives.tex:
 
 ifneq ($(strip $(shell hevea -version)),)
   HEVEA=true
 endif
 
-unison-manual.html: $(SOURCES)
-	$(MAKE) real
-
-# If the .aux file is missing, do 'make once' an extra time to make
-# sure it's present (with section numbers, etc.) before we build the
-# manual for real.
-.PHONY: real
-real:
-	@(if [ ! -f unison-manual.aux ]; then $(MAKE) once; fi)
-	$(MAKE) once
-
-.PHONY: once
-once: $(STRINGS) docs.ml prefs.tmp prefsdocs.tmp
+unisonversion.tex: ../src/Makefile.ProjectInfo
 	echo '\def\unisonversion{$(VERSION)}' > unisonversion.tex
+
 # Text versions: when using different directives then _must_ use different
 # jobname (or, output name for hevea) so that files for non-text versions are
 # not overwritten. Here, suffix -text is used.
-ifeq ($(HEVEA),true)
+
+%-text-directives.tex:
 	printf '$(TEXDIRECTIVES)\\textversiontrue\\draft$(DRAFT)' \
            > unison-manual-text-directives.tex
+
+%.dtxt: %.tex %-text-directives.tex
+ifeq ($(HEVEA),true)
 	hevea -o unison-manual-text.html unison-manual.tex
 	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump unison-manual-text.html > unison-manual.dtxt)
+endif
+
+%.txt: %.dtxt
+ifeq ($(HEVEA),true)
 	sed -e "/^----SNIP----/,+2 d" -e "/^Junk/,$$ d" unison-manual.dtxt > unison-manual.txt
+endif
+
+../src/strings.ml: unison-manual.dtxt docs.ml
+ifeq ($(HEVEA),true)
 	ocaml docs.ml < unison-manual.dtxt > ../src/strings.ml
 endif
+
+%-directives.tex:
 	printf '$(TEXDIRECTIVES)\\textversionfalse\\draft$(DRAFT)' > unison-manual-directives.tex
+
+# (pdf)latex must be run multiple times to generate toc and correct references
+
+%.aux %.htoc: %.tex %-directives.tex
 	pdflatex -draftmode unison-manual.tex
 	pdflatex -draftmode unison-manual.tex
+
+%.pdf: %.tex %-directives.tex %.aux
 	pdflatex unison-manual.tex
+
+%.ps: %.pdf
 	pdf2ps unison-manual.pdf
+
+%.html: %.tex %-directives.tex %.htoc
 ifeq ($(HEVEA),true)
 	hevea unison-manual.tex
 endif

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,50 +22,49 @@ ifneq ($(strip $(shell hevea -version)),)
 endif
 
 unisonversion.tex: ../src/Makefile.ProjectInfo
-	echo '\def\unisonversion{$(VERSION)}' > unisonversion.tex
+	echo '\def\unisonversion{$(VERSION)}' > $@
 
 # Text versions: when using different directives then _must_ use different
 # jobname (or, output name for hevea) so that files for non-text versions are
 # not overwritten. Here, suffix -text is used.
 
 %-text-directives.tex:
-	printf '$(TEXDIRECTIVES)\\textversiontrue\\draft$(DRAFT)' \
-           > unison-manual-text-directives.tex
+	printf '$(TEXDIRECTIVES)\\textversiontrue\\draft$(DRAFT)' > $@
 
 %.dtxt: %.tex %-text-directives.tex
 ifeq ($(HEVEA),true)
-	hevea -o unison-manual-text.html unison-manual.tex
-	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump unison-manual-text.html > unison-manual.dtxt)
+	hevea -o $*-text.html $<
+	(TERM=vt100; export TERM; lynx -display_charset=utf8 -dump $*-text.html > $@)
 endif
 
 %.txt: %.dtxt
 ifeq ($(HEVEA),true)
-	sed -e "/^----SNIP----/,+2 d" -e "/^Junk/,$$ d" unison-manual.dtxt > unison-manual.txt
+	sed -e "/^----SNIP----/,+2 d" -e "/^Junk/,$$ d" $< > $@
 endif
 
 ../src/strings.ml: unison-manual.dtxt docs.ml
 ifeq ($(HEVEA),true)
-	ocaml docs.ml < unison-manual.dtxt > ../src/strings.ml
+	ocaml docs.ml < $< > $@
 endif
 
 %-directives.tex:
-	printf '$(TEXDIRECTIVES)\\textversionfalse\\draft$(DRAFT)' > unison-manual-directives.tex
+	printf '$(TEXDIRECTIVES)\\textversionfalse\\draft$(DRAFT)' > $@
 
 # (pdf)latex must be run multiple times to generate toc and correct references
 
 %.aux %.htoc: %.tex %-directives.tex
-	pdflatex -draftmode unison-manual.tex
-	pdflatex -draftmode unison-manual.tex
+	pdflatex -draftmode $<
+	pdflatex -draftmode $<
 
 %.pdf: %.tex %-directives.tex %.aux
-	pdflatex unison-manual.tex
+	pdflatex $<
 
 %.ps: %.pdf
-	pdf2ps unison-manual.pdf
+	pdf2ps $<
 
 %.html: %.tex %-directives.tex %.htoc
 ifeq ($(HEVEA),true)
-	hevea unison-manual.tex
+	hevea $<
 endif
 
 # Listing of preferences

--- a/doc/local.tex
+++ b/doc/local.tex
@@ -3,11 +3,11 @@
 \newif\ifdraft  \drafttrue
 
 \ifhevea\else
-\IfFileExists{texdirectives.tex}
-   {\input{texdirectives}}
+\IfFileExists{{\jobname}-directives.tex}
+   {\input{{\jobname}-directives}}
    {\typeout{== ERROR == The dynamically generated file `texdirectives.tex' couldn't be found. You should use `make` to build the manual for Unison (`unison-manual.pdf'). Don't call latex directly.}\stop}
 \fi
-\input{texdirectives}
+\input{{\jobname}-directives}
 \input{unisonversion}
 
 \newcommand{\finish}[1]{\ifdraft{\ifhevea\red\else \large\bf\fi [#1]\ifhevea\fi}\fi}
@@ -40,7 +40,7 @@
     \iftextversion\else
       \section*{Contents}
       \begin{quote}
-      \input{unison-manual.htoc}
+      \input{\jobname.htoc}
       \end{quote}
     \fi
   \else

--- a/doc/local.tex
+++ b/doc/local.tex
@@ -2,9 +2,11 @@
 \newif\iffull \fullfalse
 \newif\ifdraft  \drafttrue
 
+\ifhevea\else
 \IfFileExists{texdirectives.tex}
    {\input{texdirectives}}
    {\typeout{== ERROR == The dynamically generated file `texdirectives.tex' couldn't be found. You should use `make` to build the manual for Unison (`unison-manual.pdf'). Don't call latex directly.}\stop}
+\fi
 \input{texdirectives}
 \input{unisonversion}
 


### PR DESCRIPTION
More details in commit messages. I have kept the commits separate for easier review. The first three commits could easily be separate into a separate PR if needed.

The dvi output is currently removed but I don't see that as a loss. What would be the use case for dvi? If needed, I can add it back but it will again complicate the makefile because it can't be built in parallel with other targets (it conflicts by trying to write to the same aux and toc files).

Edit: I also thought of adding one more commit:
```diff
diff --git a/doc/Makefile b/doc/Makefile
index f406966e..0d4ffc6f 100644
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,8 +28,12 @@ unisonversion.tex: ../src/Makefile.ProjectInfo
 # jobname (or, output name for hevea) so that files for non-text versions are
 # not overwritten. Here, suffix -text is used.
 
-%-text-directives.tex:
-       printf '$(TEXDIRECTIVES)\\textversiontrue\\draft$(DRAFT)' > $@
+%-text-directives.tex: TEXTVERSION = true
+%-directives.tex: TEXTVERSION = false
+
+.NOTINTERMEDIATE: %-directives.tex
+%-directives.tex:
+       printf '$(TEXDIRECTIVES)\\textversion$(TEXTVERSION)\\draft$(DRAFT)' > $@
 
 %.dtxt: %.tex %-text-directives.tex
 ifeq ($(HEVEA),true)
@@ -47,9 +51,6 @@ ifeq ($(HEVEA),true)
        ocaml docs.ml < $< > $@
 endif
 
-%-directives.tex:
-       printf '$(TEXDIRECTIVES)\\textversionfalse\\draft$(DRAFT)' > $@
-
 # (pdf)latex must be run multiple times to generate toc and correct references
 
 %.aux %.htoc: %.tex %-directives.tex
```
but decided not to include it because I don't think it really improves anything, yet may be more fragile.