### PR TITLE
Fix a ctime fastcheck miss

### DIFF
--- a/src/props.ml
+++ b/src/props.ml
@@ -1536,6 +1536,7 @@ let setLength p l = {p with length=l}
 
 let time p = Time.extract p.time
 let setTime p p' = {p with time = Time.replace p.time (time p'); ctime = p'.ctime}
+let resetCTime p p' = {p with ctime = p'.ctime}
 
 let perms p = Perm.extract p.perm
 

--- a/src/props.mli
+++ b/src/props.mli
@@ -41,6 +41,7 @@ val length : _ props -> Uutil.Filesize.t
 val setLength : t -> Uutil.Filesize.t -> t
 val time : _ props -> float
 val setTime : t -> _ props -> t
+val resetCTime : t -> _ props -> t
 val perms : _ props -> int
 
 val fileDefault : basic


### PR DESCRIPTION
Here we go again. After having fixed mtime fastcheck in #769 I went ahead and introduced the exact same bug with ctime. Sigh.

Some more details in the commit message but this is pretty much the same story as with #769 (except that it is exposed with preferences for extended props, like "xattrs" and "acl").