### PR TITLE
Fix a bug with fastcheck and archive properties

### DIFF
--- a/src/ubase/proplist.ml
+++ b/src/ubase/proplist.ml
@@ -39,6 +39,8 @@ let find_m (k : 'a key) : 'a Umarshal.t =
   try Obj.obj (Util.StringMap.find k !names) with
   | Not_found -> raise (Util.Fatal (Format.sprintf "Property lists: %s not yet registered!" k))
 
+let remove = Util.StringMap.remove
+
 module S = struct
   type key = string
   type value = Obj.t

--- a/src/ubase/proplist.mli
+++ b/src/ubase/proplist.mli
@@ -12,3 +12,4 @@ val empty : t
 val mem : 'a key -> t -> bool
 val find : 'a key -> t -> 'a
 val add : 'a key -> 'a -> t -> t
+val remove : 'a key -> t -> t


### PR DESCRIPTION
More details in commit messages. Long story short, the bug has been there since update predicates started being stored in archive properties but so far it has not been dangerous. Most users would likely never have noticed. With the ctime-based fastcheck, there is now an actual risk of missing some file properties. It still requires specific conditions that most users will never encounter, but it's now a real risk that needs to be fixed.
