### PR TITLE
Make feature negotiation synchronous in macOS GUI

### DIFF
--- a/src/globals.ml
+++ b/src/globals.ml
@@ -101,7 +101,7 @@ let installRoots2 () =
   let roots = rawRoots () in
   theroots :=
     Safelist.map Remote.canonize ((Safelist.map Clroot.parseRoot) roots);
-  Lwt.ignore_result (Negotiate.features (Common.sortRoots !theroots) >>= return)
+  Lwt_unix.run (Negotiate.features (Common.sortRoots !theroots))
 
 let roots () =
   match !theroots with


### PR DESCRIPTION
Asynchronous feature negotiation is too slow to complete before feature validation is carried out, leading to invalid rejection of compatible connections.

Fixes #952