### PR TITLE
Some fixes related to the `nochmod` preference

### DIFF
--- a/src/files.ml
+++ b/src/files.ml
@@ -505,7 +505,7 @@ let rec createDirectories fspath localPath props =
           createDirectories fspath parentPath rem;
           try
             let absolutePath = Fspath.concat fspath parentPath in
-             Fs.mkdir absolutePath (Props.perms desc);
+            Fs.mkdir absolutePath (Props.perms Props.dirDefault);
              Fileinfo.set fspath parentPath (`Copy parentPath) desc
             (* The directory may have already been created
                if there are several paths with the same prefix *)

--- a/src/files.ml
+++ b/src/files.ml
@@ -260,7 +260,7 @@ let mkdirOnRoot =
     (fun (fspath,(workingDir,path)) ->
        let info = Fileinfo.getBasic false workingDir path in
        if info.Fileinfo.typ = `DIRECTORY then begin
-         begin try
+         if not (Prefs.read Props.dontChmod) then begin try
            (* Make sure the directory is writable *)
            Fs.chmod (Fspath.concat workingDir path)
              (Props.perms info.Fileinfo.desc lor 0o700)

--- a/src/update.ml
+++ b/src/update.ml
@@ -678,7 +678,9 @@ let postCommitArchiveLocal (fspath,())
            try f () with e -> close_out_noerr outFd; raise e
          in
          close_on_error (fun () ->
-         System.chmod fto 0o600; (* In case the file already existed *)
+         begin try
+           System.chmod fto 0o600 (* In case the file already existed *)
+         with Unix.Unix_error _ -> () end;
          let inFd = System.open_in_bin ffrom in
          let close_on_error f =
            try f () with e -> close_in_noerr inFd; raise e


### PR DESCRIPTION
The first commit fixes a clear bug. The second one is perhaps not so much a bug than inconsistency. The third commit is mostly just defensive coding in a rarely-executed code path.