### PR TITLE
Use UTF-8 encoding-safe string truncation in UI

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -1237,11 +1237,13 @@ ubase/umarshal.cmx : \
     ubase/umarshal.cmi
 ubase/umarshal.cmi :
 ubase/util.cmo : \
+    unicode.cmi \
     system.cmi \
     ubase/safelist.cmi \
     ubase/projectInfo.cmo \
     ubase/util.cmi
 ubase/util.cmx : \
+    unicode.cmx \
     system.cmx \
     ubase/safelist.cmx \
     ubase/projectInfo.cmx \

--- a/src/ubase/util.mli
+++ b/src/ubase/util.mli
@@ -52,7 +52,7 @@ module StringMap : Map.S with type key = string
 val stringSetFromList : string list -> StringSet.t
 
 (* String manipulation *)
-val truncateString : string -> int -> string
+val truncateString : string -> int (* number of Unicode code points *) -> string
 val startswith : string -> string -> bool  (* STR,PREFIX *)
 val endswith : string -> string -> bool
 val findsubstring : ?reverse:bool -> string -> string -> int option

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -288,7 +288,7 @@ let details2string theRi sep =
   | Different {rc1 = rc1; rc2 = rc2} ->
       let root1str, root2str =
         roots2niceStrings 12 (Globals.roots()) in
-      Printf.sprintf "%s : %s\n%s : %s"
+      Printf.sprintf "%-12s : %s\n%-12s : %s"
         root1str (replicaContent2string rc1 sep)
         root2str (replicaContent2string rc2 sep)
 
@@ -314,7 +314,7 @@ let displayPath previousPath path =
 
 let roots2string () =
   let replica1, replica2 = roots2niceStrings 12 (Globals.roots()) in
-  (Printf.sprintf "%s   %s       " replica1 replica2)
+  (Printf.sprintf "%-12s   %-12s       " replica1 replica2)
 
 type action = AError | ASkip of bool | ALtoR of bool | ARtoL of bool | AMerge
 

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -60,6 +60,7 @@ val displayPath : Path.t -> Path.t -> string
 (* Format the names of the roots for display at the head of the
    corresponding columns in the UI *)
 val roots2string : unit -> string
+val roots2niceStrings : int -> Common.root * Common.root -> string * string
 
 (* Format a reconItem (and its status string) for display, eliding
    initial components that are the same as the previous path *)

--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -2935,12 +2935,14 @@ let createToplevelWindow () =
     (GTree.view_column ~title:"  Path  "
        ~renderer:(GTree.cell_renderer_text [], ["text", c_path]) ()));
 
-  let setMainWindowColumnHeaders s =
+  let setMainWindowColumnHeaders roots =
+    let escape s = String.split_on_char '_' s |> String.concat "__" in
+    let (r1, r2) = Uicommon.roots2niceStrings 15 roots in
     Array.iteri
       (fun i data ->
          (mainWindow#get_column i)#set_title data)
-      [| " " ^ Unicode.protect (String.sub s  0 12) ^ " "; "  Action  ";
-         " " ^ Unicode.protect (String.sub s 15 12) ^ " "; "  Status  ";
+      [| " " ^ Unicode.protect (escape r1) ^ " "; "  Action  ";
+         " " ^ Unicode.protect (escape r2) ^ " "; "  Status  ";
          " Path" |];
   in
 
@@ -4399,7 +4401,7 @@ let createToplevelWindow () =
   updateFromProfile :=
     (fun () ->
        displayNewProfileLabel ();
-       setMainWindowColumnHeaders (Uicommon.roots2string ());
+       setMainWindowColumnHeaders (Globals.roots ());
        sizeMainWindow ();
        buildActionMenu false);
 


### PR DESCRIPTION
The names of roots can be very long and are truncated in UI in the list of updates. Truncating by number of bytes does not play well with UTF-8 input. This patch makes the truncation safe on UTF-8 encoded strings while keeping the length of truncated strings roughly as before (and the result should also _look_ correct for Western languages, maybe also for other scripts).

There is one tiny caveat. Since this patch applies to both TUI and GUI (also macOS native GUI), this may have a side-effect of scrambling any non-ISO-8859-1 (or Windows-1252 in GUI) and non-UTF-8 encodings, if such would ever be used. There is no change for the GTK GUI, as it has always expected either ISO-8859-1/Windows-1252 or UTF-8. I don't know if this will actually be a problem because I don't know if Unison has ever worked properly with these encodings. _This caveat only applies to the root names, not to file/dir names. This is a display-only issue, it will not break any syncs!_

This is a partial fix for #959.