### PR TITLE
GHA: Fix setup-ocaml breakage for older Ubuntu builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1138,7 +1138,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v2.0.19
       with:
         ocaml-compiler: ${{ matrix.job.ocaml-version }}
         opam-disable-sandboxing: true


### PR DESCRIPTION
A recent update to `setup-ocaml` broke the GHA CI workflow.