### PR TITLE
Improve display of cmdline argument parsing errors

### DIFF
--- a/src/ubase/prefs.ml
+++ b/src/ubase/prefs.ml
@@ -624,7 +624,7 @@ let processCmdLine usage hook =
   try
     Uarg.parse argspecs anonfun (oneLineDocs usage)
   with IllegalValue str ->
-    raise(Util.Fatal(Printf.sprintf "%s \n%s\n" (oneLineDocs usage) str))
+    raise (Util.Fatal str)
 
 let parseCmdLine usage =
   processCmdLine usage (fun _ sp -> sp)


### PR DESCRIPTION
See commit message for further details.

To see what this patch does, just run something like the following, both with and without this patch:
```
unison root1 root2 -ignore Foo
unison-gui root1 root2 -ignore Foo
```