### PR TITLE
Ignore `force = newer/older` if mtimes are equal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,12 @@ Released 2023-xx-yy
     for changed build goals, input variables and build artifact names.
     See INSTALL.md for details.
   * Various fixes in Windows and Cygwin builds.
+  * Preferences "force", "prefer" and related "partial" preferences now
+    work slightly differently with values "newer" and "older". Previously,
+    if mtimes in both replicas were equal then always the second root
+    propagated to the first root (possibly reverting user changes). It
+    is now made explicit that "newer" and "older" only work when mtimes
+    are different.
   * Cleanups in documentation.
   * Bugfixes, minor improvements, cleanups.
 

--- a/src/recon.ml
+++ b/src/recon.ml
@@ -44,6 +44,10 @@ let setDirection ri dir force =
               diff.direction <- Replica1ToReplica2
         | _ ->
             let comp = Props.time rc1.desc -. Props.time rc2.desc in
+            (* If mtimes are equal then `Older and `Newer are not defined
+               and will be ignored. This is safer than the previous way of
+               always propagating from replica 2 to replica 1. *)
+            if comp <> 0.0 then
             let comp = if dir=`Newer then -. comp else comp in
             if comp<0.0 then
               diff.direction <- Replica1ToReplica2
@@ -125,7 +129,10 @@ let forceRoot: string Prefs.t =
      ^ "You can also specify \\verb|-force newer| (or \\verb|-force older|) "
      ^ "to force Unison to choose the file with the later (earlier) "
      ^ "modtime.  In this case, the \\verb|-times| preference must also "
-     ^ "be enabled.\n\n"
+     ^ "be enabled.  If modtimes are equal in both replicas when using "
+     ^ "\\verb|newer| or \\verb|older| then this preference will have no "
+     ^ "effect (changes will be synced as if without this preference or "
+     ^ "remain unsynced in case of a conflict).\n\n"
      ^ "This preference is overridden by the \\verb|forcepartial| preference.\n\n"
      ^ "This preference should be used only if you are {\\em sure} you "
      ^ "know what you are doing!")
@@ -145,7 +152,10 @@ let forceRootPartial: Pred.t =
      ^ "(or \\verb|forcepartial PATHSPEC -> older|) "
      ^ "to force Unison to choose the file with the later (earlier) "
      ^ "modtime.  In this case, the \\verb|-times| preference must also "
-     ^ "be enabled.\n\n"
+     ^ "be enabled.  If modtimes are equal in both replicas when using "
+     ^ "\\verb|newer| or \\verb|older| then this preference will have no "
+     ^ "effect (changes will be synced as if without this preference or "
+     ^ "remain unsynced in case of a conflict).\n\n"
      ^ "This preference should be used only if you are {\\em sure} you "
      ^ "know what you are doing!")
 

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -1562,7 +1562,11 @@ let docs =
       \n\
       \032         You can also specify -force newer (or -force older) to force\n\
       \032         Unison to choose the file with the later (earlier) modtime. In\n\
-      \032         this case, the -times preference must also be enabled.\n\
+      \032         this case, the -times preference must also be enabled. If\n\
+      \032         modtimes are equal in both replicas when using newer or older\n\
+      \032         then this preference will have no effect (changes will be synced\n\
+      \032         as if without this preference or remain unsynced in case of a\n\
+      \032         conflict).\n\
       \n\
       \032         This preference is overridden by the forcepartial preference.\n\
       \n\
@@ -1583,7 +1587,10 @@ let docs =
       \032         You can also specify forcepartial PATHSPEC -> newer (or\n\
       \032         forcepartial PATHSPEC -> older) to force Unison to choose the\n\
       \032         file with the later (earlier) modtime. In this case, the -times\n\
-      \032         preference must also be enabled.\n\
+      \032         preference must also be enabled. If modtimes are equal in both\n\
+      \032         replicas when using newer or older then this preference will\n\
+      \032         have no effect (changes will be synced as if without this\n\
+      \032         preference or remain unsynced in case of a conflict).\n\
       \n\
       \032         This preference should be used only if you are sure you know\n\
       \032         what you are doing!\n\


### PR DESCRIPTION
`force = newer/older` is defined (and documented as such) only for changes where mtimes are different between the replicas. If mtimes are equal then root 2 is always forced over root 1.

This produces unexpected results for changes that don't change mtime (basically all metadata changes). Since `force = newer/older` is undefined for such changes (and, importantly, is very difficult to define), this patch just ignores the preference ~~for non-conflicting changes~~ if mtimes are equal. ~~For conflicting changes, the current default of forcing root 2 is kept unchanged.~~

There is further discussion and background in the mailing list.