### PR TITLE
GHA: Build with OCaml 5.1.0 + compatibility fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,10 +46,10 @@ jobs:
       fail-fast: false
       matrix:
         job:
-        - { os: macos-12      , ocaml-version: 5.0.0 }
+        - { os: macos-12      , ocaml-version: 5.1.0 }
         - { os: macos-12      , ocaml-version: 4.14.1 }
         - { os: macos-11      , ocaml-version: 4.14.1           , publish: true  , fnsuffix: -macos-x86_64 }
-        - { os: ubuntu-22.04  , ocaml-version: 5.0.0 }
+        - { os: ubuntu-22.04  , ocaml-version: 5.1.0 }
         - { os: ubuntu-22.04  , ocaml-version: 4.14.1 }
         - { os: ubuntu-20.04  , ocaml-version: 4.14.1 }
         - { os: windows-2022  , ocaml-version: 4.14.0+mingw64c  , publish: true  , fnsuffix: -windows-x86_64 }
@@ -136,6 +136,15 @@ jobs:
       with:
         arch: "${{ steps.vars.outputs.MSVC_ARCH }}"
       if: contains(matrix.job.ocaml-version, '+msvc')
+
+    # OCaml 5.1.0 has a bug which causes all built executables to depend on
+    # libzstd, whether they use it or not. Since it's not possible to pass
+    # arguments to configure with setup-ocaml/opam then a workaround is to
+    # just remove the GHA pre-installed libzstd.
+    - name: "macOS: Work around OCaml 5.1 bug"
+      if: ${{ runner.os == 'macOS' && contains(matrix.job.ocaml-version, '5.1.') }}
+      shell: bash
+      run: brew uninstall --ignore-dependencies zstd
 
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
       uses: ocaml/setup-ocaml@v2
@@ -377,7 +386,7 @@ jobs:
         # This list is intended to balance good enough coverage and
         # limited resource usage.
         job:
-        - { os: ubuntu-22.04  , ocaml-version: 5.0.x   , ref: v2.53.0 }
+        - { os: ubuntu-22.04  , ocaml-version: 5.1.x   , ref: v2.53.0 }
         - { os: ubuntu-22.04  , ocaml-version: 4.14.x  , ref: v2.53.0 }
         - { os: ubuntu-22.04  , ocaml-version: 4.14.x  , ref: v2.52.1 }
         - { os: ubuntu-22.04  , ocaml-version: 4.14.x  , ref: v2.51.5 }

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -298,9 +298,12 @@ ifeq ($(strip $(XCODEFLAGS)),)
 endif
 endif
 
+# Note: The OCaml library names changed starting with OCaml 5.1.0
 .PHONY: macexecutable
 macexecutable:
-	(cd $(UIMACDIR); $(RM) -f ExternalSettings.xcconfig ; echo MARKETING_VERSION = $(VERSION) > ExternalSettings.xcconfig ; echo OCAMLLIBDIR = $(OCAMLLIBDIR) >> ExternalSettings.xcconfig)
+	(cd $(UIMACDIR); \
+	  LIB_SUFFIX=$$(ocaml -e 'if Sys.ocaml_release.major > 5 || Sys.ocaml_release.major = 5 && Sys.ocaml_release.minor >= 1 then print_string "nat"' 2> /dev/null); \
+	  printf "MARKETING_VERSION = $(VERSION)\nOCAMLLIBDIR = $(OCAMLLIBDIR)\nOCAMLLIB_UNIX = -lunix$${LIB_SUFFIX}\nOCAMLLIB_STR = -lcamlstr$${LIB_SUFFIX}" > ExternalSettings.xcconfig)
 	(cd $(UIMACDIR); xcodebuild $(XCODEFLAGS) SYMROOT=build)
 	$(CC) $(CFLAGS) $(UIMACDIR)/cltool.c -o $(UIMACDIR)/build/Default/Unison.app/Contents/MacOS/cltool -framework Carbon
 	codesign --remove-signature $(UIMACDIR)/build/Default/Unison.app

--- a/src/uimac/uimacnew.xcodeproj/project.pbxproj
+++ b/src/uimac/uimacnew.xcodeproj/project.pbxproj
@@ -492,9 +492,9 @@
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-L$(OCAMLLIBDIR)",
-					"-lunix",
+					"$(OCAMLLIB_UNIX)",
 					"-lthreadsnat",
-					"-lcamlstr",
+					"$(OCAMLLIB_STR)",
 					"-lasmrun",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = edu.upenn.cis.Unison;
@@ -523,9 +523,9 @@
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-L$(OCAMLLIBDIR)",
-					"-lunix",
+					"$(OCAMLLIB_UNIX)",
 					"-lthreadsnat",
-					"-lcamlstr",
+					"$(OCAMLLIB_STR)",
 					"-lasmrun",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = edu.upenn.cis.Unison;
@@ -552,9 +552,9 @@
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-L$(OCAMLLIBDIR)",
-					"-lunix",
+					"$(OCAMLLIB_UNIX)",
 					"-lthreadsnat",
-					"-lcamlstr",
+					"$(OCAMLLIB_STR)",
 					"-lasmrun",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = edu.upenn.cis.Unison;


### PR DESCRIPTION
OCaml 5.1.0 had two breaking changes that were not marked as such in the changelog.

One breaking change/bug makes _all_ executables built by OCaml to be dynamically linked with libzstd. This is not an issue within CI, as long as we don't publish the resulting binaries. On the other hand, this does break the uimac Mac native GUI build. This is easily worked around within the GHA script. I deem the temporary workaround within the GHA script acceptable as this issue is hopefully fixed in 5.1.1 or 5.2.0.

The other breaking change is also something which only breaks the uimac Mac native GUI. Working around this requires supplying OCaml version-dependent configuration to xcode to link against correct libraries. Since I don't have access to a Mac or xcode, I made the fix so that it works for CI builds; don't know if it's actually the "correct way".