### PR TITLE
GHA: Use upstream fix for OCaml 5.1 libzstd problem

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,10 +46,10 @@ jobs:
       fail-fast: false
       matrix:
         job:
-        - { os: macos-12      , ocaml-version: 5.1.0 }
+        - { os: macos-12      , ocaml-version: "5.1.0+options,ocaml-option-no-compression" }
         - { os: macos-12      , ocaml-version: 4.14.1 }
         - { os: macos-11      , ocaml-version: 4.14.1           , publish: true  , fnsuffix: -macos-x86_64 }
-        - { os: ubuntu-22.04  , ocaml-version: 5.1.0 }
+        - { os: ubuntu-22.04  , ocaml-version: "5.1.0+options,ocaml-option-no-compression" }
         - { os: ubuntu-22.04  , ocaml-version: 4.14.1 }
         - { os: ubuntu-20.04  , ocaml-version: 4.14.1 }
         - { os: windows-2022  , ocaml-version: 4.14.0+mingw64c  , publish: true  , fnsuffix: -windows-x86_64 }
@@ -136,15 +136,6 @@ jobs:
       with:
         arch: "${{ steps.vars.outputs.MSVC_ARCH }}"
       if: contains(matrix.job.ocaml-version, '+msvc')
-
-    # OCaml 5.1.0 has a bug which causes all built executables to depend on
-    # libzstd, whether they use it or not. Since it's not possible to pass
-    # arguments to configure with setup-ocaml/opam then a workaround is to
-    # just remove the GHA pre-installed libzstd.
-    - name: "macOS: Work around OCaml 5.1 bug"
-      if: ${{ runner.os == 'macOS' && contains(matrix.job.ocaml-version, '5.1.') }}
-      shell: bash
-      run: brew uninstall --ignore-dependencies zstd
 
     - name: Use OCaml ${{ matrix.job.ocaml-version }}
       uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
Just as we got our workaround merged... There's now a workaround provided by upstream.