### PR TITLE
Accept @ and % in the username part of ssh roots

### DIFF
--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -815,7 +815,7 @@ The full grammar is:
             |  socket
             |  ssh
 
-  \NT{user} ::= [-\_a-zA-Z0-9]+
+  \NT{user} ::= [-\_a-zA-Z0-9\%@]+
 
   \NT{host} ::= [-\_a-zA-Z0-9.]+
         |  \textbackslash[ [a-f0-9:.]+ \NT{zone}? \textbackslash]    IPv6 literals (no future format).

--- a/man/unison.1.in
+++ b/man/unison.1.in
@@ -119,7 +119,7 @@ grammar is:
             |  socket
             |  ssh
 
-  user ::= [-_a-zA-Z0-9]+
+  user ::= [-_a-zA-Z0-9%@]+
 
   host ::= [-_a-zA-Z0-9.]+
         |  \e[ [a-f0-9:.]+ zone? \e]     IPv6 literals (no future format).

--- a/src/clroot.ml
+++ b/src/clroot.ml
@@ -28,7 +28,7 @@
             |  socket
             |  ssh
 
-  user ::= [-_a-zA-Z0-9]+
+  user ::= [-_a-zA-Z0-9%@]+
 
   host ::= [-_a-zA-Z0-9.]+
         |  \[ [a-f0-9:.]+ zone? \]     IPv6 literals (no future format).
@@ -106,7 +106,7 @@ let getProtocolSlashSlash s =
     | _ -> None
   else None
 
-let userAtRegexp = Str.regexp "[-_a-zA-Z0-9.]+@"
+let userAtRegexp = Str.regexp "[-_a-zA-Z0-9.%@]+@"
 let getUser s =
   if Str.string_match userAtRegexp s 0
   then

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -681,7 +681,7 @@ let docs =
       \032           |  socket\n\
       \032           |  ssh\n\
       \n\
-      \032 user ::= [-_a-zA-Z0-9]+\n\
+      \032 user ::= [-_a-zA-Z0-9%@]+\n\
       \n\
       \032 host ::= [-_a-zA-Z0-9.]+\n\
       \032       |  \\[ [a-f0-9:.]+ zone? \\]    IPv6 literals (no future format).\n\


### PR DESCRIPTION
The easy fix for #979. I think the username regexp is still too restrictive (and I don't think we need or want all the restrictions of RFC 3986) but let's deal with one thing at a time.

The patch accepts both the @ and % characters. Note that this patch does not parse the percent-escapes in any way, it simply passes them forward to the remote shell program.

Unrelated to this PR, it is also possible to pass any username directly to the remote shell program by setting the `sshargs` preference (for example, `-l username` for ssh). This is a potential workaround for usernames not accepted by the very strict regexp.

Fixes #979