### PR TITLE
Add a workaround for IPv6 literals with copyprog

### DIFF
--- a/src/copy.ml
+++ b/src/copy.ml
@@ -931,6 +931,7 @@ let formatConnectionInfo root =
            (Globals.parsedClRawRoots ())
       with
         Clroot.ConnectByShell (_,rawhost,uo,_,_) ->
+          let rawhost = if String.contains rawhost ':' then "[" ^ rawhost ^ "]" else rawhost in
             (match uo with None -> "" | Some u -> u ^ "@")
           ^ rawhost ^ ":"
           (* Note that we don't do anything with the port -- hopefully


### PR DESCRIPTION
Discussing the copyprog removal may take some time. There's no harm in fixing the IPv6 literals for copyprog in the meantime. There's no point in intentionally not fixing it either.

Fixes #982