### PR TITLE
Remove incorrect [unboxed] attribute

### DIFF
--- a/src/remote.ml
+++ b/src/remote.ml
@@ -705,7 +705,7 @@ type 'a unmarshalFunction = connection -> Bytearray.t -> 'a
 type 'a marshalingFunctions = 'a marshalFunction * 'a unmarshalFunction
 
 type 'a convV0Fun =
-  V0 : ('a -> 'compat) * ('compat -> 'a) -> 'a convV0Fun [@unboxed]
+  V0 : ('a -> 'compat) * ('compat -> 'a) -> 'a convV0Fun
 
 external id : 'a -> 'a = "%identity"
 let convV0_id = V0 (id, id)


### PR DESCRIPTION
Newer compiler versions, starting with 5.2.0, warn about the misplaced attribute. Apparently, the `[unboxed]` attribute on this type has always been invalid but previous compiler versions simply silently ignored it.