### PR TITLE
Fix various typos

### DIFF
--- a/src/TODO.txt
+++ b/src/TODO.txt
@@ -86,7 +86,7 @@ It would be nice if Unison could have the "power" to copy write-protected
 * There is no way of selecting files with wildchar. I had to use
      ignorenot = Name opt/root/.unison/*.prf
      ignore = Name opt/root/.unison/*
-  But this is inconvinent, but the worse is that it gets complicated very
+  But this is inconvenient, but the worse is that it gets complicated very
   fast and I cannot make it for more complicated scenarios. I would expect
   something like (suggestion):
      Files = opt/root/.unison/*.prf

--- a/src/fsmonitor.py
+++ b/src/fsmonitor.py
@@ -561,7 +561,7 @@ to read all the settings from there."""
         parser.add_option("-w", "--sinceWhen", dest="sinceWhen",
                       help="""starting point for filesystem updates to be captured
                                           Defaults to 'now' in the first run
-                                          or the last caputured change""",default = 'now', metavar="SINCEWHEN")
+                                          or the last captured change""",default = 'now', metavar="SINCEWHEN")
         parser.add_option("-l", "--latency", dest="latency",
                       help="set notification LATENCY in seconds. default 5",default = 5, metavar="LATENCY")
         parser.add_option("-f", "--flags", dest="flags",

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -1919,7 +1919,7 @@ let docs =
       \032         watch, Unison relies on an external file monitoring process to\n\
       \032         synchronize whenever a change happens. You can combine the two\n\
       \032         with a + character to use file monitoring and also do a full\n\
-      \032         scan every specificed number of seconds. For example, watch+3600\n\
+      \032         scan every specified number of seconds. For example, watch+3600\n\
       \032         will react to changes immediately and additionally do a full\n\
       \032         scan every hour.\n\
       \n\

--- a/src/terminal.ml
+++ b/src/terminal.ml
@@ -336,7 +336,7 @@ let parseCtrlSeq s =
         begin
           match ch with
           | '\024' | '\026' -> state No (* CAN, SUB *)
-          | '\000'..'\025' -> add_char ch (* Control charaters (roughly) *)
+          | '\000'..'\025' -> add_char ch (* Control characters (roughly) *)
           | '\027' -> state Escape
           | '\048'..'\126' -> state No (* Final *)
           | '\127'..'\255' -> state No (* Invalid *)
@@ -346,7 +346,7 @@ let parseCtrlSeq s =
         begin
           match ch with
           | '\024' | '\026' -> state No (* CAN, SUB *)
-          | '\000'..'\025' -> add_char ch (* Control charaters (roughly) *)
+          | '\000'..'\025' -> add_char ch (* Control characters (roughly) *)
           | '\027' -> state Escape
           | '\064'..'\126' -> (* Final *)
               begin
@@ -367,7 +367,7 @@ let parseCtrlSeq s =
           match ch with
           | '\024' | '\026' -> state No (* CAN, SUB *)
           | '\007' -> state No (* BEL *)
-          | '\000'..'\025' -> add_char ch (* Control charaters (roughly) *)
+          | '\000'..'\025' -> add_char ch (* Control characters (roughly) *)
           | '\027' -> state OSCEsc
           | _ -> ()
         end
@@ -381,7 +381,7 @@ let parseCtrlSeq s =
         begin
           match ch with
           | '\024' | '\026' -> state No (* CAN, SUB *)
-          | '\000'..'\025' -> add_char ch (* Control charaters (roughly) *)
+          | '\000'..'\025' -> add_char ch (* Control characters (roughly) *)
           | '\027' -> state StringEsc
           | _ -> ()
         end

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -136,7 +136,7 @@ let repeat =
      ^ "beginning again. When the argument is \\verb|watch|, Unison relies on "
      ^ "an external file monitoring process to synchronize whenever a change "
      ^ "happens.  You can combine the two with a \\verb|+| character to use "
-     ^ "file monitoring and also do a full scan every specificed number of "
+     ^ "file monitoring and also do a full scan every specified number of "
      ^ "seconds.  For example, \\verb|watch+3600| will react to changes "
      ^ "immediately and additionally do a full scan every hour.")
     (fun _ -> parseRepeat)


### PR DESCRIPTION
Found via `codespell -q 3 -S "./NEWS.md,*.ai" -L cristal,fo,froms,nd,openin,projet,te,theri,ue,usere`