### PR TITLE
Fix update propagation stop request not working

### DIFF
--- a/src/transport.ml
+++ b/src/transport.ml
@@ -55,7 +55,6 @@ let maxThreads () =
 
 let run dispenseTask =
   let runConcurrent limit dispenseTask =
-    let dispenseTask () = if Abort.isAll () then None else dispenseTask () in
     let avail = ref limit in
     let rec runTask thr =
       Lwt.try_bind thr


### PR DESCRIPTION
While testing for the stack overflow crashes, I discovered that I had quite some time ago broken the user stop request for update propagation. Fix the breakage and harden the relevant functions against a similar breakage in future.