### PR TITLE
Fix potential compilation issue on illumos/Solaris

### DIFF
--- a/src/props_xattr.c
+++ b/src/props_xattr.c
@@ -227,6 +227,9 @@ CAMLprim value unison_xattr_updates_ctime(value unit)
 
 
 #if defined(__Solaris__)
+#ifndef _ATFILE_SOURCE
+#define _ATFILE_SOURCE 1
+#endif
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
The feature macro needs to be defined because non-POSIX functions are used.