### PR TITLE
Stop using deprecated `GdkPixbuf.from_xpm_data`

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name unison_lib)
  (wrapped false)
- (modules :standard \ linktext linkgtk3 uigtk3 uimacbridge test)
+ (modules :standard \ linktext linkgtk3 uigtk3 pixmaps uimacbridge test)
  (modules_without_implementation ui)
  (flags :standard
         -w -3-6-9-10-26-27-32-34-35-38-39-50-52
@@ -27,5 +27,5 @@
  (public_name unison-gui)
  (package unison-gui) ; Dummy: we don't use packages
  (flags :standard -w -3-6-9-27-32-52)
- (modules linkgtk3 uigtk3)
+ (modules linkgtk3 uigtk3 pixmaps)
  (libraries threads unison_lib lablgtk3))

--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -3293,7 +3293,7 @@ let createToplevelWindow () =
   let blackPixel  = "000000" in
 *)
   let buildPixmap p =
-    GdkPixbuf.from_xpm_data p in
+    Pixmaps.to_pixbuf p in
   let buildPixmaps f c1 =
     (buildPixmap (f c1), buildPixmap (f lightbluePixel)) in
 


### PR DESCRIPTION
Re #1033 #1034

Since the XPM format is so simple, the function to parse (subset of) XPM used for the icons is trivial. This approach does not require external resources (like image files or loader plugins) nor embedding binary-format icons in the source.

Working but not heavily tested.