### PR TITLE
[Fix] MacOS build when xcode is not installed

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -72,7 +72,14 @@ endif
 
 .PHONY: macuimaybe
 ifeq ($(OSARCH), Darwin)
-  macuimaybe: macui
+  # If XCode is not installed, xcodebuild is just a placeholder telling that XCode is not installed
+  # and any invocation of xcodebuild results in a non 0 exit code.
+  ifeq ($(shell xcodebuild -version > /dev/null; echo $$?), 0)
+    macuimaybe: macui
+  else
+    macuimaybe:
+	$(info Not building macOS native GUI because XCode is not installed.)
+  endif
 else
   macuimaybe:
 	$(info Not on macOS. macOS native GUI will not be built.)


### PR DESCRIPTION
On MacOS, there is two way to install tools you need to develop (make, git, cc, ...). EIther install `Xcode` or something called `Command Line Tools`. But the `Command Line Tools` version doesn't include all the necessary programs to build Apple applications.

Currently the src/Makefile.OCaml assumes that if the `OSARCH` is `Darwin` so it can build the macui but if the xcode version of xcodebuild is not installed, any usage of `xcodebuild` will trigger the following message and stop the build  process with an error.

```
$ xcodebuild
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```