### PR TITLE
Update .depend

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -761,8 +761,10 @@ path.cmi : \
     ubase/umarshal.cmi \
     pred.cmi \
     name.cmi
-pixmaps.cmo :
-pixmaps.cmx :
+pixmaps.cmo : \
+    bytearray.cmi
+pixmaps.cmx : \
+    bytearray.cmx
 pred.cmo : \
     ubase/util.cmi \
     ubase/umarshal.cmi \


### PR DESCRIPTION
Add missing dependencies that broke parallel builds. Non-parallel builds are not impacted.

Fixes #1078 