### PR TITLE
Portable makefiles 3

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -422,23 +422,22 @@ win32rc/unison.res.lib: win32rc/unison.rc win32rc/U.ico
 	$(WINDRES) win32rc/unison.rc win32rc/unison.res
 	$(WINDRES) win32rc/unison.res win32rc/unison.res.lib
 
-%.ml: %.mll
-	-$(RM) $@
-	ocamllex $<
+.SUFFIXES:
+.SUFFIXES: .mli .cmi .ml .cmo .cmx .c .o .obj
 
-%.cmi : %.mli
+.mli.cmi:
 	@echo "$(CAMLC): $< ---> $@"
 	$(CAMLC) $(CAMLFLAGS) -c $(CWD)/$<
 
-%.cmo: %.ml
+.ml.cmo:
 	@echo "$(OCAMLC): $< ---> $@"
 	$(OCAMLC) $(CAMLFLAGS) -c $(CWD)/$<
 
-%.cmx: %.ml
+.ml.cmx:
 	@echo "$(OCAMLOPT): $< ---> $@"
 	$(OCAMLOPT) $(CAMLFLAGS) -c $(CWD)/$<
 
-%$(OBJ_EXT): %.c
+.c$(OBJ_EXT):
 	@echo "$(CAMLC): $< ---> $@"
 	$(CAMLC) $(CAMLFLAGS) $(CAMLCFLAGS) -ccopt $(OUTPUT_SEL)$(CWD)/$@ -c $(CWD)/$<
 

--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -202,8 +202,8 @@ ifeq ($(NATIVE), true)
 
   CAMLC=$(OCAMLOPT)
 
-  CAMLOBJS=$(subst .cmo,.cmx, $(subst .cma,.cmxa, $(OCAMLOBJS)))
-  CAMLLIBS=$(subst .cma,.cmxa, $(OCAMLLIBS))
+  CAMLOBJS = $(OCAMLOBJS:.cmo=.cmx)
+  CAMLLIBS = $(OCAMLLIBS:.cma=.cmxa)
 
 else
   ## Set up for bytecode compilation


### PR DESCRIPTION
The semantics are not impacted (even though it appears as if they would on line 205; the substitution that is now removed is never needed and was there probably as a legacy leftover).

To be reviwed commit by commit.