### PR TITLE
Portable makefiles 4

### DIFF
--- a/src/Makefile.OCaml
+++ b/src/Makefile.OCaml
@@ -311,33 +311,12 @@ gui: buildexecutable $(NAME_GUI)$(EXEC_EXT)
 .PHONY: macui
 macui: buildexecutable macexecutable
 
-UIMACDIR=uimac
-
-ifeq ($(OSARCH),Darwin)
-ifeq ($(strip $(XCODEFLAGS)),)
-  XCODEFLAGS=-arch $(shell uname -m)  ## Prevent Xcode from trying to build universal binaries by default
-endif
-endif
-
-# Note: The OCaml library names changed starting with OCaml 5.1.0
 .PHONY: macexecutable
-macexecutable:
-	(cd $(UIMACDIR); \
-	  LIB_SUFFIX=$$(ocaml -e 'if Sys.ocaml_release.major > 5 || Sys.ocaml_release.major = 5 && Sys.ocaml_release.minor >= 1 then print_string "nat"' 2> /dev/null); \
-	  printf "MARKETING_VERSION = $(VERSION)\nOCAMLLIBDIR = $(OCAMLLIBDIR)\nOCAMLLIB_UNIX = -lunix$${LIB_SUFFIX}\nOCAMLLIB_STR = -lcamlstr$${LIB_SUFFIX}" > ExternalSettings.xcconfig)
-	(cd $(UIMACDIR); xcodebuild $(XCODEFLAGS) SYMROOT=build)
-	$(CC) $(CFLAGS) $(UIMACDIR)/cltool.c -o $(UIMACDIR)/build/Default/Unison.app/Contents/MacOS/cltool -framework Carbon
-	codesign --remove-signature $(UIMACDIR)/build/Default/Unison.app
-	codesign --force --sign - $(UIMACDIR)/build/Default/Unison.app/Contents/MacOS/cltool
-	codesign --force --sign - --entitlements $(UIMACDIR)/build/uimac*.build/Default/uimac.build/Unison.app.xcent $(UIMACDIR)/build/Default/Unison.app
-	codesign --verify --deep --strict $(UIMACDIR)/build/Default/Unison.app
-# cltool was added into the .app after it was signed, so the signature is now
-# broken. It must be removed, cltool separately signed, and then the entire
-# .app (re-)signed.
+macexecutable: $(NAME)-blob.o
+	cd uimac && $(MAKE) macexecutable VERSION="$(VERSION)" OCAMLLIBDIR="$(OCAMLLIBDIR)"
 
 clean::
-	-(cd $(UIMACDIR); xcodebuild clean 2> /dev/null) || true
-	-(cd $(UIMACDIR); $(RM) -r build ExternalSettings.xcconfig)
+	cd uimac && $(MAKE) clean
 
 ####################################################################
 ### Filesystem monitoring

--- a/src/uimac/Makefile
+++ b/src/uimac/Makefile
@@ -1,0 +1,30 @@
+# This makefile should not be used directly.
+# It should always be called from ../Makefile
+default:
+	$(MAKE) -C .. macui
+.PHONY: default
+
+ifeq ($(strip $(XCODEFLAGS)),)
+  XCODEFLAGS=-arch $(shell uname -m)  ## Prevent Xcode from trying to build universal binaries by default
+endif
+
+# Note: The OCaml library names changed starting with OCaml 5.1.0
+.PHONY: macexecutable
+macexecutable:
+	( \
+	  LIB_SUFFIX=$$(ocaml -e 'if Sys.ocaml_release.major > 5 || Sys.ocaml_release.major = 5 && Sys.ocaml_release.minor >= 1 then print_string "nat"' 2> /dev/null); \
+	  printf "MARKETING_VERSION = $(VERSION)\nOCAMLLIBDIR = $(OCAMLLIBDIR)\nOCAMLLIB_UNIX = -lunix$${LIB_SUFFIX}\nOCAMLLIB_STR = -lcamlstr$${LIB_SUFFIX}" > ExternalSettings.xcconfig)
+	xcodebuild $(XCODEFLAGS) SYMROOT=build
+	$(CC) $(CFLAGS) cltool.c -o build/Default/Unison.app/Contents/MacOS/cltool -framework Carbon
+	codesign --remove-signature build/Default/Unison.app
+	codesign --force --sign - build/Default/Unison.app/Contents/MacOS/cltool
+	codesign --force --sign - --entitlements build/uimac*.build/Default/uimac.build/Unison.app.xcent build/Default/Unison.app
+	codesign --verify --deep --strict build/Default/Unison.app
+# cltool was added into the .app after it was signed, so the signature is now
+# broken. It must be removed, cltool separately signed, and then the entire
+# .app (re-)signed.
+
+.PHONY: clean
+clean:
+	xcodebuild clean 2> /dev/null || true
+	-rm -f -r build ExternalSettings.xcconfig

--- a/src/uimac/uimacnew.xcodeproj/project.pbxproj
+++ b/src/uimac/uimacnew.xcodeproj/project.pbxproj
@@ -325,7 +325,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2A3C3F280992245300E404E9 /* Build configuration list for PBXNativeTarget "uimac" */;
 			buildPhases = (
-				2E282CBA0D9AE17300439D01 /* Run Script (make unison-blob.o) */,
 				69C625E50664EC3300B3C46A /* Resources */,
 				69C625E90664EC3300B3C46A /* Sources */,
 				69C625F10664EC3300B3C46A /* Frameworks */,
@@ -419,25 +418,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		2E282CBA0D9AE17300439D01 /* Run Script (make unison-blob.o) */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script (make unison-blob.o)";
-			outputPaths = (
-				"../unison-blob.o",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"Building unison-blob.o...\"\nif [ -x /usr/libexec/path_helper ]; then\n    eval `/usr/libexec/path_helper -s`\nfi\nif [ -x `which opam` ]; then\n    eval `opam config env`\nfi\nmake -C .. unison-blob.o\necho \"done\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		69C625E90664EC3300B3C46A /* Sources */ = {


### PR DESCRIPTION
Building uimac does not need to be portable. It makes sense to extract it from the main makefile and keep it self-contained.