### PR TITLE
Fix the default key display in TUI's `warnPrinter`

### DIFF
--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -969,7 +969,7 @@ let setWarnPrinter() =
            if not (Prefs.read Globals.batch) then begin
              display "Press return to continue.";
              selectAction None
-               [(["";" ";"y"],
+               [(["";"";" ";"y"],
                  ("Continue"),
                  (fun () -> newLine()));
                 (["n";"q";"x"],


### PR DESCRIPTION
Fixes #1055 by making the prompt match the default key that is displayed.
Not sure about the claim "Pressing space do nothing." in the original report. Pressing space still works as before and is a valid alternative.