### PR TITLE
GHA: Use SHA from PR HEAD commit for pkg name

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,12 +82,13 @@ jobs:
         STAGING_DIR='_staging'
         outputs STAGING_DIR
         # parse commit reference info
+        GIT_SHA=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         echo GITHUB_REF=${GITHUB_REF}
-        echo GITHUB_SHA=${GITHUB_SHA}
+        echo GIT_SHA=${GIT_SHA}
         REF_NAME="${GITHUB_REF#refs/*/}"
         unset REF_BRANCH ; case "${GITHUB_REF}" in refs/heads/*) REF_BRANCH="${GITHUB_REF#refs/heads/}" ;; esac;
         unset REF_TAG ; case "${GITHUB_REF}" in refs/tags/*) REF_TAG="${GITHUB_REF#refs/tags/}" ;; esac;
-        REF_SHAS="${GITHUB_SHA:0:8}"
+        REF_SHAS="${GIT_SHA:0:8}"
         outputs REF_BRANCH REF_NAME REF_SHAS REF_TAG
         # deployable tag? (ie, leading "vM" or "M"; M == version number)
         unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
@@ -1108,7 +1109,7 @@ jobs:
     - name: Initialize packaging variables
       id: vars
       run: |
-        REF_SHAS=$(echo '${{ github.sha }}' | awk '{ print substr($0, 1, 8) }')
+        REF_SHAS=$(echo '${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}' | awk '{ print substr($0, 1, 8) }')
         unset REF_TAG ; case "${GITHUB_REF}" in refs/tags/*) REF_TAG="${GITHUB_REF#refs/tags/}" ;; esac;
         PKG_VER="${REF_TAG:-git_$REF_SHAS}"
         PKG_VER="${PKG_VER#v}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,7 +95,7 @@ jobs:
         outputs DEPLOY
         # package name
         PKG_suffix='.tar.gz' ; case '${{ matrix.job.os }}' in windows-*) PKG_suffix='.zip' ;; esac;
-        PKG_VER="${REF_TAG:-git_$REF_SHAS}"
+        PKG_VER="${REF_TAG:${{ github.event_name == 'pull_request' && format('-unmerged-pr-{0}', github.event.pull_request.number) || '' }}-git_$REF_SHAS}"
         PKG_VER="${PKG_VER#v}"
         PKG_BASENAME="unison-${PKG_VER}${{ matrix.job.fnsuffix }}"
         PKG_NAME="${PKG_BASENAME}${PKG_suffix}"
@@ -1111,7 +1111,7 @@ jobs:
       run: |
         REF_SHAS=$(echo '${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}' | awk '{ print substr($0, 1, 8) }')
         unset REF_TAG ; case "${GITHUB_REF}" in refs/tags/*) REF_TAG="${GITHUB_REF#refs/tags/}" ;; esac;
-        PKG_VER="${REF_TAG:-git_$REF_SHAS}"
+        PKG_VER="${REF_TAG:${{ github.event_name == 'pull_request' && format('-unmerged-pr-{0}', github.event.pull_request.number) || '' }}-git_$REF_SHAS}"
         PKG_VER="${PKG_VER#v}"
         echo PKG_DIR="unison-${PKG_VER}${{ matrix.job.fnsuffix }}" >> $GITHUB_OUTPUT
         echo PKG_NAME="unison-${PKG_VER}${{ matrix.job.fnsuffix }}.tar.gz" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I'm opening this PR for discussion (see https://github.com/bcpierce00/unison/pull/1123#issuecomment-2667888894) but I'm not sure it should be merged, as there are some caveats.

The CI script still builds the merge commit. It is possible to change this and build the PR HEAD, but I'm not sure it is a good idea. The point of CI is to run the build tests before merging and the PR HEAD might be way off from the actual merge result (if it hasn't been rebased recently, for example).

With CI building the merge commit (which I think is a good idea), is it actually a good idea to name the build artifacts with the SHA from PR HEAD? If the PR was not rebased recently then the build artifacts are not based off that HEAD, strictly speaking.

(Note that all of this discussion only matters for open PRs; CI builds on merges, direct pushes and tagging are unaffected.)