### PR TITLE
Fix a compilation issue with mingw

### DIFF
--- a/src/copy_stubs.c
+++ b/src/copy_stubs.c
@@ -281,12 +281,17 @@ typedef struct _FSCTL_GET_INTEGRITY_INFORMATION_BUFFER {
 #define FSCTL_DUPLICATE_EXTENTS_TO_FILE 0x98344
 #endif
 
+#if !defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 13
+
+/* This typedef is included in mingw since version 13.0.0 */
 typedef struct _DUPLICATE_EXTENTS_DATA {
   HANDLE        FileHandle;
   LARGE_INTEGER SourceFileOffset;
   LARGE_INTEGER TargetFileOffset;
   LARGE_INTEGER ByteCount;
 } DUPLICATE_EXTENTS_DATA;
+
+#endif /* __MINGW64_VERSION_MAJOR < 13 */
 
 #endif /* defined(__MINGW32__) */
 

--- a/src/copy_stubs.c
+++ b/src/copy_stubs.c
@@ -328,22 +328,9 @@ BOOL unsn_copy_file_get_sparse(HANDLE h)
   return (info.FileAttributes & FILE_ATTRIBUTE_SPARSE_FILE) != 0;
 }
 
-BOOL unsn_copy_file_api_checked = FALSE;
-BOOL unsn_copy_file_api_available = FALSE;
-
 CAMLprim value unison_copy_file(value in_fd, value out_fd, value in_offs, value len)
 {
   CAMLparam4(in_fd, out_fd, in_offs, len);
-
-  if (!unsn_copy_file_api_checked) {
-    unsn_copy_file_api_checked = TRUE;
-    unsn_copy_file_api_available =
-      GetProcAddress(GetModuleHandleW(L"kernel32.dll"),
-                                      "GetVolumeInformationByHandleW") != NULL;
-  }
-  if (!unsn_copy_file_api_available) {
-    caml_unix_error(ENOSYS, "copy_file", Nothing);
-  }
 
   HANDLE hin = Handle_val(in_fd);
   HANDLE hout = Handle_val(out_fd);


### PR DESCRIPTION
The first commit fixes a compilation issue caused by a recent release of mingw.

The second commit removes some obsolete code, while at it.