### PR TITLE
Fix building with new version of BSD make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ default: all
 # Executed only by BSD make
 .BEGIN:
 	@touch _mk.cfg
-	@ocaml make_tools.ml conf > Makefile.cfg
+	@ocaml make_tools.ml conf MAKE="$(MAKE)" > Makefile.cfg
 	@ocaml make_tools.ml conf2 > Makefile2.cfg
 
 # Executed only by Solaris dmake

--- a/src/make_tools.ml
+++ b/src/make_tools.ml
@@ -255,9 +255,14 @@ let () = "WINDRES" <--
   end) ^ "windres"
 
 let () =
-  if is_empty inputs.$("_NMAKE_VER") then
-    "ALL__SRC" <-- "$^$>"  (* First one is for GNU and POSIX make, the other for BSD make *)
-  else
+  if is_empty inputs.$("_NMAKE_VER") then begin
+    if is_empty inputs.$("MAKE") || not_empty (
+          shell ~err_null:true ("printf '_cf_test: FRC ; @echo $^\nFRC: ;' | " ^
+            inputs.$("MAKE") ^ " -f -")) then
+      "ALL__SRC" <-- "$^"  (* GNU and POSIX make, new versions of BSD make *)
+    else
+      "ALL__SRC" <-- "$>"  (* Older versions of BSD make *)
+  end else
     "ALL__SRC" <-- "$(**)" (* NMAKE; enclose in brackets for safety if not run by NMAKE *)
 
 let () = "rule_sep" <-- if not_empty inputs.$("ASSUME_DMAKE") then ":=" else ":"


### PR DESCRIPTION
BSD make now has support for `$^` as specified in POSIX. This breaks the current build logic subtly. Detect the support for `$^` as a workaround (unfortunately, detection can't be done directly in Makefile as it's portable and NMAKE considers any use of `$^` and `$>` a syntax error).