### PR TITLE
CI: Switch to parallel build for docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
 
     - run: sudo apt-get install hevea lynx texlive-latex-base
 
-    - run: opam exec -- make docs
+    - run: opam exec -- make -j 2 docs
 
     - name: Store user manual for the build jobs
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This is meant to serve as a canary for the most obvious parallel build issues that otherwise would go completely unnoticed by CI.