### PR TITLE
Fix an oversight in uimacbridge

### DIFF
--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -419,6 +419,8 @@ let rcToString rc =
   | `Modified     -> "Modified"
   | `PropsChanged -> "PropsChanged"
   | `Created      -> "Created"
+  | `MovedOut _   -> "PropsChanged"
+  | `MovedIn _    -> "PropsChanged"
   | `Unchanged    -> "";;
 let unisonRiToLeft ri =
   match ri.ri.replicas with


### PR DESCRIPTION
This patch makes uimac show the PropsChanged icon for moved/renamed files. Without this patch it is likely that uimac would crash (but not sure, can't test it).