### PR TITLE
Fix bug #1122 - mishandling of ExFAT filesystem

### DIFF
--- a/src/update.ml
+++ b/src/update.ml
@@ -2628,7 +2628,8 @@ let t1 = Unix.gettimeofday () in
       (* Directory optimization is disabled under Windows,
          as Windows does not update directory modification times
          on FAT filesystems. *)
-      dirFastCheck = useFastChecking () && Sys.unix;
+      (* A.Frycze: dirFastCheck is disabled on exFAT filesystems *)
+      dirFastCheck = useFastChecking () && Sys.unix && not (Prefs.read Globals.fatFilesystem);
       dirStamp; rescanProps; archHash = archiveHash fspath;
       showStatus = not !Trace.runningasserver }
   in


### PR DESCRIPTION
### Pull Request Description

**Problem**  
Unison running on Linux currently fails to detect file changes on ExFAT filesystems when they are modified by a different operating system than the one running Unison.  
This happens because ExFAT implementations across operating systems (Windows, cameras, etc.) do not consistently update directory modification times when files are added or changed.
Unison’s `dirFastcheck` mechanism relies on directory modification times, which works reliably only on Unix-style filesystems. On ExFAT, this leads to false “everything is in sync” reports even when the remote replica has new or modified files.

A partial workaround already exists in Unison: `dirFastcheck` is automatically disabled when Unison is running on Windows. However, no such protection exists on Linux, even though ExFAT volumes mounted under Linux are very often shared with other systems (USB drives, SD cards from cameras, external disks used by Windows machines, etc.).
(the currently existing workaround only fixes the issue if Unison is run on Windows, leaving Linux installation vulnerable)

**Solution**  
Disable `dirFastcheck` for ExFAT filesystems on all platforms, not just Windows.

This change:
- Guarantees correct change detection on ExFAT regardless of which OS is currently running Unison.
- Has almost no performance impact (`fastcheck` mechanism is still used, only `dirFastcheck` is disabled)
- Avoids exposing a new configuration option `dirFastcheck`, which would make Unison configuration unnecessarily complicated.

**Real-world impact of the bug**  
Without this fix, users syncing an ExFAT-formatted USB stick, external HDD, second partition of internal HDD, or camera SD card from a Linux machine will frequently see Unison report “no changes” after new photos or files have been added by another device or OS, leading to silent data loss in one direction.

**Testing**  
Verified on Linux with an ExFAT-formatted USB drive:
- Before the patch: adding files from Windows → Unison reports replicas in sync.
- After the patch: changes are correctly detected and propagated.

This brings ExFAT behavior in line with the existing Windows workaround and makes Unison safe to use with typical cross-platform removable media.

ref. #1122 and #1130 