### PR TITLE
Fix crash when current directory is passed as first argument

### DIFF
--- a/src/ubase/prefs.ml
+++ b/src/ubase/prefs.ml
@@ -490,8 +490,17 @@ let processLines lines =
 
 let loadTheFile () =
   match !profileName with
-    None -> ()
-  | Some(n) -> processLines(readAFile n)
+  | None -> ()
+  | Some(n) ->
+      let path = profilePathname n in
+      try
+        let stat = System.stat path in
+        if stat.Unix.LargeFile.st_kind = Unix.S_REG then
+          processLines (readAFile n)
+        else
+          ()
+      with _ ->
+        ()
 
 let loadStrings l =
   let rec loop n out = function


### PR DESCRIPTION
When a directory (e.g. `.`) is passed as the first argument, Unison may treat it as a profile name and attempt to read it
as a preferences file, leading to:

`Sys_error("Is a directory")`

This PR:
- prevents directories from being treated as preference files
- improves CLI argument handling consistency

Now:
- multiple positional arguments are treated as roots
- directories are no longer passed to readAFile

If the first argument is `.`, it is no longer interpreted as a profile and is handled as a root path.

Fixes #1186