### PR TITLE
Update user manual

### DIFF
--- a/doc/local.tex
+++ b/doc/local.tex
@@ -119,17 +119,30 @@
 
 % The quote-based macros looks a imperfect, perhaps due to the lack of
 % alignment
+% The itemize-based macros cause warnings with hevea, due to hevea not being
+% able to remove the bullet point from \item[]. The bullet points actually look
+% relevant for the text-only version, so it's good to keep them, even if they
+% could be removed via CSS.
 % \newenvironment{textui}{{\em Textual Interface:}\begin{quote}}{\end{quote}}
 % \newenvironment{tkui}{{\em Graphical Interface:}\begin{quote}}{\end{quote}}
-\newenvironment{textui}{\medskip{\em Textual Interface:}\begin{itemize}\item[]
+\newenvironment{textui}{\medskip{\em Textual Interface:}\begin{itemize}\ifhevea\item\else\item[]\fi
   }{\end{itemize}}
-\newenvironment{tkui}{\medskip{\em Graphical Interface:}\begin{itemize}\item[]
+\newenvironment{tkui}{\medskip{\em Graphical Interface:}\begin{itemize}\ifhevea\item\else\item[]\fi
   }{\end{itemize}}
 \newenvironment{changesfromversion}[1]{%
   \noindent Changes since #1:
   \begin{itemize}
 }{
   \end{itemize}
+}
+
+% To stop hevea from complaining about arguments to \item
+\newcommand{\numitem}[1][]{
+  \ifhevea
+    \item #1%
+  \else
+    \item[#1]%
+  \fi
 }
 
 \newcommand{\incompatible}{%

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -2213,7 +2213,7 @@ Unison currently supports the following platforms and ACL types:
   \item Some NFSv4 ACL (ZFS ACL) cross-synchronization with
   POSIX-draft ACL
   \item Full cross-synchronization with other platforms that support
-  NFSv4 ACLs; limited cross-synchronization with POSIX-draft ACLs
+  NFSv4 ACLs; limited cross-syn\-chro\-niza\-tion with POSIX-draft ACLs
   \end{itemize}
 \item FreeBSD, NetBSD
   \begin{itemize}

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -702,11 +702,6 @@ one host.
 \item Create a subdirectory called {\tt shared} (or {\tt current}, or
 whatever) in your home directory on each host, and put all the files
 you want to synchronize into this directory.
-\item Create a subdirectory called {\tt shared} (or {\tt current}, or
-whatever) in your home directory on each host, and put {\em links to}
-all the files you want to synchronize into this directory.  Use the
-{\tt follow} preference (see \sectionref{symlinks}{Symbolic Links}) to make
-Unison treat these links as transparent.
 \item Make your home directory the root of the synchronization, but
 tell Unison to synchronize only some of the files and subdirectories
 within it on any given run.  This can be accomplished by using the {\tt -path} switch
@@ -2092,6 +2087,46 @@ to treat a link in this manner, add a line of the form
 \end{alltt}
 to the profile, where \ARG{pathspec} is a path pattern as described in
 \sectionref{pathspec}{Path Specification}.
+
+\begin{quote}
+  {\bf\ifhevea\red\fi Warning:} Be careful when using the \verb|follow|
+  preference. Using a \verb|Pathspec| that is not detailed and accurate enough
+  will cause Unison to follow symlinks that you may have not intended to. This
+  can cause paths outside the replica to be overwritten and deleted due to
+  updates in the other replica.  This can also cause the targets of links
+  pointing to within the replica to be synchronized under two or more names
+  (once directly and once via the link, for example), leading to unintended
+  results and conflicts.
+\end{quote}
+
+{\em Warning}: Deleting, in one replica, the path where a followed symbolic
+link is in the other replica will cause the {\em target} of the ``transparent''
+link to be deleted in the other replica. The symbolic link itself will not be
+deleted and remains as a broken link. %% FIXME: [2026-04] Is this intentional
+                                      %% or is it a bug?
+This happens even if there was a symbolic link in both replicas and only the
+link, not the link target, was deleted in one.
+
+Treating symbolic links ``transparently'' may not always work as expected when
+it comes to directories. Deleting a file or directory in one replica will cause
+the target of a ``transparent'' link to be deleted in the other replica.
+Deleting a parent directory, however, which itself might or might not be a
+followed link, will not delete the targets of any ``transparent'' links
+contained within. %% FIXME: [2026-04] Is this intentional or is it a bug?
+
+Renaming or moving a file or directory in one replica behaves as a combination
+of a delete on the old path and a recreate on the new path. Thus, all the
+caveats regarding deletion of followed symbolic links apply (see above).
+Additionally, the link {\em target} is recreated in-place on the new path,
+{\em not} the symbolic link.
+
+Followed symbolic links are treated ``transparently'' also when it comes to the
+\verb|copyonconflict| and \verb|backup| preferences. This means that the target
+of the link is copied to the conflict or backup location, and you need to
+restore to the original link target location outside the replica, should you
+need the backup. %% FIXME: [2026-04] Unlike deletion, these copies follow
+                 %% links within directory hierarchy, too. Is this inconsistency
+                 %% intentional or a bug?
 
 Not all Windows versions and file systems support symbolic links; Unison will
 refuse to propagate an opaque symbolic link from Unix to Windows and flag the

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -678,7 +678,7 @@ Clients can connect to a server over a Unix domain socket by specifying
 the absolute or relative path to the socket, instead of a server address
 and port number:
 \begin{alltt}
-       unison a.tmp socket://\{\NT{path/to/unix/socket}\}/a.tmp
+       unison a.tmp socket://\textrm{\{}\NT{path/to/unix/socket}\textrm{\}}/a.tmp
 \end{alltt}
 (socket path is enclosed in curly braces).
 
@@ -812,8 +812,8 @@ is used to specify the hostname and the port that the client Unison should
 use to contact it.
 Syntax
 \begin{alltt}
-      socket://\{\NT{path/of/socket}\}//\NT{absolute/path/of/root}
-      socket://\{\NT{path/of/socket}\}/\NT{relative/path/of/root}
+      socket://\textrm{\{}\NT{path/of/socket}\textrm{\}}//\NT{absolute/path/of/root}
+      socket://\textrm{\{}\NT{path/of/socket}\textrm{\}}/\NT{relative/path/of/root}
 \end{alltt}
 \noindent
 is used to specify the Unix domain socket the client Unison should use to
@@ -832,8 +832,8 @@ The full grammar is:
   \NT{user} ::= [-\_a-zA-Z0-9\%@]+
 
   \NT{host} ::= [-\_a-zA-Z0-9.]+
-        |  \textbackslash[ [a-f0-9:.]+ \NT{zone}? \textbackslash]    IPv6 literals (no future format).
-        |  \{ [\^{}\}]+ \}                   For Unix domain sockets only.
+        |  \textrm{\textbackslash}[ [a-f0-9:.]+ \NT{zone}? \textrm{\textbackslash}]    IPv6 literals (no future format).
+        |  \textrm{\{} [\^{}\textrm{\}}]+ \textrm{\}}                   For Unix domain sockets only.
 
   \NT{zone} ::= \%[-\_a-zA-Z0-9~\%.]+
 

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -2098,6 +2098,12 @@ refuse to propagate an opaque symbolic link from Unix to Windows and flag the
 path as erroneous if the support or privileges are lacking on the Windows side.
 When a Unix replica is to be synchronized with such Windows system, all symbolic
 links should match either an \verb|ignore| pattern or a \verb|follow| pattern.
+To completely ignore all symbolic links, you may set the preference {\tt links}
+to {\tt false}.
+
+{\em Warning}: Just like with \verb|ignore|, be careful with ``{\tt links =
+false}''. This makes Unison effectively ignore symbolic links, so they could be
+deleted without notice.
 
 You may need to acquire extra privileges to create symbolic links under
 Windows. By default, this is only allowed for administrators. Unison may not

--- a/doc/unison-manual.tex
+++ b/doc/unison-manual.tex
@@ -1861,12 +1861,12 @@ When running in the textual mode, Unison returns an exit status, which
 describes whether, and at which level, the synchronization was successful.
 The exit status could be useful when Unison is invoked from a script.
 Currently, there are four possible values for the exit status:
-\begin{itemize}
-\item [0]: successful synchronization; everything is up-to-date now.
-\item [1]: some files were skipped, but all file transfers were successful.
-\item [2]: non-fatal failures occurred during file transfer.
-\item [3]: a fatal error occurred, or the execution was interrupted.
-\end{itemize}
+\ifhevea\begin{itemize}\else\begin{quote}\begin{description}\fi
+\numitem [0]: successful synchronization; everything is up-to-date now.
+\numitem [1]: some files were skipped, but all file transfers were successful.
+\numitem [2]: non-fatal failures occurred during file transfer.
+\numitem [3]: a fatal error occurred, or the execution was interrupted.
+\ifhevea\end{itemize}\else\end{description}\end{quote}\fi
 The graphical interface does not return any useful information through the
 exit status.
 

--- a/src/copy.ml
+++ b/src/copy.ml
@@ -955,9 +955,7 @@ let copythreshold =
      ^ "copying utility specified by {\\tt copyprog}. Specifying 0 will cause "
      ^ "{\\em all} copies to use the external program; "
      ^ "a negative number will prevent any files from using it.  "
-     ^ "The default is -1.  "
-     ^ "See \\sectionref{speeding}{Making Unison Faster on Large Files} "
-     ^ "for more information.")
+     ^ "The default is -1.")
 
 (* Pref copyquoterem removed since 2.53.3 *)
 let () = Prefs.markRemoved "copyquoterem"

--- a/src/recon.ml
+++ b/src/recon.ml
@@ -126,7 +126,7 @@ let forceRoot: string Prefs.t =
     ~category:(`Advanced `Sync)
     "force changes from this replica to the other"
     ("Including the preference \\texttt{-force \\ARG{root}} causes Unison to "
-     ^ "resolve all differences (even non-conflicting changes) in favor of "
+     ^ "resolve all differences (including non-conflicting changes) in favor of "
      ^ "\\ARG{root}.  "
      ^ "This effectively changes Unison from a synchronizer into a mirroring "
      ^ "utility.  \n\n"

--- a/src/strings.ml
+++ b/src/strings.ml
@@ -579,12 +579,7 @@ let docs =
       \032   2. Create a subdirectory called shared (or current, or whatever) in\n\
       \032      your home directory on each host, and put all the files you want to\n\
       \032      synchronize into this directory.\n\
-      \032   3. Create a subdirectory called shared (or current, or whatever) in\n\
-      \032      your home directory on each host, and put links to all the files\n\
-      \032      you want to synchronize into this directory. Use the follow\n\
-      \032      preference (see the section \226\128\156Symbolic Links\226\128\157 ) to make Unison treat\n\
-      \032      these links as transparent.\n\
-      \032   4. Make your home directory the root of the synchronization, but tell\n\
+      \032   3. Make your home directory the root of the synchronization, but tell\n\
       \032      Unison to synchronize only some of the files and subdirectories\n\
       \032      within it on any given run. This can be accomplished by using the\n\
       \032      -path switch on the command line:\n\
@@ -1430,8 +1425,7 @@ let docs =
       \032         kilobytes) Unison should use the external copying utility\n\
       \032         specified by copyprog. Specifying 0 will cause all copies to use\n\
       \032         the external program; a negative number will prevent any files\n\
-      \032         from using it. The default is -1. See the section \226\128\156Making Unison\n\
-      \032         Faster on Large Files\226\128\157 for more information.\n\
+      \032         from using it. The default is -1.\n\
       \n\
       \032  debug xxx\n\
       \032         This preference is used to make Unison print various sorts of\n\
@@ -1568,8 +1562,8 @@ let docs =
       \n\
       \032  force xxx\n\
       \032         Including the preference -force root causes Unison to resolve\n\
-      \032         all differences (even non-conflicting changes) in favor of root.\n\
-      \032         This effectively changes Unison from a synchronizer into a\n\
+      \032         all differences (including non-conflicting changes) in favor of\n\
+      \032         root. This effectively changes Unison from a synchronizer into a\n\
       \032         mirroring utility.\n\
       \n\
       \032         You can also specify a unique prefix or suffix of the path of\n\
@@ -2849,12 +2843,52 @@ let docs =
       \032  to the profile, where pathspec is a path pattern as described in the\n\
       \032  section \226\128\156Path Specification\226\128\157 .\n\
       \n\
+      \032    Warning: Be careful when using the follow preference. Using a\n\
+      \032    Pathspec that is not detailed and accurate enough will cause Unison\n\
+      \032    to follow symlinks that you may have not intended to. This can cause\n\
+      \032    paths outside the replica to be overwritten and deleted due to\n\
+      \032    updates in the other replica. This can also cause the targets of\n\
+      \032    links pointing to within the replica to be synchronized under two or\n\
+      \032    more names (once directly and once via the link, for example),\n\
+      \032    leading to unintended results and conflicts.\n\
+      \n\
+      \032  Warning: Deleting, in one replica, the path where a followed symbolic\n\
+      \032  link is in the other replica will cause the target of the \226\128\156transparent\226\128\157\n\
+      \032  link to be deleted in the other replica. The symbolic link itself will\n\
+      \032  not be deleted and remains as a broken link. This happens even if there\n\
+      \032  was a symbolic link in both replicas and only the link, not the link\n\
+      \032  target, was deleted in one.\n\
+      \n\
+      \032  Treating symbolic links \226\128\156transparently\226\128\157 may not always work as expected\n\
+      \032  when it comes to directories. Deleting a file or directory in one\n\
+      \032  replica will cause the target of a \226\128\156transparent\226\128\157 link to be deleted in\n\
+      \032  the other replica. Deleting a parent directory, however, which itself\n\
+      \032  might or might not be a followed link, will not delete the targets of\n\
+      \032  any \226\128\156transparent\226\128\157 links contained within.\n\
+      \n\
+      \032  Renaming or moving a file or directory in one replica behaves as a\n\
+      \032  combination of a delete on the old path and a recreate on the new path.\n\
+      \032  Thus, all the caveats regarding deletion of followed symbolic links\n\
+      \032  apply (see above). Additionally, the link target is recreated in-place\n\
+      \032  on the new path, not the symbolic link.\n\
+      \n\
+      \032  Followed symbolic links are treated \226\128\156transparently\226\128\157 also when it comes\n\
+      \032  to the copyonconflict and backup preferences. This means that the\n\
+      \032  target of the link is copied to the conflict or backup location, and\n\
+      \032  you need to restore to the original link target location outside the\n\
+      \032  replica, should you need the backup.\n\
+      \n\
       \032  Not all Windows versions and file systems support symbolic links;\n\
       \032  Unison will refuse to propagate an opaque symbolic link from Unix to\n\
       \032  Windows and flag the path as erroneous if the support or privileges are\n\
       \032  lacking on the Windows side. When a Unix replica is to be synchronized\n\
       \032  with such Windows system, all symbolic links should match either an\n\
-      \032  ignore pattern or a follow pattern.\n\
+      \032  ignore pattern or a follow pattern. To completely ignore all symbolic\n\
+      \032  links, you may set the preference links to false.\n\
+      \n\
+      \032  Warning: Just like with ignore, be careful with \226\128\156links = false\226\128\157. This\n\
+      \032  makes Unison effectively ignore symbolic links, so they could be\n\
+      \032  deleted without notice.\n\
       \n\
       \032  You may need to acquire extra privileges to create symbolic links under\n\
       \032  Windows. By default, this is only allowed for administrators. Unison\n\


### PR DESCRIPTION
Document the `links` and `follow` preferences in a bit more detail. While looking into the `follow` preference I discovered what a foot-gun it really is, so decided to remove a section recommending its use. The semantics are underspecified, but that is to be dealt with after the release.

Building the manual is very noisy. While updating it anyway, include commits that silence several warnings.