### PR TITLE
Drop ocamlfind dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -485,7 +485,7 @@ jobs:
     - name: lablgtk install
       ## [2020-09] non-working/unavailable for musl OCaml variant
       if: ${{ !contains(matrix.job.ocaml-version, '-musl') }}
-      run: opam install lablgtk3 ocamlfind
+      run: opam install lablgtk3
 
     - if: ${{ !matrix.job.static }} ## unable to build static gtk/gui
       run: |
@@ -956,7 +956,7 @@ jobs:
     - name: Build GUI
       if: ${{ !contains(matrix.job.ocaml-version, '-musl') }}
       run: |
-        opam install --verbose --yes lablgtk3 && opam install ocamlfind
+        opam install --verbose --yes lablgtk3
         opam exec -- make gui
         cp src/unison-gui pkg/bin/
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -956,7 +956,7 @@ jobs:
     - name: Build GUI
       if: ${{ !contains(matrix.job.ocaml-version, '-musl') }}
       run: |
-        opam depext --install --verbose --yes lablgtk3 && opam install ocamlfind
+        opam install --verbose --yes lablgtk3 && opam install ocamlfind
         opam exec -- make gui
         cp src/unison-gui pkg/bin/
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -488,7 +488,7 @@ jobs:
     - name: lablgtk install
       ## [2020-09] non-working/unavailable for musl OCaml variant
       if: ${{ !contains(matrix.job.ocaml-version, '-musl') }}
-      run: opam install lablgtk3 ocamlfind
+      run: opam install lablgtk3
 
     - if: ${{ !matrix.job.static }} ## unable to build static gtk/gui
       run: |
@@ -966,7 +966,7 @@ jobs:
     - name: Build GUI
       if: ${{ !contains(matrix.job.ocaml-version, '-musl') }}
       run: |
-        opam install --verbose --yes lablgtk3 && opam install ocamlfind
+        opam install --verbose --yes lablgtk3
         opam exec -- make gui
         cp src/unison-gui pkg/bin/
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -966,7 +966,7 @@ jobs:
     - name: Build GUI
       if: ${{ !contains(matrix.job.ocaml-version, '-musl') }}
       run: |
-        opam depext --install --verbose --yes lablgtk3 && opam install ocamlfind
+        opam install --verbose --yes lablgtk3 && opam install ocamlfind
         opam exec -- make gui
         cp src/unison-gui pkg/bin/
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,7 +44,6 @@ with those systems, and not in the unison issue tracker.)
 ##### Optional, for the GUI only
 
 - lablgtk3 and its prerequisites (GTK 3 and its dependencies)
-- ocamlfind (there is backup code to operate without it in some circumstances)
 
 ##### Optional, on BSDs, for building unison-fsmonitor
 
@@ -196,7 +195,7 @@ For building the GUI (optional), you also need the following:
 - MinGW GTK 3 and its dependencies (Cygwin package example mingw64-x86_64-gtk3)
 - Some MinGW GTK icon theme (optional, but recommended; Cygwin package example
   mingw64-x86_64-adwaita-icon-theme)
-- lablgtk3 and its prerequisites (ocamlfind, dune build system)
+- lablgtk3 and its prerequisites (dune build system)
 
 Building lablgtk3 from source is complicated. It is recommended to use OPAM for
 that (Cygwin package name opam). Make sure that OPAM uses the MinGW version of
@@ -237,7 +236,7 @@ For building the GUI (optional) with MSVC, you also need the following:
   to pkgconf or pkg-config then you may also need to set the PKG_CONFIG_PATH
   environment to point to C:\gtk\lib\pkgconfig (adjust according to your GTK
   installation location).
-- lablgtk3 and its prerequisites (ocamlfind, dune build system)
+- lablgtk3 and its prerequisites (dune build system)
 
 Once built, a GTK 3 installation must be found in PATH or DLLs for GTK 3 be
 present where unison-gui.exe is located in order to run the GUI.

--- a/src/make_tools.ml
+++ b/src/make_tools.ml
@@ -49,6 +49,35 @@ let ocaml_conf_var varname = shell (ocamlc ^ " -config-var " ^ varname)
 let ocaml_ver_major, ocaml_ver_minor, ocaml_ver_patch =
   Scanf.sscanf (ocaml_conf_var "version") "%d.%d.%d" (fun x y z -> x, y, z)
 
+let ocaml_libdir = "OCAMLLIBDIR" <--? ocaml_conf_var "standard_library"
+
+(*********************************************************************
+*** Opam ***)
+
+let opam = get_command "opam"
+
+let opam_cli_ver =
+  match opam with
+  | Some cmd when has_substring "opamcli_ok"
+               (shell ~err_null:true (cmd ^ " --cli=2.1 && echo opamcli_ok")) ->
+      " --cli=2.1"
+  | _ -> ""
+
+let opam_var ?(default = "") varname =
+  match opam with
+  | Some cmd -> shell (cmd ^ opam_cli_ver ^ " var " ^ varname)
+  | None -> default
+
+let opam_pkg_libdir pkg =
+  opam_var (pkg ^ ":lib")
+    ~default:(Filename.concat (Filename.dirname ocaml_libdir) pkg)
+
+let incl_quoted_dir dir =
+  "-I " ^ (Filename.quote dir)
+
+let incl_opam_pkg_libdir pkg =
+  incl_quoted_dir (opam_pkg_libdir pkg)
+
 (*********************************************************************
 *** Try to automatically guess OS ***)
 
@@ -75,14 +104,14 @@ let () =
   if inputs.$("UISTYLE") <> "" then
     error "UISTYLE is no longer used. See build instructions."
 
-let ocaml_libdir = "OCAMLLIBDIR" <--? ocaml_conf_var "standard_library"
-
 let ocamlfind = get_command "ocamlfind"
 
 let build_GUI =
   let has_lablgtk3 =
     match ocamlfind with
     | Some cmd -> shell ~err_null:true (cmd ^ " query lablgtk3") |> not_empty
+    | None when opam_var "lablgtk3:installed" = "true" -> true
+           (* falls through if opam or lablgtk3 opam package is not installed *)
     | None -> exists ocaml_libdir "lablgtk3"
   in
   if not has_lablgtk3 then begin
@@ -305,6 +334,9 @@ let () =
       (* The weird quoting is required for Windows, but harmless in sh *)
       shell (cmd ^ " query -format \"-I \"\"%d\"\"\" lablgtk3") ^ " " ^
       shell (cmd ^ " query -format \"-I \"\"%d\"\"\" cairo2")
+  | None when opam_var "lablgtk3:installed" = "true" ->
+      incl_opam_pkg_libdir "lablgtk3" ^ " " ^
+      incl_opam_pkg_libdir "cairo2"
   | None -> "-I +lablgtk3 -I +cairo2"
 
 let () =

--- a/unison-gui.opam
+++ b/unison-gui.opam
@@ -20,7 +20,6 @@ install: [
 depends: [
   "ocaml" {>= "4.08"}
   "lablgtk3" {>= "3.1.0"}
-  "ocamlfind"
 ]
 depopts: [
   "unison" {= version}


### PR DESCRIPTION
`ocamlfind` is another bit that is no longer well maintained. There is actually no _need_ for ocamlfind but it will still be used if it's installed and found. That way, nothing changes for repositories that needed ocamlfind for builds anyway.