### PR TITLE
Remove redundant backup in moves propagation

### DIFF
--- a/src/files.ml
+++ b/src/files.ml
@@ -762,7 +762,6 @@ let moveLocal (fspath, ((pathSource, uiSource, pathTarget, uiTarget),
   let realPathTo = match finishCopy copyInfo with
   | Some conflictPath -> conflictPath
   | None -> realPathTo in
-  Stasher.backup fspath localPathTo `AndRemove curTgtArch;
   performRename fspath localPathTo
     (workingDirFrom, realPathFrom) (workingDirTo, realPathTo) curTgtArch
     ~exdev:(fun () -> raise_notrace (Util.Transient "EXDEV"));


### PR DESCRIPTION
There was a redundant call to `Stasher.backup` that was also slightly worse than the one in `performRename` function. Remove the former. (Having redundant backup calls in this case did not actually create duplicate backups due to use of `AndRemove`.)