### PR TITLE
Support mid-sync abort for external GUIs

### DIFF
--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -682,6 +682,9 @@ let unisonSynchronize () =
 ;;
 Callback.register "unisonSynchronize" unisonSynchronize;;
 
+let unisonAbortAll () = Abort.all ();;
+Callback.register "abortAll" unisonAbortAll;;
+
 let unisonIgnorePath pathString =
   Uicommon.addIgnorePattern (Uicommon.ignorePath (Path.fromString pathString));;
 let unisonIgnoreExt pathString =


### PR DESCRIPTION
The OCaml to Cocoa bridge in uimacbridge.ml doesn't expose a way for the macOS Cocoa frontend to abort an in-progress sync. This change registers an abortAll callback that calls the existing Abort.all, so Cocoa frontends can hook into it. This change is purely additive. No behavior change for existing callers.

