### PR TITLE
Use a more POSIX-y rename in Windows

### DIFF
--- a/src/files.ml
+++ b/src/files.ml
@@ -304,11 +304,32 @@ let performRename fspathTo localPathTo (workingDirFrom, pathFrom)
           be raised.  We want to avoid doing the move first, if possible,
           because this opens a "window of danger" during which the contents of
           the path is nothing. *)
+       (* [2026-05] The above is no longer true since OCaml 3.05 (released in
+          July 2002) for >= Windows XP (at least; likely >= Windows 2000) and
+          since OCaml 4.06 for all supported Windows versions, due to using
+          MoveFileEx() with MOVEFILE_REPLACE_EXISTING.
+          Testing in Windows 11 suggests that when the target exists, renaming
+          correctly keeps the props of the source.
+            NTFS: keeps source props.
+            ReFS: keeps source props.
+            exFAT: keeps source props.
+            FAT32: keeps source props.
+            SMB: keeps source props (possibly depends on server implementation).
+            Renaming symlink over file works.
+            Renaming file over symlink works.
+          According to MoveFileEx() documentation, the security descriptor is
+          not kept when moving across volumes. This function, however, is
+          normally used to rename in the same working dir. The only exception
+          is 'moves', but the props are always re-set after propagating the
+          move, precisely for this reason.
+          [Unix.rename] (used since 2.53.0) in Windows will not raise EXDEV but
+          transparently switches to copying. When this happens, we will lose
+          progress tracking. *)
       let moveFirst =
         match (filetypeFrom, filetypeTo) with
         | (_, `ABSENT)            -> false
         | ((`FILE | `SYMLINK),
-           (`FILE | `SYMLINK))    -> Sys.win32
+           (`FILE | `SYMLINK))    -> false
         | _                       -> true (* Safe default *) in
       if moveFirst then begin
         debug (fun() -> Util.msg "rename: moveFirst=true\n");

--- a/src/system/system_win.ml
+++ b/src/system/system_win.ml
@@ -66,14 +66,10 @@ let rename f1 f2 =
     try
       Unix.rename f1 f2
     with
-    | (Unix.Unix_error ((Unix.EACCES | Unix.EUNKNOWNERR (-32)), _, _)) as e ->
+    | Unix.Unix_error ((Unix.EACCES | Unix.EUNKNOWNERR (-32)), _, _) when delay < 1. ->
                                        (* ERROR_SHARING_VIOLATION *)
-        if (delay < 1.) then begin
-          Unix.sleepf delay;
-          ren_aux (delay *. 2.)
-        end else
-          raise e
-    | e -> raise e
+        Unix.sleepf delay;
+        ren_aux (delay *. 2.)
   in
   ren_aux 0.01
 

--- a/src/system/system_win.ml
+++ b/src/system/system_win.ml
@@ -58,13 +58,51 @@ let stat f = stat_impl f false
 let lstat f = stat_impl f true
 
 let rename f1 f2 =
+  let rename_with_readonly_fix () =
+    (* If the target exists and is a read-only file/symlink then the rename
+       will fail (this might get fixed in OCaml 5.6 or some later version)
+       with EACCESS (on NTFS, ReFS) or EEXIST (on (ex)FAT). To make renaming
+       more POSIX-like, strip the read-only attribute and try again. *)
+    try
+      Unix.rename f1 f2
+    with
+    | (Unix.Unix_error ((Unix.EACCES | Unix.EEXIST), _, _)) as e ->
+        let origbt = Printexc.get_raw_backtrace () in
+        let st =
+          try
+            lstat f2
+          with Unix.Unix_error _ ->
+            Printexc.raise_with_backtrace e origbt
+        in
+        if st.st_perm land 0o200 <> 0 ||
+            (st.st_kind <> S_REG && st.st_kind <> S_LNK) then
+          Printexc.raise_with_backtrace e origbt
+        else begin
+          begin
+            try
+              Unix.chmod f2 (st.st_perm lor 0o200)
+            with Unix.Unix_error _ ->
+              Printexc.raise_with_backtrace e origbt
+          end;
+          begin
+            try
+              Unix.rename f1 f2
+            with Unix.Unix_error _ as e2 ->
+              let origbt2 = Printexc.get_raw_backtrace () in
+              begin
+                try Unix.chmod f2 st.st_perm with Unix.Unix_error _ -> ()
+              end;
+              Printexc.raise_with_backtrace e2 origbt2
+          end
+        end
+  in
   (* Comment from original C stub implementation:
      Windows Unicode API: when a file cannot be renamed due to a sharing
      violation error or an access denied error, retry for up to 1 second,
      in case the file is temporarily opened by an indexer or an anti-virus. *)
   let rec ren_aux delay =
     try
-      Unix.rename f1 f2
+      rename_with_readonly_fix ()
     with
     | Unix.Unix_error ((Unix.EACCES | Unix.EUNKNOWNERR (-32)), _, _) when delay < 1. ->
                                        (* ERROR_SHARING_VIOLATION *)


### PR DESCRIPTION
The final rename was never atomic in Windows, even though it became possible since Windows 2000 or XP. It still has some quirks (such as when the target is read-only) but those can be worked around in most cases.

Make the rename system function more POSIX-y for Windows and use it to enable the final atomic rename during update propagation (as with other operating systems).
The code change looks much more complicated than it really is. The line count of the new code is vastly inflated by exception management.