### PR TITLE
Produce a better error message for macui when no roots are provided

### DIFF
--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -258,6 +258,11 @@ let do_unisonInit1 profileName =
   Trace.debug "" (fun() -> Prefs.dumpPrefsToStderr() );
 
   (* FIX: if no roots, ask the user *)
+  match Globals.rawRoots () with
+  | [] | [_] ->
+      (* Relief for https://github.com/bcpierce00/unison/issues/1058 *)
+      raise (Util.Fatal "Synchronization roots not specified in the profile")
+  | _ -> ();
 
   Recon.checkThatPreferredRootIsValid();
 


### PR DESCRIPTION
As per https://github.com/bcpierce00/unison/issues/1058#issuecomment-5463492851
This is not an actual fix for #1058 (that will have to remain for someone maintaining macui) but as the current error message does ask the user to report a bug, so it seems only fair to fix the message.

_This has to be verified by someone prior to merging. As before, I have no possibility to test on macOS._