### PR TITLE
Update .gitignore and .depend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ man/unison.1
 src/.depend.dot.tmp
 src/DEPENDENCIES.ps
 
+Makefile*.cfg
 _build
 .merlin
 *.install

--- a/src/.depend
+++ b/src/.depend
@@ -1446,7 +1446,8 @@ uimacbridge.cmo : \
     fspath.cmi \
     files.cmi \
     common.cmi \
-    clroot.cmi
+    clroot.cmi \
+    abort.cmi
 uimacbridge.cmx : \
     xferhint.cmx \
     uutil.cmx \
@@ -1472,7 +1473,8 @@ uimacbridge.cmx : \
     fspath.cmx \
     files.cmx \
     common.cmx \
-    clroot.cmx
+    clroot.cmx \
+    abort.cmx
 uitext.cmo : \
     uutil.cmi \
     ubase/util.cmi \


### PR DESCRIPTION
Some missed updates. Forgot to update `.gitignore` when shuffling build scripts. `.depend` update was missed in a recently merged PR.