### PR TITLE
Add dry run option

### DIFF
--- a/src/strings.ml
+++ b/src/strings.ml
@@ -1103,6 +1103,7 @@ let docs =
       \n\
       \032 How to sync:\n\
       \032  -batch              batch mode: ask no questions at all\n\
+      \032  -dryrun             dry run, do not change replicas\n\
       \n\
       \032 How to sync (text interface (CLI) only):\n\
       \032  -auto               automatically accept default (nonconflicting) actions\n\
@@ -1468,6 +1469,18 @@ let docs =
       \032         circumstances (and under some operating systems), the chmod call\n\
       \032         always fails. Setting this preference completely prevents Unison\n\
       \032         from ever calling chmod.\n\
+      \n\
+      \032  dryrun\n\
+      \032         Scan and reconcile updates as normal, but do not synchronize.\n\
+      \032         Allows checking for updates and seeing what actions would be\n\
+      \032         taken to synchronize the replicas without making any changes in\n\
+      \032         replicas (note that the archive files and cache files used by\n\
+      \032         Unison may still be updated).\n\
+      \n\
+      \032         Process exit code will signal if there were updates to\n\
+      \032         synchronize. See the section \226\128\156Exit Code\226\128\157 for more information.\n\
+      \032         Dry run may be used together with batch and/or silent to check\n\
+      \032         the exit code in scripts.\n\
       \n\
       \032  dumbtty\n\
       \032         When set to true, this flag makes the text mode user interface\n\

--- a/src/test.ml
+++ b/src/test.ml
@@ -906,6 +906,15 @@ let test() =
     );
   end;
 
+  (* Do the dry run test as the very last test. The dryrun option may be sticky
+     (once set, it can't be unset). *)
+  runtest "dryrun 1" ["dryrun = true"] (fun () ->
+    let r1 = Dir ["foo", File "bar"; "bar", Dir ["x", File "y"]] in
+    put R1 r1; put R2 (Dir []); sync ();
+    check "1" R1 r1;
+    check "2" R2 (Dir [])
+  );
+
   if !failures = 0 then
     Util.msg "Success :-)\n"
   else

--- a/src/uicommon.ml
+++ b/src/uicommon.ml
@@ -57,6 +57,25 @@ let auto =
      ^ "to move to the next, it will skip over all non-conflicting entries "
      ^ "and go directly to the next conflict.)" )
 
+let dryRun =
+  Prefs.createBool "dryrun" false
+    ~category:(`Basic `Syncprocess) ~local:true
+    ~send:(fun () -> false)
+    "dry run, do not change replicas"
+    "Scan and reconcile updates as normal, but do not synchronize. \
+     Allows checking for updates and seeing what actions would be taken \
+     to synchronize the replicas without making any changes in replicas \
+     (note that the archive files and cache files used by Unison may still \
+     be updated).\
+     \n\n\
+     Process exit code will signal if there were updates to synchronize. \
+     See \\sectionref{exit}{Exit Code} for more information. \
+     Dry run may be used together with \\texttt{batch} and/or \\texttt{silent} \
+     to check the exit code in scripts."
+(* Provide commonly-used alternatives *)
+let () = Prefs.alias dryRun "-dry-run"
+let () = Prefs.alias dryRun "n"
+
 (* This has to be here rather than in uigtk.ml, because it is part of what
    gets sent to the server at startup *)
 let mainWindowHeight =
@@ -701,6 +720,7 @@ let transportFinish () = Transport.logFinish ()
 
 let transportItems items pRiThisRound makeAction =
   if Abort.isAll () then () else
+  if Prefs.read dryRun then () else
   let waiter = Lwt.wait () in
   let outstanding = ref 0 in
   let starting () = incr outstanding in

--- a/src/uicommon.mli
+++ b/src/uicommon.mli
@@ -18,6 +18,9 @@ end
 (* User preference: when true, ask fewer questions *)
 val auto : bool Prefs.t
 
+(* User preference: when true, do not synchronize *)
+val dryRun : bool Prefs.t
+
 (* User preference: How tall to make the main window in the GTK ui *)
 val mainWindowHeight : int Prefs.t
 

--- a/src/uigtk3.ml
+++ b/src/uigtk3.ml
@@ -3869,7 +3869,9 @@ let createToplevelWindow () =
     Main function : synchronize
    *********************************************************************)
   let synchronize () =
-    if Array.length !theState = 0 then
+    if Prefs.read Uicommon.dryRun then
+      Trace.status "Dry run enabled, will not synchronize"
+    else if Array.length !theState = 0 then
       Trace.status "Nothing to synchronize"
     else begin
       grDisactivateAll ();

--- a/src/uimacbridge.ml
+++ b/src/uimacbridge.ml
@@ -554,7 +554,9 @@ Callback.register "runShowDiffs" runShowDiffs;;
 (* --------------------------------------------------- *)
 
 let do_unisonSynchronize () =
-  if Array.length !theState = 0 then
+  if Prefs.read Uicommon.dryRun then
+    Trace.status "Dry run enabled, will not synchronize"
+  else if Array.length !theState = 0 then
     Trace.status "Nothing to synchronize"
   else begin
     Trace.status "Propagating changes";

--- a/src/uitext.ml
+++ b/src/uitext.ml
@@ -1146,7 +1146,9 @@ let rec interactAndPropagateChanges prevItemList reconItemList
         failedPaths;
     if intr then raise Sys.Break; (* Make sure repeat mode is stopped *)
     (skipped > 0, partials > 0, failures > 0, notstarted > 0, failedPaths) in
-  if updatesToDo = 0 then begin
+  if Prefs.read Uicommon.dryRun then
+    (skipped > 0, false, false, updatesToDo > 0, [])
+  else if updatesToDo = 0 then begin
     (* BCP (3/09): We need to commit the archives even if there are
        no updates to propagate because some files (in fact, if we've
        just switched to DST on windows, a LOT of files) might have new


### PR DESCRIPTION
This is the simplest dry run implementation possible. A new preference `dryrun` is added (I chose to name it so that it maches other preferences, but the very common `--dry-run` and `-n` also work).

Updates scanning and reconciliation are run as normal, but the synchronization step is simply skipped. The exit codes remain the same as they've always been.

All other preferences continue working as they otherwise would. In particular, this means that the UI is interactive by default. In scripts you want to combine dry run with `-silent` and/or `-batch`.

The simplest implementation I've opted for here is to simply skip the synchronization step wholesale. This means that you can see the updates that are detected, what actions are suggested by reconciliation, the pre-sync summary (in TUI) and the process exit code remains meaningful.

On the other hand, this does not simulate the syncing action for each individual path. I don't know if this would be useful or not. It is certainly possible and I even tried it for a quick PoC but I'm not sure it is worth the additional code complexity (increased maintenance burden is a slight worry, but without major safeguards it would pose the risk of some future code change accidentally ignoring the dry run restriction).

Closes #1203